### PR TITLE
Save pain test dataset to local directory

### DIFF
--- a/nimare/tests/conftest.py
+++ b/nimare/tests/conftest.py
@@ -15,20 +15,16 @@ from nimare.tests.utils import download_nidm_pain, get_test_data_path
 
 
 @pytest.fixture(scope='session', autouse=True)
-def download_data(tmpdir_factory):
+def download_data():
     """
-    Download 21 pain studies from NeuroVault to test IBMA functions.
+    Download and save 21 pain studies from NeuroVault to test IBMA functions.
     """
-    tst_dir = tmpdir_factory.mktemp('tests')
-    out_dir = tst_dir.ensure('resources',
-                             'data',
-                             'neurovault-data',
-                             'collection-1425',
-                             dir=True)
+    home = op.expanduser("~")
+    out_dir = op.join(home, '.nimare', 'data', 'neurovault', 'collection-1425')
     if not op.isdir(op.join(out_dir, 'pain_21.nidm')):
         download_nidm_pain(out_dir)
     pytest.dset_dir = out_dir
-    return tst_dir
+    return out_dir
 
 
 @pytest.fixture(scope='session', autouse=True)


### PR DESCRIPTION
When the tests are first run, the NIDM pain dataset will be saved locally under `~.nidm`, preventing a ~200 MB download each time.

Closes #172.