### PR TITLE
Small speedups in kernel transforms

### DIFF
--- a/nimare/meta/cbma/kernel.py
+++ b/nimare/meta/cbma/kernel.py
@@ -61,11 +61,12 @@ class ALEKernel(KernelEstimator):
         imgs = []
         kernels = {}
         for id_, data in self.coordinates.groupby('id'):
-            ijk = data[['i', 'j', 'k']].values.astype(int)
+            #ijk = data[['i', 'j', 'k']].values.astype(int)
+            ijk = np.vstack((data.i.values, data.j.values, data.k.values)).T.astype(int)
             if n is not None:
                 n_subjects = n
             elif fwhm is None:
-                n_subjects = data['n'].astype(float).values[0]
+                n_subjects = data.n.astype(float).values[0]
 
             if fwhm is not None:
                 assert np.isfinite(fwhm), 'FWHM must be finite number'
@@ -141,7 +142,7 @@ class MKDAKernel(KernelEstimator):
         imgs = []
         for id_, data in self.coordinates.groupby('id'):
             kernel_data = np.zeros(dims)
-            for ijk in data[['i', 'j', 'k']].values:
+            for ijk in np.vstack((data.i.values, data.j.values, data.k.values)).T:
                 xx, yy, zz = [slice(-r // vox_dims[i], r // vox_dims[i] + 0.01, 1) for i in range(len(ijk))]
                 cube = np.vstack([row.ravel() for row in np.mgrid[xx, yy, zz]])
                 sphere = cube[:, np.sum(np.dot(np.diag(vox_dims), cube) ** 2, 0) ** .5 <= r]
@@ -208,7 +209,7 @@ class KDAKernel(KernelEstimator):
         imgs = []
         for id_, data in self.coordinates.groupby('id'):
             kernel_data = np.zeros(dims)
-            for ijk in data[['i', 'j', 'k']].values:
+            for ijk in np.vstack((data.i.values, data.j.values, data.k.values)).T:
                 xx, yy, zz = [slice(-r // vox_dims[i], r // vox_dims[i] + 0.01, 1) for i in range(len(ijk))]
                 cube = np.vstack([row.ravel() for row in np.mgrid[xx, yy, zz]])
                 sphere = cube[:, np.sum(np.dot(np.diag(vox_dims), cube) ** 2, 0) ** .5 <= r]
@@ -258,7 +259,7 @@ class Peaks2MapsKernel(KernelEstimator):
         for id_ in ids:
             data = self.coordinates.loc[self.coordinates['id'] == id_]
             mm_coords = []
-            for coord in data[['i', 'j', 'k']].values:
+            for coord in np.vstack((data.i.values, data.j.values, data.k.values)).T:
                 mm_coords.append(vox2mm(coord, self.mask.affine))
             coordinates_list.append(mm_coords)
 

--- a/nimare/meta/cbma/kernel.py
+++ b/nimare/meta/cbma/kernel.py
@@ -60,8 +60,7 @@ class ALEKernel(KernelEstimator):
             mask_data = self.mask.get_data().astype(np.bool)
         imgs = []
         kernels = {}
-        for id_ in ids:
-            data = self.coordinates.loc[self.coordinates['id'] == id_]
+        for id_, data in self.coordinates.groupby('id'):
             ijk = data[['i', 'j', 'k']].values.astype(int)
             if n is not None:
                 n_subjects = n
@@ -140,8 +139,7 @@ class MKDAKernel(KernelEstimator):
             mask_data = self.mask.get_data().astype(np.bool)
 
         imgs = []
-        for id_ in ids:
-            data = self.coordinates.loc[self.coordinates['id'] == id_]
+        for id_, data in self.coordinates.groupby('id'):
             kernel_data = np.zeros(dims)
             for ijk in data[['i', 'j', 'k']].values:
                 xx, yy, zz = [slice(-r // vox_dims[i], r // vox_dims[i] + 0.01, 1) for i in range(len(ijk))]
@@ -208,8 +206,7 @@ class KDAKernel(KernelEstimator):
             mask_data = self.mask.get_data().astype(np.bool)
 
         imgs = []
-        for id_ in ids:
-            data = self.coordinates.loc[self.coordinates['id'] == id_]
+        for id_, data in self.coordinates.groupby('id'):
             kernel_data = np.zeros(dims)
             for ijk in data[['i', 'j', 'k']].values:
                 xx, yy, zz = [slice(-r // vox_dims[i], r // vox_dims[i] + 0.01, 1) for i in range(len(ijk))]

--- a/nimare/meta/cbma/utils.py
+++ b/nimare/meta/cbma/utils.py
@@ -132,7 +132,6 @@ def peaks2maps(contrasts_coordinates, skip_out_of_bounds=True,
     niis = [nb.Nifti1Image(np.squeeze(result), affine) for result in results]
     return niis
 
-
 def compute_ma(shape, ijk, kernel):
     """
     Generate modeled activation (MA) maps.
@@ -158,25 +157,37 @@ def compute_ma(shape, ijk, kernel):
     """
     ma_values = np.zeros(shape)
     mid = int(np.floor(kernel.shape[0] / 2.))
+    mid1 = mid+1
     for j_peak in range(ijk.shape[0]):
         i, j, k = ijk[j_peak, :]
         xl = max(i-mid, 0)
-        xh = min(i+mid+1, ma_values.shape[0])
+        xh = min(i+mid1, ma_values.shape[0])
         yl = max(j-mid, 0)
-        yh = min(j+mid+1, ma_values.shape[1])
+        yh = min(j+mid1, ma_values.shape[1])
         zl = max(k-mid, 0)
-        zh = min(k+mid+1, ma_values.shape[2])
+        zh = min(k+mid1, ma_values.shape[2])
         xlk = mid - (i - xl)
         xhk = mid - (i - xh)
         ylk = mid - (j - yl)
         yhk = mid - (j - yh)
         zlk = mid - (k - zl)
         zhk = mid - (k - zh)
-        if all(np.array([xl, xh, yl, yh, zl, zh, xlk, xhk, ylk, yhk, zlk, zhk]) >= 0):
+
+        if ((xl >=0)
+            & (xh >=0)
+            & (yl >=0)
+            & (yh >=0)
+            & (zl >=0)
+            & (zh >=0)
+            & (xlk >=0)
+            & (xhk >=0)
+            & (ylk >=0)
+            & (yhk >=0)
+            & (zlk >=0)
+            & (zhk >=0)):
             ma_values[xl:xh, yl:yh, zl:zh] = np.maximum(ma_values[xl:xh, yl:yh, zl:zh],
                                                         kernel[xlk:xhk, ylk:yhk, zlk:zhk])
     return ma_values
-
 
 @due.dcite(Doi('10.1002/hbm.20718'),
            description='Introduces sample size-dependent kernels to ALE.')


### PR DESCRIPTION
Using groupby instead of looping through ids and calling loc is a little bit faster. Using the '.' accessor is slightly faster than using the '[]' to get values. Also, I added some small optimizations in the compute_ma code.