### PR TITLE
[ENH] Support initialized and uninitialized kernels for CBMA

### DIFF
--- a/nimare/base.py
+++ b/nimare/base.py
@@ -294,6 +294,18 @@ class MetaEstimator(Estimator):
 
 class CBMAEstimator(MetaEstimator):
     """Base class for coordinate-based meta-analysis methods.
+
+    Parameters
+    ----------
+    kernel_transformer : :obj:`nimare.base.KernelTransformer`, optional
+        Kernel with which to convolve coordinates from dataset. Default is
+        ALEKernel.
+    *args
+        Optional arguments to the :obj:`nimare.base.MetaEstimator` __init__
+        (called automatically).
+    **kwargs
+        Optional keyword arguments to the :obj:`nimare.base.MetaEstimator`
+        __init__ (called automatically).
     """
     def __init__(self, kernel_transformer, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -3,12 +3,12 @@ Base classes for datasets.
 """
 import gzip
 import pickle
+import inspect
 import logging
 import multiprocessing as mp
 from collections import defaultdict
 from abc import ABCMeta, abstractmethod
 
-import inspect
 import numpy as np
 import pandas as pd
 from six import with_metaclass
@@ -307,7 +307,7 @@ class CBMAEstimator(MetaEstimator):
                 not issubclass(type(kernel_transformer), KernelTransformer):
             raise ValueError('Argument "kernel_transformer" must be a kind of '
                              'KernelTransformer')
-        elif not isclass(kernel_transformer) and kernel_args:
+        elif not inspect.isclass(kernel_transformer) and kernel_args:
             LGR.warning('Argument "kernel_transformer" has already been '
                         'initialized, so kernel arguments will be ignored: '
                         '{}'.format(', '.join(kernel_args.keys())))

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -311,7 +311,7 @@ class CBMAEstimator(MetaEstimator):
             LGR.warning('Argument "kernel_transformer" has already been '
                         'initialized, so kernel arguments will be ignored: '
                         '{}'.format(', '.join(kernel_args.keys())))
-        else:
+        elif inspect.isclass(kernel_transformer):
             kernel_transformer = kernel_transformer(**kernel_args)
         self.kernel_transformer = kernel_transformer
 

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -295,8 +295,25 @@ class MetaEstimator(Estimator):
 class CBMAEstimator(MetaEstimator):
     """Base class for coordinate-based meta-analysis methods.
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, kernel_transformer, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        # Get kernel transformer
+        kernel_args = {k.split('kernel__')[1]: v for k, v in kwargs.items()
+                       if k.startswith('kernel__')}
+
+        # Allow both instances and classes for the kernel transformer input.
+        if not issubclass(kernel_transformer, KernelTransformer) and \
+                not issubclass(type(kernel_transformer), KernelTransformer):
+            raise ValueError('Argument "kernel_transformer" must be a kind of '
+                             'KernelTransformer')
+        elif not isclass(kernel_transformer) and kernel_args:
+            LGR.warning('Argument "kernel_transformer" has already been '
+                        'initialized, so kernel arguments will be ignored: '
+                        '{}'.format(', '.join(kernel_args.keys())))
+        else:
+            kernel_transformer = kernel_transformer(**kernel_args)
+        self.kernel_transformer = kernel_transformer
 
     def _preprocess_input(self, dataset):
         """Mask required input images using either the dataset's mask or the

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -80,15 +80,9 @@ class ALE(CBMAEstimator):
     }
 
     def __init__(self, kernel_transformer=ALEKernel, **kwargs):
-        super().__init__(**kwargs)
-        kernel_args = {k.split('kernel__')[1]: v for k, v in kwargs.items()
-                       if k.startswith('kernel__')}
-
-        if not issubclass(kernel_transformer, KernelTransformer):
-            raise ValueError('Argument "kernel_transformer" must be a KernelTransformer')
-
+        # Add kernel transformer attribute and process keyword arguments
+        super().__init__(kernel_transformer=kernel_transformer, **kwargs)
         self.dataset = None
-        self.kernel_transformer = kernel_transformer(**kernel_args)
         self.results = None
 
     def _fit(self, dataset):
@@ -419,7 +413,6 @@ class ALESubtraction(CBMAEstimator):
     }
 
     def __init__(self, n_iters=10000):
-        super().__init__()
         self.meta1 = None
         self.meta2 = None
         self.results = None
@@ -558,16 +551,10 @@ class SCALE(CBMAEstimator):
 
     def __init__(self, voxel_thresh=0.001, n_iters=10000, n_cores=-1, ijk=None,
                  kernel_transformer=ALEKernel, **kwargs):
-        super().__init__(**kwargs)
-        kernel_args = {k.split('kernel__')[1]: v for k, v in kwargs.items()
-                       if k.startswith('kernel__')}
-
-        if not issubclass(kernel_transformer, KernelTransformer):
-            raise ValueError('Argument "kernel_transformer" must be a '
-                             'KernelTransformer')
+        # Add kernel transformer attribute and process keyword arguments
+        super().__init__(kernel_transformer=kernel_transformer, **kwargs)
 
         self.dataset = None
-        self.kernel_transformer = kernel_transformer(**kernel_args)
         self.results = None
         self.voxel_thresh = voxel_thresh
         self.ijk = ijk

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -10,7 +10,7 @@ import pandas as pd
 import nibabel as nib
 from scipy import ndimage
 
-from .kernel import ALEKernel, KernelTransformer
+from .kernel import ALEKernel
 from ...results import MetaResult
 from ...base import CBMAEstimator
 from ...due import due

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -10,7 +10,7 @@ from tqdm.auto import tqdm
 from scipy import ndimage, special
 from statsmodels.sandbox.stats.multicomp import multipletests
 
-from .kernel import MKDAKernel, KDAKernel, KernelTransformer
+from .kernel import MKDAKernel, KDAKernel
 from ...results import MetaResult
 from ...base import CBMAEstimator
 from ...stats import null_to_p, one_way, two_way

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -51,15 +51,10 @@ class MKDADensity(CBMAEstimator):
     }
 
     def __init__(self, kernel_transformer=MKDAKernel, **kwargs):
-        super().__init__(**kwargs)
-        kernel_args = {k.split('kernel__')[1]: v for k, v in kwargs.items()
-                       if k.startswith('kernel__')}
-
-        if not issubclass(kernel_transformer, KernelTransformer):
-            raise ValueError('Argument "kernel_transformer" must be a KernelTransformer')
+        # Add kernel transformer attribute and process keyword arguments
+        super().__init__(kernel_transformer=kernel_transformer, **kwargs)
 
         self.dataset = None
-        self.kernel_transformer = kernel_transformer(**kernel_args)
         self.results = None
 
     def _fit(self, dataset):
@@ -271,15 +266,9 @@ class MKDAChi2(CBMAEstimator):
     }
 
     def __init__(self, prior=0.5, kernel_transformer=MKDAKernel, **kwargs):
-        super().__init__(**kwargs)
-        kernel_args = {k.split('kernel__')[1]: v for k, v in kwargs.items()
-                       if k.startswith('kernel__')}
+        # Add kernel transformer attribute and process keyword arguments
+        super().__init__(kernel_transformer=kernel_transformer, **kwargs)
 
-        if not issubclass(kernel_transformer, KernelTransformer):
-            raise ValueError('Argument "kernel_transformer" must be a '
-                             'KernelTransformer')
-
-        self.kernel_transformer = kernel_transformer(**kernel_args)
         self.prior = prior
 
     def fit(self, dataset1, dataset2):
@@ -634,16 +623,10 @@ class KDA(CBMAEstimator):
     }
 
     def __init__(self, kernel_transformer=KDAKernel, **kwargs):
-        super().__init__(**kwargs)
-        kernel_args = {k.split('kernel__')[1]: v for k, v in kwargs.items()
-                       if k.startswith('kernel__')}
-
-        if not issubclass(kernel_transformer, KernelTransformer):
-            raise ValueError('Argument "kernel_transformer" must be a '
-                             'KernelTransformer')
+        # Add kernel transformer attribute and process keyword arguments
+        super().__init__(kernel_transformer=kernel_transformer, **kwargs)
 
         self.dataset = None
-        self.kernel_transformer = kernel_transformer(**kernel_args)
         self.results = None
 
     def _fit(self, dataset):

--- a/nimare/tests/test_cbma_mkda.py
+++ b/nimare/tests/test_cbma_mkda.py
@@ -1,9 +1,42 @@
 """
 Test nimare.meta.cbma.mkda (KDA-based meta-analytic algorithms).
 """
+import pytest
+
 import nimare
-from nimare.meta.cbma import mkda
+from nimare.meta.cbma import mkda, kernel
 from nimare.correct import FWECorrector, FDRCorrector
+
+
+def test_mkda_density_kernel_instance_with_kwargs(testdata):
+    """
+    Smoke test for MKDADensity with a kernel transformer object, with kernel
+    arguments provided, which should result in a warning, but the original
+    object's parameters should remain untouched.
+    """
+    kern = kernel.MKDAKernel(r=2)
+    meta = mkda.MKDADensity(kern, kernel__r=6)
+
+    assert meta.kernel_transformer.get_params().get('r') == 2
+
+
+def test_mkda_density_kernel_class(testdata):
+    """
+    Smoke test for MKDADensity with a kernel transformer class.
+    """
+    meta = mkda.MKDADensity(kernel.MKDAKernel, kernel__r=5)
+    res = meta.fit(testdata['dset'])
+    assert isinstance(res, nimare.base.MetaResult)
+
+
+def test_mkda_density_kernel_instance(testdata):
+    """
+    Smoke test for MKDADensity with a kernel transformer object.
+    """
+    kern = kernel.MKDAKernel(r=5)
+    meta = mkda.MKDADensity(kern)
+    res = meta.fit(testdata['dset'])
+    assert isinstance(res, nimare.base.MetaResult)
 
 
 def test_mkda_density(testdata):


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Allow kernel transformers to be initialized before they're fed into the meta-analytic estimator.
- Pop a few things up in the CBMAEstimator hierarchy to reduce duplication.
