### PR TITLE
[ENH] Support Dataset transformations in kernel transformers

### DIFF
--- a/examples/02_meta-analyses/plot_generate_ma_maps.py
+++ b/examples/02_meta-analyses/plot_generate_ma_maps.py
@@ -39,13 +39,13 @@ dset = nimare.dataset.Dataset(dset_file)
 # argument to control the radius of the kernel.
 
 kernel = nimare.meta.kernel.MKDAKernel(r=2)
-mkda_r02 = kernel.transform(dset)
+mkda_r02 = kernel.transform(dset, return_type="image")
 kernel = nimare.meta.kernel.MKDAKernel(r=6)
-mkda_r06 = kernel.transform(dset)
+mkda_r06 = kernel.transform(dset, return_type="image")
 kernel = nimare.meta.kernel.MKDAKernel(r=10)
-mkda_r10 = kernel.transform(dset)
+mkda_r10 = kernel.transform(dset, return_type="image")
 kernel = nimare.meta.kernel.MKDAKernel(r=14)
-mkda_r14 = kernel.transform(dset)
+mkda_r14 = kernel.transform(dset, return_type="image")
 
 fig, axes = plt.subplots(nrows=2, ncols=2, figsize=(20, 10))
 plot_stat_map(mkda_r02[2], cut_coords=[-2, -10, -4],
@@ -74,11 +74,11 @@ fig.show()
 # :class:`nimare.meta.kernel.ALEKernel` convolves coordinates with a 3D
 # Gaussian, for which the FWHM is determined by the sample size of each study.
 kernel = nimare.meta.kernel.MKDAKernel(r=10)
-mkda_res = kernel.transform(dset)
+mkda_res = kernel.transform(dset, return_type="image")
 kernel = nimare.meta.kernel.KDAKernel(r=10)
-kda_res = kernel.transform(dset)
+kda_res = kernel.transform(dset, return_type="image")
 kernel = nimare.meta.kernel.ALEKernel(sample_size=20)
-ale_res = kernel.transform(dset)
+ale_res = kernel.transform(dset, return_type="image")
 max_conv = np.max(kda_res[2].get_fdata())
 plot_stat_map(mkda_res[2], cut_coords=[-2, -10, -4], title='MKDA', vmax=max_conv)
 plot_stat_map(kda_res[2], cut_coords=[-2, -10, -4], title='KDA', vmax=max_conv)

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -477,9 +477,6 @@ class KernelTransformer(Transformer):
 
     Notes
     -----
-    This base class exists solely to allow CBMA algorithms to check the class
-    of their kernel_transformer parameters.
-
     All extra (non-ijk) parameters for a given kernel should be overrideable as
     parameters to __init__, so we can access them with get_params() and also
     apply them to datasets with missing data.
@@ -489,6 +486,25 @@ class KernelTransformer(Transformer):
         pass
 
     def _infer_names(self, **kwargs):
+        """
+        Determine the filename pattern for image files created with this transformer,
+        as well as the image type (i.e., the column for the Dataset.images DataFrame).
+        The parameters used to construct the filenames come from the transformer's
+        parameters (attributes saved in `__init__()`).
+
+        Parameters
+        ----------
+        **kwargs
+            Additional key/value pairs to incorporate into the image name.
+            A common example is the hash for the target template's affine.
+
+        Attributes
+        ----------
+        filename_pattern : str
+            Filename pattern for images that will be saved by the transformer.
+        image_type : str
+            Name of the corresponding column in the Dataset.images DataFrame.
+        """
         params = self.get_params()
         params = dict(**params, **kwargs)
 

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -488,6 +488,20 @@ class KernelTransformer(Transformer):
     def __init__(self):
         pass
 
+    def _infer_names(self, **kwargs):
+        params = self.get_params()
+        params = dict(**params, **kwargs)
+
+        # Determine names for kernel-specific files
+        keys = sorted(params.keys())
+        param_str = "_".join("{k}-{v}".format(k=k, v=str(params[k])) for k in keys)
+        self.filename_pattern = (
+            "study-[[id]]_{ps}_{n}.nii.gz".format(n=self.__class__.__name__, ps=param_str)
+            .replace("[[", "{")
+            .replace("]]", "}")
+        )
+        self.image_type = "{ps}_{n}".format(n=self.__class__.__name__, ps=param_str)
+
 
 class Decoder(NiMAREBase):
     """Base class for decoders in :mod:`nimare.decode`.

--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -106,6 +106,7 @@ class Dataset(NiMAREBase):
         self.images = dict_to_df(id_df, data, key="images")
         self.metadata = dict_to_df(id_df, data, key="metadata")
         self.texts = dict_to_df(id_df, data, key="text")
+        self.basepath = None
 
     @property
     def ids(self):
@@ -253,6 +254,7 @@ class Dataset(NiMAREBase):
         new_path : :obj:`str`
             Path to prepend to relative paths of files in Dataset.images.
         """
+        self.basepath = new_path
         df = self.images
         relative_path_cols = [c for c in df if c.endswith("__relative")]
         for col in relative_path_cols:

--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -262,6 +262,11 @@ class Dataset(NiMAREBase):
             df[abs_col] = df[col].apply(try_prepend, prefix=new_path)
         self.images = df
 
+    def copy(self):
+        """Create a copy of the Dataset.
+        """
+        return copy.deepcopy(self)
+
     def get(self, dict_):
         """
         Retrieve files and/or metadata from the current Dataset.

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -55,17 +55,28 @@ class ALEKernel(KernelTransformer):
             Dataset for which to make images. Can be a DataFrame if necessary.
         masker : img_like, optional
             Only used if dataset is a DataFrame.
-        return_type : {'image', 'array'}, optional
-            Whether to return a niimg ('image') or a numpy array.
-            Default is 'image'.
+        return_type : {'array', 'image', 'dataset'}, optional
+            Whether to return a numpy array ('array'), a list of niimgs ('image'), or
+            a Dataset with MA images saved as files ('dataset').
+            Default is 'dataset'.
 
         Returns
         -------
-        imgs : :obj:`list` of :class:`nibabel.nifti1.Nifti1Image` or :class:`numpy.ndarray`
-            If return_type is 'image', a list of modeled activation images
-            (one for each of the Contrasts in the input dataset).
+        imgs : (C x V) :class:`numpy.ndarray` or :obj:`list` of :class:`nibabel.Nifti1Image` or\
+               :class:`nimare.dataset.Dataset`
             If return_type is 'array', a 2D numpy array (C x V), where C is
             contrast and V is voxel.
+            If return_type is 'image', a list of modeled activation images
+            (one for each of the Contrasts in the input dataset).
+            If return_type is 'dataset', a new Dataset object with modeled activation
+            images saved to files and referenced in the Dataset.images attribute.
+
+        Attributes
+        ----------
+        filename_pattern : str
+            Filename pattern for MA maps that will be saved by the transformer.
+        image_type : str
+            Name of the corresponding column in the Dataset.images DataFrame.
         """
         if return_type not in ("array", "image", "dataset"):
             raise ValueError('Argument "return_type" must be "image", "array", or "dataset".')
@@ -197,17 +208,28 @@ class MKDAKernel(KernelTransformer):
             Dataset for which to make images. Can be a DataFrame if necessary.
         masker : img_like, optional
             Only used if dataset is a DataFrame.
-        return_type : {'image', 'array'}, optional
-            Whether to return a niimg ('image') or a numpy array.
-            Default is 'image'.
+        return_type : {'array', 'image', 'dataset'}, optional
+            Whether to return a numpy array ('array'), a list of niimgs ('image'), or
+            a Dataset with MA images saved as files ('dataset').
+            Default is 'dataset'.
 
         Returns
         -------
-        imgs : :obj:`list` of :class:`nibabel.Nifti1Image` or :class:`numpy.ndarray`
-            If return_type is 'image', a list of modeled activation images
-            (one for each of the Contrasts in the input dataset).
+        imgs : (C x V) :class:`numpy.ndarray` or :obj:`list` of :class:`nibabel.Nifti1Image` or\
+               :class:`nimare.dataset.Dataset`
             If return_type is 'array', a 2D numpy array (C x V), where C is
             contrast and V is voxel.
+            If return_type is 'image', a list of modeled activation images
+            (one for each of the Contrasts in the input dataset).
+            If return_type is 'dataset', a new Dataset object with modeled activation
+            images saved to files and referenced in the Dataset.images attribute.
+
+        Attributes
+        ----------
+        filename_pattern : str
+            Filename pattern for MA maps that will be saved by the transformer.
+        image_type : str
+            Name of the corresponding column in the Dataset.images DataFrame.
         """
         if return_type not in ("array", "image", "dataset"):
             raise ValueError('Argument "return_type" must be "image", "array", or "dataset".')
@@ -475,17 +497,28 @@ class Peaks2MapsKernel(KernelTransformer):
             Dataset for which to make images.
         masker : img_like, optional
             Only used if dataset is a DataFrame.
-        return_type : {'image', 'array'}, optional
-            Whether to return a niimg ('image') or a numpy array.
-            Default is 'image'.
+        return_type : {'array', 'image', 'dataset'}, optional
+            Whether to return a numpy array ('array'), a list of niimgs ('image'), or
+            a Dataset with MA images saved as files ('dataset').
+            Default is 'dataset'.
 
         Returns
         -------
-        imgs : :obj:`list` of :class:`nibabel.Nifti1Image` or :class:`numpy.ndarray`
-            If return_type is 'image', a list of modeled activation images
-            (one for each of the Contrasts in the input dataset).
+        imgs : (C x V) :class:`numpy.ndarray` or :obj:`list` of :class:`nibabel.Nifti1Image` or\
+               :class:`nimare.dataset.Dataset`
             If return_type is 'array', a 2D numpy array (C x V), where C is
             contrast and V is voxel.
+            If return_type is 'image', a list of modeled activation images
+            (one for each of the Contrasts in the input dataset).
+            If return_type is 'dataset', a new Dataset object with modeled activation
+            images saved to files and referenced in the Dataset.images attribute.
+
+        Attributes
+        ----------
+        filename_pattern : str
+            Filename pattern for MA maps that will be saved by the transformer.
+        image_type : str
+            Name of the corresponding column in the Dataset.images DataFrame.
         """
         if return_type not in ("array", "image", "dataset"):
             raise ValueError('Argument "return_type" must be "image", "array", or "dataset".')

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -89,15 +89,17 @@ class ALEKernel(KernelTransformer):
             # Check for existing MA maps
             # Use coordinates to get IDs instead of Dataset.ids bc of possible mismatch
             # between full Dataset and contrasts with coordinates.
-            files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
-            if all(f is not None for f in files):
-                LGR.debug("Files already exist. Using them.")
-                if return_type == "array":
-                    return masker.transform(files).T
-                elif return_type == "image":
-                    return [nib.load(f) for f in files]
-                elif return_type == "dataset":
-                    return dataset.copy()
+            if self.image_type in dataset.images.columns:
+                files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
+                if all(f is not None for f in files):
+                    LGR.debug("Files already exist. Using them.")
+                    if return_type == "array":
+                        return masker.transform(files).T
+                    elif return_type == "image":
+                        return [nib.load(f) for f in files]
+                    elif return_type == "dataset":
+                        return dataset.copy()
+
 
         # Otherwise, generate the MA maps
         if return_type == "array":
@@ -229,15 +231,17 @@ class MKDAKernel(KernelTransformer):
             # Check for existing MA maps
             # Use coordinates to get IDs instead of Dataset.ids bc of possible mismatch
             # between full Dataset and contrasts with coordinates.
-            files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
-            if all(f is not None for f in files):
-                LGR.debug("Files already exist. Using them.")
-                if return_type == "array":
-                    return masker.transform(files).T
-                elif return_type == "image":
-                    return [nib.load(f) for f in files]
-                elif return_type == "dataset":
-                    return dataset.copy()
+            if self.image_type in dataset.images.columns:
+                files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
+                if all(f is not None for f in files):
+                    LGR.debug("Files already exist. Using them.")
+                    if return_type == "array":
+                        return masker.transform(files).T
+                    elif return_type == "image":
+                        return [nib.load(f) for f in files]
+                    elif return_type == "dataset":
+                        return dataset.copy()
+
 
         # Otherwise, generate the MA maps
         if return_type == "array":
@@ -374,15 +378,17 @@ class KDAKernel(KernelTransformer):
             # Check for existing MA maps
             # Use coordinates to get IDs instead of Dataset.ids bc of possible mismatch
             # between full Dataset and contrasts with coordinates.
-            files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
-            if all(f is not None for f in files):
-                LGR.debug("Files already exist. Using them.")
-                if return_type == "array":
-                    return masker.transform(files).T
-                elif return_type == "image":
-                    return [nib.load(f) for f in files]
-                elif return_type == "dataset":
-                    return dataset.copy()
+            if self.image_type in dataset.images.columns:
+                files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
+                if all(f is not None for f in files):
+                    LGR.debug("Files already exist. Using them.")
+                    if return_type == "array":
+                        return masker.transform(files).T
+                    elif return_type == "image":
+                        return [nib.load(f) for f in files]
+                    elif return_type == "dataset":
+                        return dataset.copy()
+
 
         # Otherwise, generate the MA maps
         if return_type == "array":
@@ -508,15 +514,16 @@ class Peaks2MapsKernel(KernelTransformer):
             # Check for existing MA maps
             # Use coordinates to get IDs instead of Dataset.ids bc of possible mismatch
             # between full Dataset and contrasts with coordinates.
-            files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
-            if all(f is not None for f in files):
-                LGR.debug("Files already exist. Using them.")
-                if return_type == "array":
-                    return masker.transform(files).T
-                elif return_type == "image":
-                    return [nib.load(f) for f in files]
-                elif return_type == "dataset":
-                    return dataset.copy()
+            if self.image_type in dataset.images.columns:
+                files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
+                if all(f is not None for f in files):
+                    LGR.debug("Files already exist. Using them.")
+                    if return_type == "array":
+                        return masker.transform(files).T
+                    elif return_type == "image":
+                        return [nib.load(f) for f in files]
+                    elif return_type == "dataset":
+                        return dataset.copy()
 
         # Otherwise, generate the MA maps
         if return_type == "dataset":

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -80,24 +80,25 @@ class ALEKernel(KernelTransformer):
                 return_type != "dataset"
             ), "Input dataset must be a Dataset if return_type='dataset'."
         else:
