### PR TITLE
[FIX] Mask coordinates before kernel convolution

### DIFF
--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -10,6 +10,7 @@ import os.path as op
 import numpy as np
 import pandas as pd
 import nibabel as nib
+from scipy.spatial.distance import cdist
 
 from .base import NiMAREBase
 from .utils import (tal2mni, mni2tal, mm2vox, get_template, listify,
@@ -574,7 +575,6 @@ class Dataset(NiMAREBase):
             A list of IDs from the Dataset with at least one focus within
             radius r of requested coordinates.
         """
-        from scipy.spatial.distance import cdist
         xyz = np.array(xyz)
         assert xyz.shape[1] == 3 and xyz.ndim == 2
         distances = cdist(xyz, self.coordinates[['x', 'y', 'z']].values)

--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -543,7 +543,6 @@ class Dataset(NiMAREBase):
         found_ids : list
             A list of IDs from the Dataset with at least one focus in the mask.
         """
-        from scipy.spatial.distance import cdist
         if isinstance(mask, str):
             mask = nib.load(mask)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #37.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add step in `MetaEstimator._preprocess_input` to mask coordinates if they fall outside of the analysis mask.
