### PR TITLE
[ENH] Add PairwiseCBMAEstimator class and add low_memory option to ALESubtraction

### DIFF
--- a/nimare/base.py
+++ b/nimare/base.py
@@ -389,6 +389,62 @@ class CBMAEstimator(MetaEstimator):
                 )
 
 
+class PairwiseCBMAEstimator(CBMAEstimator):
+    """Base class for pairwise coordinate-based meta-analysis methods.
+
+    Parameters
+    ----------
+    kernel_transformer : :obj:`nimare.base.KernelTransformer`, optional
+        Kernel with which to convolve coordinates from dataset. Default is
+        ALEKernel.
+    *args
+        Optional arguments to the :obj:`nimare.base.MetaEstimator` __init__
+        (called automatically).
+    **kwargs
+        Optional keyword arguments to the :obj:`nimare.base.MetaEstimator`
+        __init__ (called automatically).
+    """
+
+    def fit(self, dataset1, dataset2):
+        """
+        Fit Estimator to two Datasets.
+
+        Parameters
+        ----------
+        dataset1/dataset2 : :obj:`nimare.dataset.Dataset`
+            Dataset objects to analyze.
+
+        Returns
+        -------
+        :obj:`nimare.results.MetaResult`
+            Results of Estimator fitting.
+
+        Notes
+        -----
+        The `fit` method is a light wrapper that runs input validation and
+        preprocessing before fitting the actual model. Estimators' individual
+        "fitting" methods are implemented as `_fit`, although users should
+        call `fit`.
+        """
+        self._validate_input(dataset1)
+        self._validate_input(dataset2)
+        # grab and override
+        self._preprocess_input(dataset1)
+        self.inputs_["coordinates1"] = self.inputs_.pop("coordinates")
+        # grab and override
+        self._preprocess_input(dataset2)
+        self.inputs_["coordinates2"] = self.inputs_.pop("coordinates")
+
+        maps = self._fit(dataset1, dataset2)
+
+        if hasattr(self, "masker") and self.masker is not None:
+            masker = self.masker
+        else:
+            masker = dataset1.masker
+        self.results = MetaResult(self, masker, maps)
+        return self.results
+
+
 class Transformer(NiMAREBase):
     """Transformers take in Datasets and return Datasets
 

--- a/nimare/meta/ale.py
+++ b/nimare/meta/ale.py
@@ -481,9 +481,11 @@ class ALESubtraction(CBMAEstimator):
 
         if self.low_memory:
             from tempfile import mkdtemp
+
             filename = os.path.join(mkdtemp(), "iter_diff_values.dat")
-            iter_diff_values = np.memmap(filename, dtype=ma_arr.dtype, mode="w+",
-                                         shape=(self.n_iters, n_voxels))
+            iter_diff_values = np.memmap(
+                filename, dtype=ma_arr.dtype, mode="w+", shape=(self.n_iters, n_voxels)
+            )
         else:
             iter_diff_values = np.zeros((self.n_iters, n_voxels), dtype=ma_arr.dtype)
 
@@ -505,8 +507,9 @@ class ALESubtraction(CBMAEstimator):
         if self.low_memory:
             iter_diff_values.flush()
             del iter_diff_values
-            iter_diff_values = np.memmap(filename, dtype=ma_arr.dtype, mode="r",
-                                         shape=(self.n_iters, n_voxels))
+            iter_diff_values = np.memmap(
+                filename, dtype=ma_arr.dtype, mode="r", shape=(self.n_iters, n_voxels)
+            )
 
         for voxel in range(n_voxels):
             p_arr[voxel] = null_to_p(

--- a/nimare/meta/ale.py
+++ b/nimare/meta/ale.py
@@ -481,8 +481,8 @@ class ALESubtraction(CBMAEstimator):
 
         if self.low_memory:
             from tempfile import mkdtemp
-            filename = os.path.join(mkdtemp(), 'iter_diff_values.dat')
-            iter_diff_values = np.memmap(filename, dtype=ma_arr.dtype, mode='w+',
+            filename = os.path.join(mkdtemp(), "iter_diff_values.dat")
+            iter_diff_values = np.memmap(filename, dtype=ma_arr.dtype, mode="w+",
                                          shape=(self.n_iters, n_voxels))
         else:
             iter_diff_values = np.zeros((self.n_iters, n_voxels), dtype=ma_arr.dtype)
@@ -505,7 +505,7 @@ class ALESubtraction(CBMAEstimator):
         if self.low_memory:
             iter_diff_values.flush()
             del iter_diff_values
-            iter_diff_values = np.memmap(filename, dtype=ma_arr.dtype, mode='r',
+            iter_diff_values = np.memmap(filename, dtype=ma_arr.dtype, mode="r",
                                          shape=(self.n_iters, n_voxels))
 
         for voxel in range(n_voxels):

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -80,14 +80,25 @@ def test_ale_subtraction(testdata_cbma):
     Smoke test for ALESubtraction
     """
     out_file = os.path.abspath("file.pkl.gz")
-    meta1 = ale.ALE()
-    meta1.fit(testdata_cbma)
 
-    meta2 = ale.ALE()
-    meta2.fit(testdata_cbma)
+    sub_meta = ale.ALESubtraction(n_iters=10, low_memory=False)
+    sub_meta.fit(testdata_cbma, testdata_cbma)
+    assert isinstance(sub_meta.results, nimare.results.MetaResult)
+    assert "z_desc-group1MinusGroup2" in sub_meta.results.maps.keys()
 
-    sub_meta = ale.ALESubtraction(n_iters=10)
-    sub_meta.fit(meta1, meta2)
+    sub_meta.save(out_file)
+    assert os.path.isfile(out_file)
+    os.remove(out_file)
+
+
+def test_ale_subtraction_lowmem(testdata_cbma):
+    """
+    Smoke test for ALESubtraction with low memory settings.
+    """
+    out_file = os.path.abspath("file.pkl.gz")
+
+    sub_meta = ale.ALESubtraction(n_iters=10, low_memory=True)
+    sub_meta.fit(testdata_cbma, testdata_cbma)
     assert isinstance(sub_meta.results, nimare.results.MetaResult)
     assert "z_desc-group1MinusGroup2" in sub_meta.results.maps.keys()
 

--- a/nimare/workflows/ale.py
+++ b/nimare/workflows/ale.py
@@ -185,8 +185,8 @@ false discovery rate and performing statistical contrasts. Human brain mapping,
         )
         cres1 = corr.transform(res1)
         cres2 = corr.transform(res2)
-        sub = ALESubtraction(n_iters=n_iters)
-        sres = sub.fit(ale1, ale2)
+        sub = ALESubtraction(n_iters=n_iters, kernel__fwhm=fwhm)
+        sres = sub.fit(dset1, dset2)
 
         boilerplate = boilerplate.format(
             n_exps1=len(dset1.ids),


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #246. References #189.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add a `PairwiseCBMAEstimator` base class.
- Add a low_memory option to ALESubtraction.
- Use `numpy.memmap` for the largest array in the method (the voxel-wise null distributions of difference scores).