-            mask = dataset.masker.mask_img
+            mask = dataset.masker.mask_img if not masker else masker.mask_img
+
+            # Determine MA map filenames. Must happen after parameters are set.
+            self._infer_names(affine=md5(mask.affine).hexdigest())
+
+            # Check for existing MA maps
+            # Use coordinates to get IDs instead of Dataset.ids bc of possible mismatch
+            # between full Dataset and contrasts with coordinates.
+            files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
+            if all(f is not None for f in files):
+                LGR.debug("Files already exist. Using them.")
+                if return_type == "array":
+                    return masker.transform(files).T
+                elif return_type == "image":
+                    return [nib.load(f) for f in files]
+                elif return_type == "dataset":
+                    return dataset.copy()
+
             coordinates = dataset.coordinates
-
-        # Determine MA map filenames. Must happen after parameters are set.
-        self._infer_names(affine=md5(mask.affine).hexdigest())
-
-        # Check for existing MA maps
-        # Use coordinates to get IDs instead of Dataset.ids bc of possible mismatch
-        # between full Dataset and contrasts with coordinates.
-        files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
-        if all(f is not None for f in files):
-            LGR.debug("Files already exist. Using them.")
-            if return_type == "array":
-                return masker.transform(files).T
-            elif return_type == "image":
-                return [nib.load(f) for f in files]
-            elif return_type == "dataset":
-                return dataset.copy()
 
         # Otherwise, generate the MA maps
         if return_type == "array":
