### PR TITLE
[FIX] Add setuptools to requirements

### DIFF
--- a/nimare/info.py
+++ b/nimare/info.py
@@ -60,6 +60,7 @@ REQUIRES = [
     "scikit-learn",
     "scipy",
     "seaborn",
+    "setuptools",
     "six",
     "statsmodels",
     "tqdm",

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -1,6 +1,8 @@
 """
 Test nimare.meta.kernel (CBMA kernel estimators).
 """
+import shutil
+
 import numpy as np
 from scipy.ndimage.measurements import center_of_mass
 
@@ -378,3 +380,4 @@ def test_Peaks2MapsKernel(testdata_cbma, tmp_path_factory):
     assert np.array_equal(ma_arr, ma_maps_dset)
     assert np.array_equal(ma_arr, ma_maps_from_dset_arr)
     assert np.array_equal(ma_arr, ma_arr_from_dset)
+    shutil.rmtree(model_dir)

--- a/nimare/tests/test_meta_mkda.py
+++ b/nimare/tests/test_meta_mkda.py
@@ -95,15 +95,3 @@ def test_kda_density_fwe_1core(testdata_cbma):
     cres = corr.transform(res)
     assert isinstance(res, nimare.results.MetaResult)
     assert isinstance(cres, nimare.results.MetaResult)
-
-
-def test_kda_density_fwe_100core(testdata_cbma):
-    """
-    Smoke test for KDA
-    """
-    meta = mkda.KDA()
-    res = meta.fit(testdata_cbma)
-    assert isinstance(res, nimare.results.MetaResult)
-    corr_100core = FWECorrector(method="montecarlo", n_iters=5, n_cores=100)
-    cres_100core = corr_100core.transform(res)
-    assert isinstance(cres_100core, nimare.results.MetaResult)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None. I don't think this should be necessary, but RTD is failing with the following error:

```
Processing /home/docs/checkouts/readthedocs.org/user_builds/nimare/checkouts/latest
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
ERROR: Exception:
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_internal/cli/base_command.py", line 216, in _main
    status = self.run(options, args)
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_internal/cli/req_command.py", line 182, in wrapper
    return func(self, options, args)
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_internal/commands/install.py", line 325, in run
    reqs, check_supported_wheels=not options.target_dir
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 183, in resolve
    discovered_reqs.extend(self._resolve_one(requirement_set, req))
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 388, in _resolve_one
    abstract_dist = self._get_abstract_dist_for(req_to_install)
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_internal/resolution/legacy/resolver.py", line 340, in _get_abstract_dist_for
    abstract_dist = self.preparer.prepare_linked_requirement(req)
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 483, in prepare_linked_requirement
    req, self.req_tracker, self.finder, self.build_isolation,
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_internal/operations/prepare.py", line 91, in _get_prepared_distribution
    abstract_dist.prepare_distribution_metadata(finder, build_isolation)
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_internal/distributions/sdist.py", line 38, in prepare_distribution_metadata
    self._setup_isolation(finder)
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_internal/distributions/sdist.py", line 96, in _setup_isolation
    reqs = backend.get_requires_for_build_wheel()
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_vendor/pep517/wrappers.py", line 161, in get_requires_for_build_wheel
    'config_settings': config_settings
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_vendor/pep517/wrappers.py", line 265, in _call_hook
    raise BackendUnavailable(data.get('traceback', ''))
pip._vendor.pep517.wrappers.BackendUnavailable: Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/pip/_vendor/pep517/_in_process.py", line 86, in _build_backend
    obj = import_module(mod_path)
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/docs/.pyenv/versions/3.7.3/lib/python3.7/site-packages/setuptools/__init__.py", line 6, in <module>
    import distutils.core
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/site-packages/_distutils_hack/__init__.py", line 82, in create_module
    return importlib.import_module('._distutils', 'setuptools')
  File "/home/docs/checkouts/readthedocs.org/user_builds/nimare/envs/latest/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
ModuleNotFoundError: No module named 'setuptools._distutils'
```

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add setuptools to requirements.
-
