### PR TITLE
store originating estimator in MetaResult

### DIFF
--- a/nimare/base/meta.py
+++ b/nimare/base/meta.py
@@ -14,7 +14,8 @@ class MetaResult(object):
     """Base class for meta-analytic results.
     Will contain slots for different kinds of results maps (e.g., z-map, p-map)
     """
-    def __init__(self, mask=None, **kwargs):
+    def __init__(self, estimator, mask=None, **kwargs):
+        self.estimator = estimator
         self.mask = mask
         self.images = {}
         for key, array in kwargs.items():

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -113,7 +113,7 @@ class ALE(CBMAEstimator):
             ma_maps = k_est.transform(self.ids, **self.kernel_arguments)
             images = self._run_ale(ma_maps, prefix='')
 
-        self.results = MetaResult(mask=self.mask, **images)
+        self.results = MetaResult(self, mask=self.mask, **images)
 
     def subtraction_analysis(self, ids, ids2, image1, image2, ma_maps):
         grp1_voxel = image1 > 0
@@ -537,7 +537,7 @@ class SCALE(CBMAEstimator):
                   'p': p_values,
                   'z': z_values,
                   'vthresh': vthresh_z_values}
-        self.results = MetaResult(mask=self.mask, **images)
+        self.results = MetaResult(self, mask=self.mask, **images)
 
     def _compute_ale(self, df=None, ma_maps=None):
         """

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -119,8 +119,9 @@ class MKDADensity(CBMAEstimator):
         vthresh_of_map = apply_mask(nib.Nifti1Image(vthresh_of_map,
                                                     of_map.affine),
                                     self.mask)
-        self.results = MetaResult(vthresh=vthresh_of_map, cfwe=cfwe_of_map,
-                                  vfwe=vfwe_of_map, mask=self.mask)
+        self.results = MetaResult(self, vthresh=vthresh_of_map,
+                                  cfwe=cfwe_of_map, vfwe=vfwe_of_map,
+                                  mask=self.mask)
 
     def _perm(self, params):
         iter_ijk, iter_df, weight_vec, conn = params
@@ -310,7 +311,7 @@ class MKDAChi2(CBMAEstimator):
             pFgA_z_FDR = p_to_z(pFgA_p_FDR, tail='two') * pFgA_sign
             images['specificity_z_FDR'] = pFgA_z_FDR
 
-        self.results = MetaResult(mask=self.mask, **images)
+        self.results = MetaResult(self, mask=self.mask, **images)
 
     def _perm(self, params):
         iter_df, iter_ijk, iter_ = params
@@ -402,7 +403,7 @@ class KDA(CBMAEstimator):
         vfwe_thresh = np.percentile(perm_max_values, percentile)
         vfwe_of_map = of_map.copy()
         vfwe_of_map[vfwe_of_map < vfwe_thresh] = 0.
-        self.results = MetaResult(vfwe=vfwe_of_map, mask=self.mask)
+        self.results = MetaResult(self, vfwe=vfwe_of_map, mask=self.mask)
 
     def _perm(self, params):
         iter_ijk, iter_df = params


### PR DESCRIPTION
This PR tweaks the `MetaResult` class to add a reference to the originating `Estimator` instance. This will be important when writing out logs—we'll want to include the estimator's name, parameters, etc. Closes #45.