@@ -220,24 +221,25 @@ class MKDAKernel(KernelTransformer):
                 return_type != "dataset"
             ), "Input dataset must be a Dataset if return_type='dataset'."
         else:
-            mask = dataset.masker.mask_img
+            mask = dataset.masker.mask_img if not masker else masker.mask_img
+
+            # Determine MA map filenames. Must happen after parameters are set.
+            self._infer_names(affine=md5(mask.affine).hexdigest())
+
+            # Check for existing MA maps
+            # Use coordinates to get IDs instead of Dataset.ids bc of possible mismatch
+            # between full Dataset and contrasts with coordinates.
+            files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
+            if all(f is not None for f in files):
+                LGR.debug("Files already exist. Using them.")
+                if return_type == "array":
+                    return masker.transform(files).T
+                elif return_type == "image":
+                    return [nib.load(f) for f in files]
+                elif return_type == "dataset":
+                    return dataset.copy()
+
             coordinates = dataset.coordinates
-
-        # Determine MA map filenames. Must happen after parameters are set.
-        self._infer_names(affine=md5(mask.affine).hexdigest())
-
-        # Check for existing MA maps
-        # Use coordinates to get IDs instead of Dataset.ids bc of possible mismatch
-        # between full Dataset and contrasts with coordinates.
-        files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
-        if all(f is not None for f in files):
-            LGR.debug("Files already exist. Using them.")
-            if return_type == "array":
-                return masker.transform(files).T
-            elif return_type == "image":
-                return [nib.load(f) for f in files]
-            elif return_type == "dataset":
-                return dataset.copy()
 
         # Otherwise, generate the MA maps
         if return_type == "array":
@@ -365,24 +367,24 @@ class KDAKernel(KernelTransformer):
                 return_type != "dataset"
             ), "Input dataset must be a Dataset if return_type='dataset'."
         else:
-            mask = dataset.masker.mask_img
+            mask = dataset.masker.mask_img if not masker else masker.mask_img
+
+            # Determine MA map filenames. Must happen after parameters are set.
+            self._infer_names(affine=md5(mask.affine).hexdigest())
+
+            # Check for existing MA maps
+            # Use coordinates to get IDs instead of Dataset.ids bc of possible mismatch
+            # between full Dataset and contrasts with coordinates.
+            files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
+            if all(f is not None for f in files):
+                LGR.debug("Files already exist. Using them.")
+                if return_type == "array":
+                    return masker.transform(files).T
+                elif return_type == "image":
+                    return [nib.load(f) for f in files]
+                elif return_type == "dataset":
+                    return dataset.copy()
             coordinates = dataset.coordinates
