### PR TITLE
[FIX] remove abc as dependency

### DIFF
--- a/nimare/version.py
+++ b/nimare/version.py
@@ -60,5 +60,4 @@ MINOR = _version_minor
 MICRO = _version_micro
 VERSION = __version__
 REQUIRES = ["nibabel", "numpy", "scipy", "pandas", "statsmodels", "nipype",
-            "scikit-learn", "nilearn", "duecredit", "pyneurovault", "six",
-            "abc"]
+            "scikit-learn", "nilearn", "duecredit", "pyneurovault", "six"]


### PR DESCRIPTION
abc is a part of the standard library and does not need to be installed (Thanks to @bilgelm)