### PR TITLE
adding the `conperm` CLI command

### DIFF
--- a/nimare/cli.py
+++ b/nimare/cli.py
@@ -1,6 +1,7 @@
 import click
 
 from nimare.workflows.ale import ale_sleuth_inference
+from nimare.workflows.ibma_perm import con_perm
 
 
 @click.group()
@@ -9,3 +10,4 @@ def cli():
 
 
 cli.add_command(ale_sleuth_inference)
+cli.add_command(con_perm)

--- a/nimare/workflows/ibma_perm.py
+++ b/nimare/workflows/ibma_perm.py
@@ -24,8 +24,10 @@ def con_perm(contrast_images, output_dir=None, output_prefix=output_prefix_defau
              n_iters=n_iters_default):
     target = 'mni152_2mm'
     mask_img = get_template(target, mask='brain')
+    click.echo("Loading contrast maps...")
     z_data = apply_mask(contrast_images, mask_img)
 
+    click.echo("Estimating the null distribution...")
     res = rfx_glm(z_data, mask_img, null='empirical', n_iters=n_iters)
 
     if output_dir is None:
@@ -33,5 +35,5 @@ def con_perm(contrast_images, output_dir=None, output_prefix=output_prefix_defau
     else:
         pathlib.Path(output_dir).mkdir(parents=True, exist_ok=True)
 
-    for name, img in res.images.items():
-        img.to_filename(os.path.join(output_dir, output_prefix + name + ".nii.gz"))
+    click.echo("Saving output maps...")
+    res.save_results(output_dir=output_dir, prefix=output_prefix)

--- a/nimare/workflows/ibma_perm.py
+++ b/nimare/workflows/ibma_perm.py
@@ -1,0 +1,38 @@
+import os
+import pathlib
+import click
+from nilearn.masking import apply_mask
+
+from ..utils import get_template
+from ..meta.ibma import rfx_glm
+
+n_iters_default = 10000
+output_prefix_default = ''
+
+
+@click.command(name='conperm', short_help='permutation based metaanalysis of contrast maps',
+               help='Metaanalysis of contrast maps using random effects and '
+                    'two-sided inference with empirical (permutation based) null distribution '
+                    'and Family Wise Error multiple comparison correction.')
+@click.argument('contrast_images', nargs=-1, required=True, type=click.Path(exists=True))
+@click.option('--output_dir', help="Where to put the output maps.")
+@click.option('--output_prefix', help="Common prefix for output maps.",
+              default=output_prefix_default, show_default=True)
+@click.option('--n_iters', default=n_iters_default, show_default=True,
+              help="Number of iterations for permutation testing.")
+def con_perm(contrast_images, output_dir=None, output_prefix=output_prefix_default,
+             n_iters=n_iters_default):
+    target = 'mni152_2mm'
+    mask_img = get_template(target, mask='brain')
+    z_data = apply_mask(contrast_images, mask_img)
+
+    res = rfx_glm(z_data, mask_img, null='empirical', n_iters=n_iters)
+
+    if output_dir is None:
+        output_dir = os.getcwd()
+    else:
+        pathlib.Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    for name, img in res.images.items():
+        print(output_dir, output_prefix, name)
+        img.to_filename(os.path.join(output_dir, output_prefix + name + ".nii.gz"))

--- a/nimare/workflows/ibma_perm.py
+++ b/nimare/workflows/ibma_perm.py
@@ -34,5 +34,4 @@ def con_perm(contrast_images, output_dir=None, output_prefix=output_prefix_defau
         pathlib.Path(output_dir).mkdir(parents=True, exist_ok=True)
 
     for name, img in res.images.items():
-        print(output_dir, output_prefix, name)
         img.to_filename(os.path.join(output_dir, output_prefix + name + ".nii.gz"))


### PR DESCRIPTION
```
Usage: nimare conperm [OPTIONS] CONTRAST_IMAGES...

  Metaanalysis of contrast maps using random effects and two-sided inference
  with empirical (permutation based) null distribution and Family Wise Error
  multiple comparison correction.

Options:
  --output_dir TEXT     Where to put the output maps.
  --output_prefix TEXT  Common prefix for output maps.  [default: ]
  --n_iters INTEGER     Number of iterations for permutation testing.
                        [default: 10000]
  --help                Show this message and exit.
```