### PR TITLE
[FIX] Remove deprecated sklearn dependency

### DIFF
--- a/nimare/base/base.py
+++ b/nimare/base/base.py
@@ -6,8 +6,8 @@ import multiprocessing as mp
 from collections import defaultdict
 from abc import ABCMeta, abstractmethod
 
+import inspect
 from six import with_metaclass
-from sklearn.utils.fixes import signature
 
 from ..dataset.dataset import Dataset
 
@@ -48,7 +48,7 @@ class NiMAREBase(with_metaclass(ABCMeta)):
 
         # introspect the constructor arguments to find the model parameters
         # to represent
-        init_signature = signature(init)
+        init_signature = inspect.signature(init)
         # Consider the constructor parameters excluding 'self'
         parameters = [p for p in init_signature.parameters.values()
                       if p.name != 'self' and p.kind != p.VAR_KEYWORD]

--- a/nimare/base/base.py
+++ b/nimare/base/base.py
@@ -18,7 +18,7 @@ class NiMAREBase(with_metaclass(ABCMeta)):
     def __init__(self):
         """
         TODO: Actually write/refactor class methods. They mostly come directly from sklearn
-        https://github.com/scikit-learn/scikit-learn/blob/afe540c7f2cbad259dd333e6744b088213180bee/sklearn/base.py#L176
+        https://github.com/scikit-learn/scikit-learn/blob/2a1e9686eeb203f5fddf44fd06414db8ab6a554a/sklearn/base.py#L141
         """
         pass
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Scikit-learn no longer has a custom signature function, which has been raising errors in our tests. I've updated our base class's parameter inspection methods to match scikit-learn's current version.