### PR TITLE
[DOC] Fix Lancaster xform and Sleuth conversion docstrings

### DIFF
--- a/nimare/io.py
+++ b/nimare/io.py
@@ -193,9 +193,7 @@ def convert_sleuth_to_dict(text_file):
             xyz = [row.split() for row in xyz]
             correct_shape = np.all([len(coord) == 3 for coord in xyz])
             if not correct_shape:
-                all_shapes = np.unique([len(coord) for coord in xyz]).astype(
-                    str
-                )
+                all_shapes = np.unique([len(coord) for coord in xyz]).astype(str)
                 raise ValueError(
                     'Coordinates for study "{0}" are not all '
                     "correct length. Lengths detected: "

--- a/nimare/io.py
+++ b/nimare/io.py
@@ -122,8 +122,9 @@ def convert_sleuth_to_dict(text_file):
 
     Parameters
     ----------
-    text_file : :obj:`str`
+    text_file : :obj:`str` or :obj:`list` of :obj:`str`
         Path to Sleuth-format text file.
+        More than one text file may be provided.
 
     Returns
     -------

--- a/nimare/io.py
+++ b/nimare/io.py
@@ -190,13 +190,13 @@ def convert_sleuth_to_dict(text_file):
             contrast_name = ":".join(study_info.split(":")[1:]).strip()
             sample_size = int(exp_data[n_idx].replace(" ", "").replace("//Subjects=", ""))
             xyz = exp_data[n_idx + 1 :]  # Coords are everything after study info and n
-            xyz = [row.split("\t") for row in xyz]
+            xyz = [row.split() for row in xyz]
             correct_shape = np.all([len(coord) == 3 for coord in xyz])
             if not correct_shape:
                 all_shapes = np.unique([len(coord) for coord in xyz]).astype(
                     str
                 )  # pylint: disable=no-member
-                raise Exception(
+                raise ValueError(
                     'Coordinates for study "{0}" are not all '
                     "correct length. Lengths detected: "
                     "{1}.".format(study_info, ", ".join(all_shapes))
@@ -205,12 +205,12 @@ def convert_sleuth_to_dict(text_file):
             try:
                 xyz = np.array(xyz, dtype=float)
             except:
-                # Prettify xyz
+                # Prettify xyz before reporting error
                 strs = [[str(e) for e in row] for row in xyz]
                 lens = [max(map(len, col)) for col in zip(*strs)]
                 fmt = "\t".join("{{:{}}}".format(x) for x in lens)
                 table = "\n".join([fmt.format(*row) for row in strs])
-                raise Exception(
+                raise ValueError(
                     "Conversion to numpy array failed for study "
                     '"{0}". Coords:\n{1}'.format(study_info, table)
                 )

--- a/nimare/io.py
+++ b/nimare/io.py
@@ -155,7 +155,7 @@ def convert_sleuth_to_dict(text_file):
 
     SPACE_OPTS = ["MNI", "TAL", "Talairach"]
     if space not in SPACE_OPTS:
-        raise Exception(
+        raise ValueError(
             "Space {0} unknown. Options supported: {1}.".format(space, ", ".join(SPACE_OPTS))
         )
 
@@ -195,7 +195,7 @@ def convert_sleuth_to_dict(text_file):
             if not correct_shape:
                 all_shapes = np.unique([len(coord) for coord in xyz]).astype(
                     str
-                )  # pylint: disable=no-member
+                )
                 raise ValueError(
                     'Coordinates for study "{0}" are not all '
                     "correct length. Lengths detected: "

--- a/nimare/io.py
+++ b/nimare/io.py
@@ -274,13 +274,9 @@ def convert_sleuth_to_dataset(text_file, target="ale_2mm"):
     :obj:`nimare.dataset.Dataset`
         Dataset object containing experiment information from text_file.
     """
-    if isinstance(text_file, str):
-        text_files = [text_file]
-    elif isinstance(text_file, list):
-        text_files = text_file
-    else:
+    if not isinstance(text_file, str) and not isinstance(text_file, list):
         raise ValueError(
             'Unsupported type for parameter "text_file": ' "{0}".format(type(text_file))
         )
-    dict_ = convert_sleuth_to_dict(text_files)
+    dict_ = convert_sleuth_to_dict(text_file)
     return Dataset(dict_, target=target)

--- a/nimare/io.py
+++ b/nimare/io.py
@@ -2,7 +2,6 @@
 Input/Output operations.
 """
 import json
-import os.path as op
 import re
 from itertools import groupby
 from operator import itemgetter

--- a/nimare/tests/data/test_sleuth_file2.txt
+++ b/nimare/tests/data/test_sleuth_file2.txt
@@ -5,6 +5,6 @@
 
 // StudyName4: ExperimentName2
 // Subjects = 20
--18	-58	-24
+-18   -58     -24
 26	-64	-50
 12	-70	-42

--- a/nimare/tests/data/test_sleuth_file2.txt
+++ b/nimare/tests/data/test_sleuth_file2.txt
@@ -1,4 +1,8 @@
 // Reference = Talairach
+// StudyName: ExperimentName2
+// Subjects = 25
+-18	-58	-24
+
 // StudyName4: ExperimentName2
 // Subjects = 20
 -18	-58	-24

--- a/nimare/tests/data/test_sleuth_file2.txt
+++ b/nimare/tests/data/test_sleuth_file2.txt
@@ -1,0 +1,6 @@
+// Reference = Talairach
+// StudyName4: ExperimentName2
+// Subjects = 20
+-18	-58	-24
+26	-64	-50
+12	-70	-42

--- a/nimare/tests/data/test_sleuth_file3.txt
+++ b/nimare/tests/data/test_sleuth_file3.txt
@@ -1,0 +1,5 @@
+// Reference = Talairach
+// StudyName: ExperimentName
+// Subjects = 25
+-18	-58	-24
+10  20  dog

--- a/nimare/tests/data/test_sleuth_file4.txt
+++ b/nimare/tests/data/test_sleuth_file4.txt
@@ -1,0 +1,5 @@
+// Reference = Talairach
+// StudyName: ExperimentName
+// Subjects = 25
+-18	-58	-24
+10  20

--- a/nimare/tests/data/test_sleuth_file5.txt
+++ b/nimare/tests/data/test_sleuth_file5.txt
@@ -1,0 +1,5 @@
+// Reference = Dog
+// StudyName: ExperimentName
+// Subjects = 25
+-18	-58	-24
+10  20  10

--- a/nimare/tests/test_io.py
+++ b/nimare/tests/test_io.py
@@ -13,10 +13,15 @@ def test_convert_sleuth_to_dataset_smoke():
     Smoke test for Sleuth text file conversion.
     """
     sleuth_file = os.path.join(get_test_data_path(), "test_sleuth_file.txt")
+    sleuth_file2 = os.path.join(get_test_data_path(), "test_sleuth_file2.txt")
     dset = io.convert_sleuth_to_dataset(sleuth_file)
     assert isinstance(dset, nimare.dataset.Dataset)
     assert dset.coordinates.shape[0] == 7
     assert len(dset.ids) == 3
+    dset2 = io.convert_sleuth_to_dataset([sleuth_file, sleuth_file2])
+    assert isinstance(dset2, nimare.dataset.Dataset)
+    assert dset2.coordinates.shape[0] == 10
+    assert len(dset2.ids) == 4
 
 
 def test_convert_sleuth_to_json_smoke():

--- a/nimare/tests/test_io.py
+++ b/nimare/tests/test_io.py
@@ -16,6 +16,8 @@ def test_convert_sleuth_to_dataset_smoke():
     """
     sleuth_file = os.path.join(get_test_data_path(), "test_sleuth_file.txt")
     sleuth_file2 = os.path.join(get_test_data_path(), "test_sleuth_file2.txt")
+    sleuth_file3 = os.path.join(get_test_data_path(), "test_sleuth_file3.txt")
+    sleuth_file4 = os.path.join(get_test_data_path(), "test_sleuth_file4.txt")
     # Use one input file
     dset = io.convert_sleuth_to_dataset(sleuth_file)
     assert isinstance(dset, nimare.dataset.Dataset)
@@ -29,6 +31,12 @@ def test_convert_sleuth_to_dataset_smoke():
     # Use invalid input
     with pytest.raises(ValueError):
         io.convert_sleuth_to_dataset(5)
+    # Use invalid input (one coordinate is a str instead of a number)
+    with pytest.raises(ValueError):
+        io.convert_sleuth_to_dataset(sleuth_file3)
+    # Use invalid input (one has x & y, but not z)
+    with pytest.raises(ValueError):
+        io.convert_sleuth_to_dataset(sleuth_file4)
 
 
 def test_convert_sleuth_to_json_smoke():
@@ -38,6 +46,8 @@ def test_convert_sleuth_to_json_smoke():
     out_file = os.path.abspath("temp.json")
     sleuth_file = os.path.join(get_test_data_path(), "test_sleuth_file.txt")
     sleuth_file2 = os.path.join(get_test_data_path(), "test_sleuth_file2.txt")
+    sleuth_file3 = os.path.join(get_test_data_path(), "test_sleuth_file3.txt")
+    sleuth_file4 = os.path.join(get_test_data_path(), "test_sleuth_file4.txt")
     # Use one input file
     io.convert_sleuth_to_json(sleuth_file, out_file)
     dset = nimare.dataset.Dataset(out_file)
@@ -52,9 +62,15 @@ def test_convert_sleuth_to_json_smoke():
     assert isinstance(dset2, nimare.dataset.Dataset)
     assert dset2.coordinates.shape[0] == 11
     assert len(dset2.ids) == 5
-    # Use invalid input
+    # Use invalid input (number instead of file)
     with pytest.raises(ValueError):
         io.convert_sleuth_to_json(5, out_file)
+    # Use invalid input (one coordinate is a str instead of a number)
+    with pytest.raises(ValueError):
+        io.convert_sleuth_to_json(sleuth_file3, out_file)
+    # Use invalid input (one has x & y, but not z)
+    with pytest.raises(ValueError):
+        io.convert_sleuth_to_dataset(sleuth_file4)
 
 
 def test_convert_neurosynth_to_dataset_smoke():

--- a/nimare/tests/test_io.py
+++ b/nimare/tests/test_io.py
@@ -3,6 +3,8 @@ Test nimare.io (Dataset IO/transformations).
 """
 import os
 
+import pytest
+
 import nimare
 from nimare import io
 from nimare.tests.utils import get_test_data_path
@@ -14,14 +16,19 @@ def test_convert_sleuth_to_dataset_smoke():
     """
     sleuth_file = os.path.join(get_test_data_path(), "test_sleuth_file.txt")
     sleuth_file2 = os.path.join(get_test_data_path(), "test_sleuth_file2.txt")
+    # Use one input file
     dset = io.convert_sleuth_to_dataset(sleuth_file)
     assert isinstance(dset, nimare.dataset.Dataset)
     assert dset.coordinates.shape[0] == 7
     assert len(dset.ids) == 3
+    # Use two input files
     dset2 = io.convert_sleuth_to_dataset([sleuth_file, sleuth_file2])
     assert isinstance(dset2, nimare.dataset.Dataset)
-    assert dset2.coordinates.shape[0] == 10
-    assert len(dset2.ids) == 4
+    assert dset2.coordinates.shape[0] == 11
+    assert len(dset2.ids) == 5
+    # Use invalid input
+    with pytest.raises(ValueError):
+        io.convert_sleuth_to_dataset(5)
 
 
 def test_convert_sleuth_to_json_smoke():
@@ -30,6 +37,8 @@ def test_convert_sleuth_to_json_smoke():
     """
     out_file = os.path.abspath("temp.json")
     sleuth_file = os.path.join(get_test_data_path(), "test_sleuth_file.txt")
+    sleuth_file2 = os.path.join(get_test_data_path(), "test_sleuth_file2.txt")
+    # Use one input file
     io.convert_sleuth_to_json(sleuth_file, out_file)
     dset = nimare.dataset.Dataset(out_file)
     assert os.path.isfile(out_file)
@@ -37,6 +46,15 @@ def test_convert_sleuth_to_json_smoke():
     assert dset.coordinates.shape[0] == 7
     assert len(dset.ids) == 3
     os.remove(out_file)
+    # Use two input files
+    io.convert_sleuth_to_json([sleuth_file, sleuth_file2], out_file)
+    dset2 = nimare.dataset.Dataset(out_file)
+    assert isinstance(dset2, nimare.dataset.Dataset)
+    assert dset2.coordinates.shape[0] == 11
+    assert len(dset2.ids) == 5
+    # Use invalid input
+    with pytest.raises(ValueError):
+        io.convert_sleuth_to_json(5, out_file)
 
 
 def test_convert_neurosynth_to_dataset_smoke():

--- a/nimare/tests/test_io.py
+++ b/nimare/tests/test_io.py
@@ -18,6 +18,7 @@ def test_convert_sleuth_to_dataset_smoke():
     sleuth_file2 = os.path.join(get_test_data_path(), "test_sleuth_file2.txt")
     sleuth_file3 = os.path.join(get_test_data_path(), "test_sleuth_file3.txt")
     sleuth_file4 = os.path.join(get_test_data_path(), "test_sleuth_file4.txt")
+    sleuth_file5 = os.path.join(get_test_data_path(), "test_sleuth_file5.txt")
     # Use one input file
     dset = io.convert_sleuth_to_dataset(sleuth_file)
     assert isinstance(dset, nimare.dataset.Dataset)
@@ -37,6 +38,9 @@ def test_convert_sleuth_to_dataset_smoke():
     # Use invalid input (one has x & y, but not z)
     with pytest.raises(ValueError):
         io.convert_sleuth_to_dataset(sleuth_file4)
+    # Use invalid input (bad space)
+    with pytest.raises(ValueError):
+        io.convert_sleuth_to_dataset(sleuth_file5)
 
 
 def test_convert_sleuth_to_json_smoke():
@@ -48,6 +52,7 @@ def test_convert_sleuth_to_json_smoke():
     sleuth_file2 = os.path.join(get_test_data_path(), "test_sleuth_file2.txt")
     sleuth_file3 = os.path.join(get_test_data_path(), "test_sleuth_file3.txt")
     sleuth_file4 = os.path.join(get_test_data_path(), "test_sleuth_file4.txt")
+    sleuth_file5 = os.path.join(get_test_data_path(), "test_sleuth_file5.txt")
     # Use one input file
     io.convert_sleuth_to_json(sleuth_file, out_file)
     dset = nimare.dataset.Dataset(out_file)
@@ -70,7 +75,10 @@ def test_convert_sleuth_to_json_smoke():
         io.convert_sleuth_to_json(sleuth_file3, out_file)
     # Use invalid input (one has x & y, but not z)
     with pytest.raises(ValueError):
-        io.convert_sleuth_to_dataset(sleuth_file4)
+        io.convert_sleuth_to_json(sleuth_file4, out_file)
+    # Use invalid input (bad space)
+    with pytest.raises(ValueError):
+        io.convert_sleuth_to_json(sleuth_file5, out_file)
 
 
 def test_convert_neurosynth_to_dataset_smoke():

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -424,6 +424,32 @@ def t_to_z(t_values, dof):
 
 
 def z_to_t(z_values, dof):
+    """
+    Convert z-statistics to t-statistics.
+
+    An inversion of the t_to_z implementation of [1]_ from Vanessa Sochat's
+    TtoZ package [2]_.
+
+    Parameters
+    ----------
+    z_values : array_like
+        Z-statistics
+    dof : int
+        Degrees of freedom
+
+    Returns
+    -------
+    t_values : array_like
+        T-statistics
+
+    References
+    ----------
+    .. [1] Hughett, P. (2007). Accurate Computation of the F-to-z and t-to-z
+           Transforms for Large Arguments. Journal of Statistical Software,
+           23(1), 1-5.
+    .. [2] Sochat, V. (2015, October 21). TtoZ Original Release. Zenodo.
+           http://doi.org/10.5281/zenodo.32508
+    """
     # Select just the nonzero voxels
     nonzero = z_values[z_values != 0]
 
@@ -457,6 +483,22 @@ def z_to_t(z_values, dof):
 def vox2mm(ijk, affine):
     """
     Convert matrix subscripts to coordinates.
+
+    Parameters
+    ----------
+    ijk : (X, 3) :obj:`numpy.ndarray`
+        Matrix subscripts for coordinates being transformed.
+        One row for each coordinate, with three columns: i, j, and k.
+    affine : (4, 4) :obj:`numpy.ndarray`
+        Affine matrix from image.
+
+    Returns
+    -------
+    xyz : (X, 3) :obj:`numpy.ndarray`
+        Coordinates in image-space.
+
+    Notes
+    -----
     From here:
     http://blog.chrisgorgolewski.org/2014/12/how-to-convert-between-voxel-and-mm.html
     """
@@ -467,6 +509,22 @@ def vox2mm(ijk, affine):
 def mm2vox(xyz, affine):
     """
     Convert coordinates to matrix subscripts.
+
+    Parameters
+    ----------
+    xyz : (X, 3) :obj:`numpy.ndarray`
+        Coordinates in image-space.
+        One row for each coordinate, with three columns: x, y, and z.
+    affine : (4, 4) :obj:`numpy.ndarray`
+        Affine matrix from image.
+
+    Returns
+    -------
+    ijk : (X, 3) :obj:`numpy.ndarray`
+        Matrix subscripts for coordinates being transformed.
+
+    Notes
+    -----
     From here:
     http://blog.chrisgorgolewski.org/2014/12/how-to-convert-between-voxel-and-mm.html
     """
@@ -486,17 +544,30 @@ def mm2vox(xyz, affine):
 )
 def tal2mni(coords):
     """
+    Convert coordinates from Talairach space to MNI space.
+
+    Parameters
+    ----------
+    coords : (X, 3) :obj:`numpy.ndarray`
+        Coordinates in Talairach space to convert.
+        Each row is a coordinate, with three columns.
+
+    Returns
+    -------
+    coords : (X, 3) :obj:`numpy.ndarray`
+        Coordinates in MNI space.
+        Each row is a coordinate, with three columns.
+
+    Notes
+    -----
     Python version of BrainMap's tal2icbm_other.m.
+
     This function converts coordinates from Talairach space to MNI
     space (normalized using templates other than those contained
     in SPM and FSL) using the tal2icbm transform developed and
     validated by Jack Lancaster at the Research Imaging Center in
     San Antonio, Texas.
     http://www3.interscience.wiley.com/cgi-bin/abstract/114104479/ABSTRACT
-    FORMAT outpoints = tal2icbm_other(inpoints)
-    Where inpoints is N by 3 or 3 by N matrix of coordinates
-    (N being the number of points)
-    ric.uthscsa.edu 3/14/07
     """
     # Find which dimensions are of size 3
     shape = np.array(coords.shape)
@@ -548,16 +619,28 @@ def tal2mni(coords):
 )
 def mni2tal(coords):
     """
+    Convert coordinates from MNI space Talairach space.
+
+    Parameters
+    ----------
+    coords : (X, 3) :obj:`numpy.ndarray`
+        Coordinates in MNI space to convert.
+        Each row is a coordinate, with three columns.
+
+    Returns
+    -------
+    coords : (X, 3) :obj:`numpy.ndarray`
+        Coordinates in Talairach space.
+        Each row is a coordinate, with three columns.
+
+    Notes
+    -----
     Python version of BrainMap's icbm_other2tal.m.
     This function converts coordinates from MNI space (normalized using
     templates other than those contained in SPM and FSL) to Talairach space
     using the icbm2tal transform developed and validated by Jack Lancaster at
     the Research Imaging Center in San Antonio, Texas.
     http://www3.interscience.wiley.com/cgi-bin/abstract/114104479/ABSTRACT
-    FORMAT outpoints = icbm_other2tal(inpoints)
-    Where inpoints is N by 3 or 3 by N matrix of coordinates
-    (N being the number of points)
-    ric.uthscsa.edu 3/14/07
     """
     # Find which dimensions are of size 3
     shape = np.array(coords.shape)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None. Fixes gaps in the docstrings for functions identified by @mriedel56.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Test `convert_sleuth_to_dataset` with multiple Sleuth files.
- Explicitly support multiple input files in docstrings for `convert_sleuth_to_dataset`, `convert_sleuth_to_json`, and `convert_sleuth_to_dict`.
- Clean up how those multiple input files are handled.
-  Improve documentation of `mni2tal` and `tal2mni` functions.