-
-        # Determine MA map filenames. Must happen after parameters are set.
-        self._infer_names(affine=md5(mask.affine).hexdigest())
-
-        # Check for existing MA maps
-        # Use coordinates to get IDs instead of Dataset.ids bc of possible mismatch
-        # between full Dataset and contrasts with coordinates.
-        files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
-        if all(f is not None for f in files):
-            LGR.debug("Files already exist. Using them.")
-            if return_type == "array":
-                return masker.transform(files).T
-            elif return_type == "image":
-                return [nib.load(f) for f in files]
-            elif return_type == "dataset":
-                return dataset.copy()
 
         # Otherwise, generate the MA maps
         if return_type == "array":
@@ -499,24 +501,24 @@ class Peaks2MapsKernel(KernelTransformer):
                 return_type != "dataset"
             ), "Input dataset must be a Dataset if return_type='dataset'."
         else:
-            mask = dataset.masker.mask_img
+            mask = dataset.masker.mask_img if not masker else masker.mask_img
+
+            # Determine MA map filenames. Must happen after parameters are set.
+            self._infer_names(affine=md5(mask.affine).hexdigest())
+
+            # Check for existing MA maps
+            # Use coordinates to get IDs instead of Dataset.ids bc of possible mismatch
+            # between full Dataset and contrasts with coordinates.
+            files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
+            if all(f is not None for f in files):
+                LGR.debug("Files already exist. Using them.")
+                if return_type == "array":
+                    return masker.transform(files).T
+                elif return_type == "image":
+                    return [nib.load(f) for f in files]
+                elif return_type == "dataset":
+                    return dataset.copy()
             coordinates = dataset.coordinates
-
-        # Determine MA map filenames. Must happen after parameters are set.
-        self._infer_names(affine=md5(mask.affine).hexdigest())
-
-        # Check for existing MA maps
-        # Use coordinates to get IDs instead of Dataset.ids bc of possible mismatch
-        # between full Dataset and contrasts with coordinates.
-        files = dataset.get_images(ids=coordinates["id"].unique(), imtype=self.image_type)
-        if all(f is not None for f in files):
-            LGR.debug("Files already exist. Using them.")
-            if return_type == "array":
-                return masker.transform(files).T
-            elif return_type == "image":
-                return [nib.load(f) for f in files]
-            elif return_type == "dataset":
-                return dataset.copy()
 
         # Otherwise, generate the MA maps
         if return_type == "dataset":

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -81,6 +81,7 @@ class ALEKernel(KernelTransformer):
             ), "Input dataset must be a Dataset if return_type='dataset'."
         else:
             mask = dataset.masker.mask_img if not masker else masker.mask_img
+            coordinates = dataset.coordinates
 
             # Determine MA map filenames. Must happen after parameters are set.
             self._infer_names(affine=md5(mask.affine).hexdigest())
@@ -97,8 +98,6 @@ class ALEKernel(KernelTransformer):
                     return [nib.load(f) for f in files]
                 elif return_type == "dataset":
                     return dataset.copy()
-
-            coordinates = dataset.coordinates
 
         # Otherwise, generate the MA maps
         if return_type == "array":
@@ -222,6 +221,7 @@ class MKDAKernel(KernelTransformer):
             ), "Input dataset must be a Dataset if return_type='dataset'."
         else:
             mask = dataset.masker.mask_img if not masker else masker.mask_img
+            coordinates = dataset.coordinates
 
             # Determine MA map filenames. Must happen after parameters are set.
             self._infer_names(affine=md5(mask.affine).hexdigest())
@@ -238,8 +238,6 @@ class MKDAKernel(KernelTransformer):
                     return [nib.load(f) for f in files]
                 elif return_type == "dataset":
                     return dataset.copy()
-
-            coordinates = dataset.coordinates
 
         # Otherwise, generate the MA maps
         if return_type == "array":
@@ -368,6 +366,7 @@ class KDAKernel(KernelTransformer):
             ), "Input dataset must be a Dataset if return_type='dataset'."
         else:
             mask = dataset.masker.mask_img if not masker else masker.mask_img
+            coordinates = dataset.coordinates
 
             # Determine MA map filenames. Must happen after parameters are set.
             self._infer_names(affine=md5(mask.affine).hexdigest())
@@ -384,7 +383,6 @@ class KDAKernel(KernelTransformer):
                     return [nib.load(f) for f in files]
                 elif return_type == "dataset":
                     return dataset.copy()
-            coordinates = dataset.coordinates
 
         # Otherwise, generate the MA maps
         if return_type == "array":
@@ -502,6 +500,7 @@ class Peaks2MapsKernel(KernelTransformer):
             ), "Input dataset must be a Dataset if return_type='dataset'."
         else:
             mask = dataset.masker.mask_img if not masker else masker.mask_img
+            coordinates = dataset.coordinates
 
             # Determine MA map filenames. Must happen after parameters are set.
             self._infer_names(affine=md5(mask.affine).hexdigest())
@@ -518,7 +517,6 @@ class Peaks2MapsKernel(KernelTransformer):
                     return [nib.load(f) for f in files]
                 elif return_type == "dataset":
                     return dataset.copy()
-            coordinates = dataset.coordinates
 
         # Otherwise, generate the MA maps
         if return_type == "dataset":

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -80,7 +80,8 @@ class ALEKernel(KernelTransformer):
                 return_type != "dataset"
             ), "Input dataset must be a Dataset if return_type='dataset'."
         else:
-            mask = dataset.masker.mask_img if not masker else masker.mask_img
+            masker = dataset.masker if not masker else masker
+            mask = masker.mask_img
             coordinates = dataset.coordinates
 
             # Determine MA map filenames. Must happen after parameters are set.
@@ -94,7 +95,7 @@ class ALEKernel(KernelTransformer):
                 if all(f is not None for f in files):
                     LGR.debug("Files already exist. Using them.")
                     if return_type == "array":
-                        return masker.transform(files).T
+                        return masker.transform(files)
                     elif return_type == "image":
                         return [nib.load(f) for f in files]
                     elif return_type == "dataset":
