### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/nimare/extract/utils.py
+++ b/nimare/extract/utils.py
@@ -10,7 +10,7 @@ import requests
 
 import numpy as np
 import pandas as pd
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 from ..utils import uk_to_us
 

--- a/nimare/info.py
+++ b/nimare/info.py
@@ -49,7 +49,7 @@ DOWNLOAD_URL = (
 
 REQUIRES = [
     'cognitiveatlas',
-    'fuzzywuzzy',
+    'rapidfuzz',
     'matplotlib',
     'nibabel',
     'nilearn',


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy