### PR TITLE
[FIX] Replace NaNs in Datasets with Nones

### DIFF
--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -50,6 +50,8 @@ def dict_to_df(id_df, data, key='labels'):
     df = pd.merge(id_df, temp_df, left_index=True, right_index=True, how='outer')
     df = df.reset_index(drop=True)
     df = df.replace(to_replace='None', value=np.nan)
+    # replace nan with none
+    df = df.where(pd.notnull(df), None)
     return df
 
 
@@ -100,6 +102,8 @@ def dict_to_coordinates(data, masker, space):
     df = pd.concat(all_dfs, axis=0, join='outer', sort=False)
     df = df[columns].reset_index(drop=True)
     df = df.replace(to_replace='None', value=np.nan)
+    # replace nan with none
+    df = df.where(pd.notnull(df), None)
     df[['x', 'y', 'z']] = df[['x', 'y', 'z']].astype(float)
 
     # Now to apply transformations!


### PR DESCRIPTION
<!---
This is a suggested pull request template for tedana.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None, but fixes a bug I noticed while working on #273.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- In Dataset DataFrame attributes, fill missing values with `None` instead of `numpy.nan`. This works with `Dataset.get` and other methods that were checking against None rather than `isnan`. It also makes it easier to have missing data in the json file.