@@ -221,7 +222,8 @@ class MKDAKernel(KernelTransformer):
                 return_type != "dataset"
             ), "Input dataset must be a Dataset if return_type='dataset'."
         else:
-            mask = dataset.masker.mask_img if not masker else masker.mask_img
+            masker = dataset.masker if not masker else masker
+            mask = masker.mask_img
             coordinates = dataset.coordinates
 
             # Determine MA map filenames. Must happen after parameters are set.
@@ -235,7 +237,7 @@ class MKDAKernel(KernelTransformer):
                 if all(f is not None for f in files):
                     LGR.debug("Files already exist. Using them.")
                     if return_type == "array":
-                        return masker.transform(files).T
+                        return masker.transform(files)
                     elif return_type == "image":
                         return [nib.load(f) for f in files]
                     elif return_type == "dataset":
@@ -367,7 +369,8 @@ class KDAKernel(KernelTransformer):
                 return_type != "dataset"
             ), "Input dataset must be a Dataset if return_type='dataset'."
         else:
-            mask = dataset.masker.mask_img if not masker else masker.mask_img
+            masker = dataset.masker if not masker else masker
+            mask = masker.mask_img
             coordinates = dataset.coordinates
 
             # Determine MA map filenames. Must happen after parameters are set.
@@ -381,7 +384,7 @@ class KDAKernel(KernelTransformer):
                 if all(f is not None for f in files):
                     LGR.debug("Files already exist. Using them.")
                     if return_type == "array":
-                        return masker.transform(files).T
+                        return masker.transform(files)
                     elif return_type == "image":
                         return [nib.load(f) for f in files]
                     elif return_type == "dataset":
@@ -502,7 +505,8 @@ class Peaks2MapsKernel(KernelTransformer):
                 return_type != "dataset"
             ), "Input dataset must be a Dataset if return_type='dataset'."
         else:
-            mask = dataset.masker.mask_img if not masker else masker.mask_img
+            masker = dataset.masker if not masker else masker
+            mask = masker.mask_img
             coordinates = dataset.coordinates
 
             # Determine MA map filenames. Must happen after parameters are set.
@@ -516,7 +520,7 @@ class Peaks2MapsKernel(KernelTransformer):
                 if all(f is not None for f in files):
                     LGR.debug("Files already exist. Using them.")
                     if return_type == "array":
-                        return masker.transform(files).T
+                        return masker.transform(files)
                     elif return_type == "image":
                         return [nib.load(f) for f in files]
                     elif return_type == "dataset":

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -100,7 +100,6 @@ class ALEKernel(KernelTransformer):
                     elif return_type == "dataset":
                         return dataset.copy()
 
-
         # Otherwise, generate the MA maps
         if return_type == "array":
             mask_data = mask.get_fdata().astype(np.bool)
@@ -241,7 +240,6 @@ class MKDAKernel(KernelTransformer):
                         return [nib.load(f) for f in files]
                     elif return_type == "dataset":
                         return dataset.copy()
-
 
         # Otherwise, generate the MA maps
         if return_type == "array":
@@ -388,7 +386,6 @@ class KDAKernel(KernelTransformer):
                         return [nib.load(f) for f in files]
                     elif return_type == "dataset":
                         return dataset.copy()
-
 
         # Otherwise, generate the MA maps
         if return_type == "array":

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -261,6 +261,7 @@ class KDAKernel(KernelTransformer):
             coordinates = dataset.coordinates
         # Determine paths. Must happen after parameters are set.
         from hashlib import md5
+
         self._infer_names(affine=md5(mask.affine).hexdigest())
 
         if return_type == "image":
@@ -304,14 +305,9 @@ class KDAKernel(KernelTransformer):
                 kernel_data *= mask_data
                 img = nib.Nifti1Image(kernel_data, mask.affine)
                 if return_type == "dataset":
-                    out_file = os.path.join(
-                        dataset.basepath,
-                        self.filename_pattern.format(id=id_)
-                    )
+                    out_file = os.path.join(dataset.basepath, self.filename_pattern.format(id=id_))
                     img.to_filename(out_file)
-                    dataset.images.loc[
-                        dataset.images["id"] == id_, self.image_type
-                    ] = out_file
+                    dataset.images.loc[dataset.images["id"] == id_, self.image_type] = out_file
             elif return_type == "array":
                 img = kernel_data[mask_data]
 

--- a/nimare/meta/mkda.py
+++ b/nimare/meta/mkda.py
@@ -107,7 +107,7 @@ class MKDADensity(CBMAEstimator):
         iter_ma_maps = self.kernel_transformer.transform(
             iter_df, masker=self.masker, return_type="array"
         )
-        iter_ma_maps *= self.weight_vec
+        iter_ma_maps = iter_ma_maps * self.weight_vec
         iter_of_map = np.sum(iter_ma_maps, axis=0)
         iter_max_value = np.max(iter_of_map)
         iter_of_map = self.masker.inverse_transform(iter_of_map)

--- a/nimare/meta/mkda.py
+++ b/nimare/meta/mkda.py
@@ -92,7 +92,7 @@ class MKDADensity(CBMAEstimator):
             weight_vec = np.ones((ma_values.shape[0], 1))
         self.weight_vec = weight_vec
 
