### PR TITLE
[REF] Operate on arrays in ALESubtraction

### DIFF
--- a/nimare/io.py
+++ b/nimare/io.py
@@ -155,12 +155,12 @@ def convert_sleuth_to_dict(text_file):
 
     # Get contiguous header lines to define contrasts
     ranges = []
-    for k, g in groupby(enumerate(header_lines), lambda x : x[0] - x[1]):
+    for k, g in groupby(enumerate(header_lines), lambda x: x[0] - x[1]):
         group = list(map(itemgetter(1), g))
         ranges.append((group[0], group[-1]))
         if "Subjects" not in data[group[-1]]:
-            raise ValueError('Sample size line missing for {}'.format(
-                data[group[0]:group[-1] + 1])
+            raise ValueError(
+                "Sample size line missing for {}".format(data[group[0] : group[-1] + 1])
             )
     start_idx = [r[0] for r in ranges]
     end_idx = start_idx[1:] + [len(data) + 1]

--- a/nimare/meta/ale.py
+++ b/nimare/meta/ale.py
@@ -454,20 +454,16 @@ class ALESubtraction(CBMAEstimator):
         self.masker = meta1.dataset.masker
 
         ma_maps1 = meta1.kernel_transformer.transform(
-            meta1.inputs_["coordinates"], masker=self.masker, return_type="image"
+            meta1.inputs_["coordinates"], masker=self.masker, return_type="array"
         )
 
         ma_maps2 = meta2.kernel_transformer.transform(
-            meta2.inputs_["coordinates"], masker=self.masker, return_type="image"
+            meta2.inputs_["coordinates"], masker=self.masker, return_type="array"
         )
 
-        n_grp1 = len(ma_maps1)
-        ma_maps = ma_maps1 + ma_maps2
-
-        id_idx = np.arange(len(ma_maps))
-
-        # Get MA values for both samples.
-        ma_arr = self.masker.transform(ma_maps)
+        n_grp1 = ma_maps1.shape[0]
+        ma_arr = np.vstack((ma_maps1, ma_maps2))
+        id_idx = np.arange(ma_arr.shape[0])
         n_voxels = ma_arr.shape[1]
 
         # Get ALE values for first group.

--- a/nimare/tests/test_annotate_cogat.py
+++ b/nimare/tests/test_annotate_cogat.py
@@ -26,7 +26,7 @@ def test_cogat():
     counts_df, rep_text_df = annotate.cogat.extract_cogat(
         ns_dset_laird.texts, id_df, text_column="abstract"
     )
-    assert 'id' in ns_dset_laird.texts.columns
+    assert "id" in ns_dset_laird.texts.columns
     expanded_df = annotate.cogat.expand_counts(counts_df, rel_df, weights)
     assert isinstance(expanded_df, pd.DataFrame)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None. On a test dataset (used as both dset 1 and dset 2) with 21 studies and with 100 iterations, it drops memory from 1039.6 MiB to 602.8 MiB. This difference probably doesn't scale well with larger numbers of iterations, since the null distribution arrays will increasingly dominate memory consumption as the number of iterations increases.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Switch from creating MA maps as images and masking them to get arrays to just creating the maps as arrays to begin with.
