### PR TITLE
[FIX] Retain ALESubtraction results

### DIFF
--- a/nimare/cli.py
+++ b/nimare/cli.py
@@ -88,6 +88,7 @@ def _get_parser():
         '--n_cores',
         dest='n_cores',
         type=int,
+        default=1,
         help=('Number of processes to use for meta-analysis. If -1, use '
               'all available cores.')
     )
@@ -225,6 +226,7 @@ def _get_parser():
         '--n_cores',
         dest='n_cores',
         type=int,
+        default=1,
         help=('Number of processes to use for meta-analysis. If -1, use '
               'all available cores.')
     )
@@ -282,6 +284,7 @@ def _get_parser():
         '--n_cores',
         dest='n_cores',
         type=int,
+        default=1,
         help=('Number of processes to use for meta-analysis. If -1, use '
               'all available cores.')
     )

--- a/nimare/correct/base.py
+++ b/nimare/correct/base.py
@@ -81,7 +81,7 @@ class Corrector(metaclass=ABCMeta):
         # MetaEstimator, use it. Otherwise fall back on _transform.
         if (correction_method is not None and hasattr(est, correction_method)):
             LGR.info('Using correction method implemented in Estimator: {}.'
-                     '{}.'.format(est, correction_method))
+                     '{}.'.format(type(est), correction_method))
             corr_maps = getattr(est, correction_method)(result, **self.parameters)
         else:
             self._validate_input(result)

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -546,7 +546,7 @@ class ALESubtraction(CBMAEstimator):
         diff_z_map[grp1_voxel] = grp1_z_map[grp1_voxel]
 
         images = {'grp1-grp2_z': diff_z_map}
-        self.results = MetaResult(self, self.mask, maps=images)
+        return images
 
 
 @due.dcite(references.SCALE,

--- a/nimare/workflows/ale.py
+++ b/nimare/workflows/ale.py
@@ -163,7 +163,7 @@ false discovery rate and performing statistical contrasts. Human brain mapping,
         ale1 = ALE(kernel__fwhm=fwhm)
         ale2 = ALE(kernel__fwhm=fwhm)
 
-        LGR.info('Performing meta-analysis...')
+        LGR.info('Performing meta-analyses...')
         res1 = ale1.fit(dset1)
         res2 = ale2.fit(dset2)
         corr = FWECorrector(method='permutation', n_iters=n_iters,


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None. Addresses a bug identified by @mriedel56 offline, in which ALESubtractions were not returning any maps in the MetaResults objects.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:
- Was setting self.results within the _fit method, and returning None. The problem is that _fit is supposed to return the images dictionary, and fit is what sets self.results. So it was overwriting self.results with an empty MetaResult object.
- Add n_cores defaults to CLI.