-        ma_values *= self.weight_vec
+        ma_values = ma_values * self.weight_vec
         of_values = np.sum(ma_values, axis=0)
 
         images = {

--- a/nimare/stats.py
+++ b/nimare/stats.py
@@ -141,6 +141,10 @@ def null_to_p(test_value, null_array, tail="two"):
         p_value = stats.percentileofscore(null_array, test_value) / 100.0
     else:
         raise ValueError('Argument "tail" must be one of ["two", "upper", ' '"lower"]')
+
+    if p_value == 0:
+        p_value = np.finfo(float).eps
+
     return p_value
 
 

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -1,8 +1,11 @@
 """
 Test nimare.meta.kernel (CBMA kernel estimators).
 """
+import shutil
+
 import numpy as np
 from scipy.ndimage.measurements import center_of_mass
+import tempfile
 
 from nimare.meta import kernel
 
@@ -78,7 +81,7 @@ def test_alekernel_2mm(testdata_cbma):
     assert np.array_equal(ijk, max_ijk)
 
 
-def test_alekernel_dataset(testdata_cbma):
+def test_alekernel_inputdataset_returnimages(testdata_cbma):
     """
     Peaks of ALE kernel maps should match the foci fed in (assuming focus isn't
     masked out).
@@ -144,6 +147,29 @@ def test_alekernel_sample_size(testdata_cbma):
     assert np.array_equal(ijk, max_ijk)
 
 
+def test_alekernel_inputdataset_returndataset(testdata_cbma):
+    """
+    Check that the different return types produce equivalent results
+    (minus the masking element).
+    """
+    temp_dir = tempfile.mkdtemp()
+    testdata_cbma.update_path(temp_dir)
+    kern = kernel.ALEKernel()
+    ma_maps = kern.transform(testdata_cbma, return_type="image")
+    ma_arr = kern.transform(testdata_cbma, return_type="array")
+    dset = kern.transform(testdata_cbma, return_type="dataset")
+    ma_maps_arr = testdata_cbma.masker.transform(ma_maps)
+    ma_maps_dset = testdata_cbma.masker.transform(
+        dset.get_images(
+            ids=dset.ids, imtype=kern.image_type
+        )
+    )
+    assert np.array_equal(ma_arr, ma_maps_arr)
+    assert np.array_equal(ma_arr, ma_maps_dset)
+    # It would be nice to use a better teardown
+    shutil.rmtree(temp_dir)
+
+
 def test_mkdakernel_smoke(testdata_cbma):
     """
     Smoke test for nimare.meta.kernel.MKDAKernel, using Dataset object.
@@ -189,6 +215,29 @@ def test_mkdakernel_2mm(testdata_cbma):
     com = np.array(center_of_mass(kern_data)).astype(int).T
     com = np.squeeze(com)
     assert np.array_equal(ijk, com)
+
+
+def test_mkdakernel_inputdataset_returndataset(testdata_cbma):
+    """
+    Check that the different return types produce equivalent results
+    (minus the masking element).
+    """
+    temp_dir = tempfile.mkdtemp()
+    testdata_cbma.update_path(temp_dir)
+    kern = kernel.MKDAKernel(r=4, value=1)
+    ma_maps = kern.transform(testdata_cbma, return_type="image")
+    ma_arr = kern.transform(testdata_cbma, return_type="array")
+    dset = kern.transform(testdata_cbma, return_type="dataset")
+    ma_maps_arr = testdata_cbma.masker.transform(ma_maps)
+    ma_maps_dset = testdata_cbma.masker.transform(
+        dset.get_images(
+            ids=dset.ids, imtype=kern.image_type
+        )
+    )
+    assert np.array_equal(ma_arr, ma_maps_arr)
+    assert np.array_equal(ma_arr, ma_maps_dset)
+    # It would be nice to use a better teardown
+    shutil.rmtree(temp_dir)
 
 
 def test_kdakernel_smoke(testdata_cbma):
@@ -238,7 +287,7 @@ def test_kdakernel_2mm(testdata_cbma):
     assert np.array_equal(ijk, com)
 
 
-def test_kdakernel_dataset(testdata_cbma):
+def test_kdakernel_inputdataset_returnimages(testdata_cbma):
     """
     COMs of KDA kernel maps should match the foci fed in (assuming focus isn't
     masked out and spheres don't overlap).
@@ -254,3 +303,26 @@ def test_kdakernel_dataset(testdata_cbma):
     com = np.array(center_of_mass(kern_data)).astype(int).T
     com = np.squeeze(com)
     assert np.array_equal(ijk, com)
+
+
+def test_kdakernel_inputdataset_returndataset(testdata_cbma):
+    """
+    Check that the different return types produce equivalent results
+    (minus the masking element).
+    """
+    temp_dir = tempfile.mkdtemp()
+    testdata_cbma.update_path(temp_dir)
+    kern = kernel.KDAKernel(r=4, value=1)
+    ma_maps = kern.transform(testdata_cbma, return_type="image")
+    ma_arr = kern.transform(testdata_cbma, return_type="array")
+    dset = kern.transform(testdata_cbma, return_type="dataset")
+    ma_maps_arr = testdata_cbma.masker.transform(ma_maps)
+    ma_maps_dset = testdata_cbma.masker.transform(
+        dset.get_images(
+            ids=dset.ids, imtype=kern.image_type
+        )
+    )
+    assert np.array_equal(ma_arr, ma_maps_arr)
+    assert np.array_equal(ma_arr, ma_maps_dset)
+    # It would be nice to use a better teardown
+    shutil.rmtree(temp_dir)

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -160,9 +160,7 @@ def test_alekernel_inputdataset_returndataset(testdata_cbma):
     dset = kern.transform(testdata_cbma, return_type="dataset")
     ma_maps_arr = testdata_cbma.masker.transform(ma_maps)
     ma_maps_dset = testdata_cbma.masker.transform(
-        dset.get_images(
-            ids=dset.ids, imtype=kern.image_type
-        )
+        dset.get_images(ids=dset.ids, imtype=kern.image_type)
     )
     assert np.array_equal(ma_arr, ma_maps_arr)
     assert np.array_equal(ma_arr, ma_maps_dset)
@@ -230,9 +228,7 @@ def test_mkdakernel_inputdataset_returndataset(testdata_cbma):
     dset = kern.transform(testdata_cbma, return_type="dataset")
     ma_maps_arr = testdata_cbma.masker.transform(ma_maps)
     ma_maps_dset = testdata_cbma.masker.transform(
-        dset.get_images(
-            ids=dset.ids, imtype=kern.image_type
-        )
+        dset.get_images(ids=dset.ids, imtype=kern.image_type)
     )
     assert np.array_equal(ma_arr, ma_maps_arr)
     assert np.array_equal(ma_arr, ma_maps_dset)
@@ -318,9 +314,7 @@ def test_kdakernel_inputdataset_returndataset(testdata_cbma):
     dset = kern.transform(testdata_cbma, return_type="dataset")
     ma_maps_arr = testdata_cbma.masker.transform(ma_maps)
     ma_maps_dset = testdata_cbma.masker.transform(
-        dset.get_images(
-            ids=dset.ids, imtype=kern.image_type
-        )
+        dset.get_images(ids=dset.ids, imtype=kern.image_type)
     )
     assert np.array_equal(ma_arr, ma_maps_arr)
     assert np.array_equal(ma_arr, ma_maps_dset)

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy.ndimage.measurements import center_of_mass
 import tempfile
 
+from nimare.dataset import Dataset
 from nimare.meta import kernel
 
 
@@ -158,12 +159,20 @@ def test_alekernel_inputdataset_returndataset(testdata_cbma):
     ma_maps = kern.transform(testdata_cbma, return_type="image")
     ma_arr = kern.transform(testdata_cbma, return_type="array")
     dset = kern.transform(testdata_cbma, return_type="dataset")
+    ma_maps_from_dset = kern.transform(dset, return_type="image")
+    ma_arr_from_dset = kern.transform(dset, return_type="array")
     ma_maps_arr = testdata_cbma.masker.transform(ma_maps)
+    ma_maps_from_dset_arr = dset.masker.transform(ma_maps_from_dset)
+    dset_from_dset = kern.transform(dset, return_type="dataset")
     ma_maps_dset = testdata_cbma.masker.transform(
         dset.get_images(ids=dset.ids, imtype=kern.image_type)
     )
+    assert isinstance(dset_from_dset, Dataset)
     assert np.array_equal(ma_arr, ma_maps_arr)
     assert np.array_equal(ma_arr, ma_maps_dset)
+    assert np.array_equal(ma_arr, ma_maps_from_dset_arr)
+    assert np.array_equal(ma_arr, ma_arr_from_dset)
+
     # It would be nice to use a better teardown
     shutil.rmtree(temp_dir)
 
@@ -226,12 +235,20 @@ def test_mkdakernel_inputdataset_returndataset(testdata_cbma):
     ma_maps = kern.transform(testdata_cbma, return_type="image")
     ma_arr = kern.transform(testdata_cbma, return_type="array")
     dset = kern.transform(testdata_cbma, return_type="dataset")
+    ma_maps_from_dset = kern.transform(dset, return_type="image")
+    ma_arr_from_dset = kern.transform(dset, return_type="array")
+    dset_from_dset = kern.transform(dset, return_type="dataset")
     ma_maps_arr = testdata_cbma.masker.transform(ma_maps)
+    ma_maps_from_dset_arr = dset.masker.transform(ma_maps_from_dset)
     ma_maps_dset = testdata_cbma.masker.transform(
         dset.get_images(ids=dset.ids, imtype=kern.image_type)
     )
+    assert isinstance(dset_from_dset, Dataset)
     assert np.array_equal(ma_arr, ma_maps_arr)
     assert np.array_equal(ma_arr, ma_maps_dset)
+    assert np.array_equal(ma_arr, ma_maps_from_dset_arr)
+    assert np.array_equal(ma_arr, ma_arr_from_dset)
+
     # It would be nice to use a better teardown
     shutil.rmtree(temp_dir)
 
@@ -309,14 +326,36 @@ def test_kdakernel_inputdataset_returndataset(testdata_cbma):
     temp_dir = tempfile.mkdtemp()
     testdata_cbma.update_path(temp_dir)
     kern = kernel.KDAKernel(r=4, value=1)
+    # MA map generation from transformer
     ma_maps = kern.transform(testdata_cbma, return_type="image")
     ma_arr = kern.transform(testdata_cbma, return_type="array")
     dset = kern.transform(testdata_cbma, return_type="dataset")
+    # Load generated MA maps
+    ma_maps_from_dset = kern.transform(dset, return_type="image")
+    ma_arr_from_dset = kern.transform(dset, return_type="array")
+    dset_from_dset = kern.transform(dset, return_type="dataset")
     ma_maps_arr = testdata_cbma.masker.transform(ma_maps)
+    ma_maps_from_dset_arr = dset.masker.transform(ma_maps_from_dset)
     ma_maps_dset = testdata_cbma.masker.transform(
         dset.get_images(ids=dset.ids, imtype=kern.image_type)
     )
+    assert isinstance(dset_from_dset, Dataset)
     assert np.array_equal(ma_arr, ma_maps_arr)
     assert np.array_equal(ma_arr, ma_maps_dset)
+    assert np.array_equal(ma_arr, ma_maps_from_dset_arr)
+    assert np.array_equal(ma_arr, ma_arr_from_dset)
+
     # It would be nice to use a better teardown
     shutil.rmtree(temp_dir)
+
+
+def test_kdakernel_transform_attributes(testdata_cbma):
+    """
+    Check that attributes are added at transform.
+    """
+    kern = kernel.KDAKernel(r=4, value=1)
+    assert not hasattr(kern, "filename_pattern")
+    assert not hasattr(kern, "image_type")
+    _ = kern.transform(testdata_cbma, return_type="image")
+    assert hasattr(kern, "filename_pattern")
+    assert hasattr(kern, "image_type")

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -90,7 +90,7 @@ def test_alekernel_inputdataset_returnimages(testdata_cbma):
     # Manually override dataset coordinates file sample sizes
     # This column would be extracted from metadata and added to coordinates
     # automatically by the Estimator
-    testdata_cbma = testdata_cbma.slice(testdata_cbma.ids)
+    testdata_cbma = testdata_cbma.copy()
     coordinates = testdata_cbma.coordinates.copy()
     coordinates["sample_size"] = 20
     testdata_cbma.coordinates = coordinates
@@ -154,7 +154,7 @@ def test_alekernel_inputdataset_returndataset(testdata_cbma):
     """
     temp_dir = tempfile.mkdtemp()
     testdata_cbma.update_path(temp_dir)
-    kern = kernel.ALEKernel()
+    kern = kernel.ALEKernel(sample_size=20)
     ma_maps = kern.transform(testdata_cbma, return_type="image")
     ma_arr = kern.transform(testdata_cbma, return_type="array")
     dset = kern.transform(testdata_cbma, return_type="dataset")

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -45,7 +45,7 @@ def test_alekernel_1mm(testdata_cbma):
 
     id_ = "pain_01.nidm-1"
     kern = kernel.ALEKernel()
-    ma_maps = kern.transform(coordinates, testdata_cbma.masker)
+    ma_maps = kern.transform(coordinates, testdata_cbma.masker, return_type="image")
     ijk = coordinates.loc[coordinates["id"] == id_, ["i", "j", "k"]]
     ijk = ijk.values.astype(int)
     kern_data = ma_maps[0].get_fdata()
@@ -68,7 +68,7 @@ def test_alekernel_2mm(testdata_cbma):
 
     id_ = "pain_01.nidm-1"
     kern = kernel.ALEKernel()
-    ma_maps = kern.transform(coordinates, masker=testdata_cbma.masker)
+    ma_maps = kern.transform(coordinates, masker=testdata_cbma.masker, return_type="image")
 
     ijk = coordinates.loc[coordinates["id"] == id_, ["i", "j", "k"]]
     ijk = np.squeeze(ijk.values.astype(int))
@@ -94,7 +94,7 @@ def test_alekernel_dataset(testdata_cbma):
 
     id_ = "pain_01.nidm-1"
     kern = kernel.ALEKernel()
-    ma_maps = kern.transform(testdata_cbma)
+    ma_maps = kern.transform(testdata_cbma, return_type="image")
 
     ijk = coordinates.loc[coordinates["id"] == id_, ["i", "j", "k"]]
     ijk = np.squeeze(ijk.values.astype(int))
@@ -114,7 +114,7 @@ def test_alekernel_fwhm(testdata_cbma):
 
     id_ = "pain_01.nidm-1"
     kern = kernel.ALEKernel(fwhm=10)
-    ma_maps = kern.transform(coordinates, masker=testdata_cbma.masker)
+    ma_maps = kern.transform(coordinates, masker=testdata_cbma.masker, return_type="image")
 
     ijk = coordinates.loc[coordinates["id"] == id_, ["i", "j", "k"]]
     ijk = np.squeeze(ijk.values.astype(int))
@@ -134,7 +134,7 @@ def test_alekernel_sample_size(testdata_cbma):
 
     id_ = "pain_01.nidm-1"
     kern = kernel.ALEKernel(sample_size=20)
-    ma_maps = kern.transform(coordinates, masker=testdata_cbma.masker)
+    ma_maps = kern.transform(coordinates, masker=testdata_cbma.masker, return_type="image")
 
     ijk = coordinates.loc[coordinates["id"] == id_, ["i", "j", "k"]]
     ijk = np.squeeze(ijk.values.astype(int))
@@ -149,7 +149,7 @@ def test_mkdakernel_smoke(testdata_cbma):
     Smoke test for nimare.meta.kernel.MKDAKernel, using Dataset object.
     """
     kern = kernel.MKDAKernel()
-    ma_maps = kern.transform(testdata_cbma)
+    ma_maps = kern.transform(testdata_cbma, return_type="image")
     assert len(ma_maps) == len(testdata_cbma.ids)
     ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="array")
     assert ma_maps.shape[0] == len(testdata_cbma.ids)
@@ -163,7 +163,7 @@ def test_mkdakernel_1mm(testdata_cbma):
     """
     id_ = "pain_01.nidm-1"
     kern = kernel.MKDAKernel(r=4, value=1)
-    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker)
+    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="image")
 
     ijk = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["i", "j", "k"]]
     ijk = np.squeeze(ijk.values.astype(int))
