### PR TITLE
[FIX] Support multiline experiment names in Sleuth converter

### DIFF
--- a/nimare/io.py
+++ b/nimare/io.py
@@ -147,12 +147,16 @@ def convert_sleuth_to_dict(text_file):
     for i_exp, exp_idx in enumerate(split_idx):
         exp_data = data[exp_idx[0]:exp_idx[1]]
         if exp_data:
-            study_info = exp_data[0].replace('//', '').strip()
+            header_idx = [i for i in range(len(exp_data)) if exp_data[i].startswith('//')]
+            study_info_idx = header_idx[:-1]
+            n_idx = header_idx[-1]
+            study_info = [exp_data[i].replace('//', '').strip() for i in study_info_idx]
+            study_info = ' '.join(study_info)
             study_name = study_info.split(':')[0]
             contrast_name = ':'.join(study_info.split(':')[1:]).strip()
-            sample_size = int(exp_data[1].replace(
+            sample_size = int(exp_data[n_idx].replace(
                 ' ', '').replace('//Subjects=', ''))
-            xyz = exp_data[2:]  # Coords are everything after study info and n
+            xyz = exp_data[n_idx+1:]  # Coords are everything after study info and n
             xyz = [row.split('\t') for row in xyz]
             correct_shape = np.all([len(coord) == 3 for coord in xyz])
             if not correct_shape:


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #129.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Makes the Sleuth converter more flexible, to allow for multiline experiment names. These occur when the name is too long and ends up wrapped in the text file, or when grouping is applied to consolidate experiments within the same study.
