### PR TITLE
skeleton of MC correction hierarchy

### DIFF
--- a/nimare/correct/__init__.py
+++ b/nimare/correct/__init__.py
@@ -1,0 +1,6 @@
+from .base import FDRCorrector
+
+
+__all__ = [
+    'FDRCorrector'
+]

--- a/nimare/correct/base.py
+++ b/nimare/correct/base.py
@@ -1,16 +1,21 @@
+from abc import abstractmethod, ABCMeta
 
 
-class Corrector(object):
+class Corrector(metaclass=ABCMeta):
     ''' Base class for multiple comparison correction. '''
     _correction_method = None
     
     def transform(self, result, **kwargs):
         est = result.estimator
         method = self._correction_method
-        if (self._correction_method is not None and hasattr(est, meth)):
+        if (self._correction_method is not None and hasattr(est, method)):
             getattr(est, method)(result, **kwargs)
         else:
-            self._transform(result, **kwargss)
+            self._transform(result, **kwargs)
+
+    @abstractmethod
+    def _transform(self, result, **kwargs):
+        pass
 
 
 class FDRCorrector(Corrector):

--- a/nimare/correct/base.py
+++ b/nimare/correct/base.py
@@ -1,0 +1,25 @@
+
+
+class Corrector(object):
+    ''' Base class for multiple comparison correction. '''
+    _correction_method = None
+    
+    def transform(self, result, **kwargs):
+        est = result.estimator
+        method = self._correction_method
+        if (self._correction_method is not None and hasattr(est, meth)):
+            getattr(est, method)(result, **kwargs)
+        else:
+            self._transform(result, **kwargss)
+
+
+class FDRCorrector(Corrector):
+
+    # The name of the method that must be implemented in a MetaEstimator class
+    # in order to override the default correction method.
+    _correction_method = '_fdr_correct'
+
+    def _transform(self, result, **kwargs):
+        # Do standard FDR correction here, then return a copy of the
+        # MetaResult that contains the new FDR-corrected image(s)
+        return result


### PR DESCRIPTION
This PR creates a skeleton `nimare.correct` hierarchy with a barebones class hierarchy, to illustrate how the API could work. This is untested and may need some tweaking. I added a sample `FDRCorrect` class to illustrate usage.