### PR TITLE
[FIX] Operate on copy of df in extract_cogat()

### DIFF
--- a/nimare/annotate/cogat.py
+++ b/nimare/annotate/cogat.py
@@ -123,6 +123,7 @@ def extract_cogat(text_df, id_df=None, text_column="abstract"):
       knowledge foundation for cognitive neuroscience." Frontiers in
       neuroinformatics 5 (2011): 17. https://doi.org/10.3389/fninf.2011.00017
     """
+    text_df = text_df.copy()
     if id_df is None:
         cogat = download_cognitive_atlas()
         id_df = pd.read_csv(cogat["ids"])
@@ -130,7 +131,6 @@ def extract_cogat(text_df, id_df=None, text_column="abstract"):
     if "id" in text_df.columns:
         text_df.set_index("id", inplace=True)
 
-    text_df = text_df.copy()
     text_df[text_column] = text_df[text_column].fillna("")
     text_df[text_column] = text_df[text_column].apply(uk_to_us)
 

--- a/nimare/tests/test_annotate_cogat.py
+++ b/nimare/tests/test_annotate_cogat.py
@@ -26,6 +26,7 @@ def test_cogat():
     counts_df, rep_text_df = annotate.cogat.extract_cogat(
         ns_dset_laird.texts, id_df, text_column="abstract"
     )
+    assert 'id' in ns_dset_laird.texts.columns
     expanded_df = annotate.cogat.expand_counts(counts_df, rel_df, weights)
     assert isinstance(expanded_df, pd.DataFrame)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None, but fixes a bug identified by @julio-a-yanes.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Copy `texts` DataFrame in `nimare.annotate.cogat.extract_cogat()` _before_ operating on the DataFrame. This was dropping the `id` column from the `Dataset.texts` attribute, which prevented Dataset slicing.
- Add check in cogat test for this bug.