@@ -181,7 +181,7 @@ def test_mkdakernel_2mm(testdata_cbma):
     """
     id_ = "pain_01.nidm-1"
     kern = kernel.MKDAKernel(r=4, value=1)
-    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker)
+    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="image")
 
     ijk = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["i", "j", "k"]]
     ijk = np.squeeze(ijk.values.astype(int))
@@ -196,7 +196,7 @@ def test_kdakernel_smoke(testdata_cbma):
     Smoke test for nimare.meta.kernel.KDAKernel
     """
     kern = kernel.KDAKernel()
-    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker)
+    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="image")
     assert len(ma_maps) == len(testdata_cbma.ids)
     ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="array")
     assert ma_maps.shape[0] == len(testdata_cbma.ids)
@@ -210,7 +210,7 @@ def test_kdakernel_1mm(testdata_cbma):
     """
     id_ = "pain_01.nidm-1"
     kern = kernel.KDAKernel(r=4, value=1)
-    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker)
+    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="image")
 
     ijk = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["i", "j", "k"]]
     ijk = np.squeeze(ijk.values.astype(int))
@@ -228,7 +228,7 @@ def test_kdakernel_2mm(testdata_cbma):
     """
     id_ = "pain_01.nidm-1"
     kern = kernel.KDAKernel(r=4, value=1)
