### PR TITLE
[FIX] Fix missing parameter q of FDRCorrector

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -57,6 +57,11 @@
       "name": "Laird, Angela R.",
       "affiliation": "Florida International University",
       "orcid": "0000-0003-3379-8744"
+    },
+    {
+      "name": "Pérez, Alexandre",
+      "affiliation": "Montreal Neurological Institute, McGill University",
+      "orcid": "0000-0003-0556-0763"
     }
   ],
   "keywords": [

--- a/nimare/correct/correct.py
+++ b/nimare/correct/correct.py
@@ -53,7 +53,8 @@ class FDRCorrector(Corrector):
 
     _correction_method = '_fdr_correct'
 
-    def __init__(self, method='indep', **kwargs):
+    def __init__(self, q=0.05, method='indep', **kwargs):
+        self.q = q
         self.method = method
         self.parameters = kwargs
 

--- a/nimare/correct/correct.py
+++ b/nimare/correct/correct.py
@@ -43,7 +43,7 @@ class FDRCorrector(Corrector):
 
     Parameters
     ----------
-    q : `obj`:float
+    alpha : `obj`:float
         The FDR correction rate to use.
     method : `obj`:str
         The FDR correction to use. Either 'indep' (for independent or
@@ -53,8 +53,8 @@ class FDRCorrector(Corrector):
 
     _correction_method = '_fdr_correct'
 
-    def __init__(self, q=0.05, method='indep', **kwargs):
-        self.q = q
+    def __init__(self, alpha=0.05, method='indep', **kwargs):
+        self.alpha = alpha
         self.method = method
         self.parameters = kwargs
 
@@ -64,7 +64,7 @@ class FDRCorrector(Corrector):
 
     def _transform(self, result):
         p = result.maps['p']
-        _, p_corr = mc.fdrcorrection(p, alpha=self.q, method=self.method,
+        _, p_corr = mc.fdrcorrection(p, alpha=self.alpha, method=self.method,
                                      is_sorted=False)
         corr_maps = {'p': p_corr}
         self._generate_secondary_maps(result, corr_maps)


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #181.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->

I added the missing parameter `q` in the `__init__`function of the `nimare.correct.FDRCorrector`.

The other alternative would have been to read this parameter from the existing `self.parameters` dictionary but I found it weirder since `q` is a required argument.
