### PR TITLE
[TST] Add CI step for building docs

### DIFF
--- a/.circleci/artifact_path
+++ b/.circleci/artifact_path
@@ -1,0 +1,1 @@
+0/tmp/src/NiMARE/docs/_build/html/index.html

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,13 +28,29 @@ jobs:
             else
                 conda create -n testenv python=3.6 numpy scipy scikit-learn traits -yq
                 source activate testenv
-                pip install -e .[tests]
+                pip install -e .[tests,doc]
             fi
             python setup.py install --user
       - save_cache:  # environment cache tied to requirements
           key: deps9-{{ checksum "nimare/info.py" }}
           paths:
             - "/opt/conda/envs/testenv"
+
+  build_docs:
+    docker:
+      - image: continuumio/miniconda3
+    steps:
+      - attach_workspace:  # get NiMARE
+          at: /tmp
+      - restore_cache:  # load environment
+          key: deps9-{{ checksum "nimare/info.py" }}
+      - run:
+          name: Build documentation
+          command: |
+            source activate testenv
+            make -C doc html
+      - store_artifacts:
+          path: /tmp/src/NiMARE/docs/_build/html
 
   style_check:
     working_directory: /tmp/src/NiMARE
@@ -98,6 +114,9 @@ workflows:
   run_tests:
     jobs:
       - build
+      - build_docs:
+          requires:
+            - build
       - style_check:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: |
             apt-get install -yqq make
             source activate testenv
-            make -C doc html
+            make -C docs html
       - store_artifacts:
           path: /tmp/src/NiMARE/docs/_build/html
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ jobs:
             - "/opt/conda/envs/testenv"
 
   build_docs:
+    working_directory: /tmp/src/NiMARE
     docker:
       - image: continuumio/miniconda3
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ jobs:
       - run:
           name: Build documentation
           command: |
+            apt-get install -yqq make
             source activate testenv
             make -C doc html
       - store_artifacts:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Ultimately, however, we plan to support all (or most) of the methods listed belo
     - Weighted Stouffer's meta-analysis
     - Fisher's meta-analysis
 - Automated annotation (`nimare.annotate`)
-    - Tf-idf vectorization of text (`nimare.annotate.tfidf`)
+    - TF-IDF vectorization of text (`nimare.annotate.tfidf`)
     - Ontology-based annotation (`nimare.annotate.ontology`)
         - Cognitive Paradigm Ontology (`nimare.annotate.ontology.cogpo`)
         - Cognitive Atlas (`nimare.annotate.ontology.cogat`)

--- a/docs/requirements-dev.txt
+++ b/docs/requirements-dev.txt
@@ -3,3 +3,4 @@ numpydoc
 sphinx_gallery
 m2r
 sphinx_rtd_theme
+pillow

--- a/docs/requirements-dev.txt
+++ b/docs/requirements-dev.txt
@@ -2,3 +2,4 @@ sphinx-argparse
 numpydoc
 sphinx_gallery
 m2r
+sphinx_rtd_theme

--- a/nimare/info.py
+++ b/nimare/info.py
@@ -88,6 +88,7 @@ EXTRA_REQUIRES = {
         'sphinx>=1.5.3',
         'sphinx-argparse',
         'sphinx_rtd_theme',
+        'sphinx_gallery',
         'numpydoc',
         'm2r'
     ],

--- a/nimare/info.py
+++ b/nimare/info.py
@@ -86,8 +86,8 @@ EXTRA_REQUIRES = {
     ],
     'doc': [
         'sphinx>=1.5.3',
-        'sphinx_rtd_theme',
         'sphinx-argparse',
+        'sphinx_rtd_theme',
         'numpydoc',
         'm2r'
     ],

--- a/nimare/info.py
+++ b/nimare/info.py
@@ -90,7 +90,8 @@ EXTRA_REQUIRES = {
         'sphinx_rtd_theme',
         'sphinx_gallery',
         'numpydoc',
-        'm2r'
+        'm2r',
+        'pillow'
     ],
     'tests': TESTS_REQUIRES,
     'duecredit': ['duecredit'],

--- a/nimare/info.py
+++ b/nimare/info.py
@@ -85,7 +85,7 @@ EXTRA_REQUIRES = {
         'appdirs'
     ],
     'doc': [
-        'sphinx>=1.5.3',
+        'sphinx~=2.4.2',
         'sphinx-argparse',
         'sphinx_rtd_theme',
         'sphinx_gallery',


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #180. Takes approach from pybids and fmriprep.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add step in CircleCI config for building docs.
- Add artifact_path file with path to doc main page.