-    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker)
+    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="image")
 
     ijk = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["i", "j", "k"]]
     ijk = np.squeeze(ijk.values.astype(int))
@@ -246,7 +246,7 @@ def test_kdakernel_dataset(testdata_cbma):
     """
     id_ = "pain_01.nidm-1"
     kern = kernel.KDAKernel(r=4, value=1)
-    ma_maps = kern.transform(testdata_cbma)
+    ma_maps = kern.transform(testdata_cbma, return_type="image")
 
     ijk = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["i", "j", "k"]]
     ijk = np.squeeze(ijk.values.astype(int))


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #41 and closes #307 and references #195.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add copy method to Dataset so that kernel transformers, when returning Datasets, don't update the original object.
- Track image basepath in Dataset.
- Support Dataset transformation in kernel transformers. This transformation creates an unmasked version of the MA map, saves it to a file based on `Dataset.basepath` and the parameters of the transformer, and stores the path in the `Dataset.images` attribute.
- Fix bug in `nimare.stats.null_to_p()`. Values outside the range of the null distribution (i.e., p = 0) are now cropped down to epsilon for float.

To do:
- [x] Do not mask MA maps when saving to files. This way they're template-, but not mask-, specific.
- [x] Load images from files when possible. Use masker to apply the mask.
- [ ] Move as much as possible to the base class.
- [ ] Drop absolute paths from images DataFrame. The new basepath attribute should be sufficient.
- [x] Update tests.

Something to perhaps keep an eye on is that there was a new overflow error in one of the MKDA tests. Since these changes shouldn't impact behavior, I think the new error (which reflects a bug in `null_to_p`), probably stems from a random seed thing.