### PR TITLE
[FIX, DOC] Change natural log to base-ten and document output naming convention

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,12 +59,12 @@ To install NiMARE check out our `installation guide`_.
 
   about
   installation
-  cli
+  api
   auto_examples/index
   contributing
   dev_guide
   roadmap
-  api
+  cli
 
 Indices and tables
 ------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ To install NiMARE check out our `installation guide`_.
   dev_guide
   roadmap
   cli
+  outputs
 
 Indices and tables
 ------------------

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -12,9 +12,10 @@ NiMARE-generated files, especially ones made by meta-analyses, follow a naming c
 
 Here is the basic naming convention for statistical maps:
 
-```Text
-[value]_desc-[description]_level-[cluster|voxel]_corr-[FWE|FDR]_method-[method].nii.gz
-```
+.. code-block:: Text
+
+   [value]_desc-[description]_level-[cluster|voxel]_corr-[FWE|FDR]_method-[method].nii.gz
+
 
 First, the `value` represents type of data in the map (e.g., z-statistic, t-statistic).
 Some of the values found in NiMARE include:

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -1,0 +1,36 @@
+.. include:: links.rst
+
+Outputs of NiMARE
+======================
+
+NiMARE includes a wide range of tools with a correspondingly large number of possible outputs.
+Here we outline the rules we apply to NiMARE outputs.
+
+File names
+----------
+NiMARE-generated files, especially ones made by meta-analyses, follow a naming convention somewhat based on BIDS.
+
+Here is the basic naming convention for statistical maps:
+
+```Text
+[value]_desc-[description]_level-[cluster|voxel]_corr-[FWE|FDR]_method-[method].nii.gz
+```
+
+First, the `value` represents type of data in the map (e.g., z-statistic, t-statistic).
+Some of the values found in NiMARE include:
+
+- z: Z-statistic
+- t: T-statistic
+- p: p-value
+- logp: Negative base-ten logarithm of p-value
+- chi2: Chi-squared value
+- prob: Probability value
+- of: Test value of MKDA and KDA methods
+- ale: Test value of ALE and SCALE methods
+
+Next, a series of key/value pairs describe the methods applied to generate the map.
+
+- desc: Description of the data type. Only used when multiple maps with the same data type are produced by the same method.
+- level: Level of multiple comparisons correction. Either cluster or voxel.
+- corr: Type of multiple comparisons correction. Either FWE (familywise error rate) or FDR (false discovery rate).
+- method: Name of the method used for multiple comparisons correction (e.g., "montecarlo" for a Monte Carlo procedure).

--- a/nimare/meta/ale.py
+++ b/nimare/meta/ale.py
@@ -349,8 +349,8 @@ class ALE(CBMAEstimator):
         p_cfwe_values = np.squeeze(
             self.masker.transform(nib.Nifti1Image(p_cfwe_map, self.masker.mask_img.affine))
         )
-        logp_cfwe_values = -np.log(p_cfwe_values)
-        logp_cfwe_values[np.isinf(logp_cfwe_values)] = -np.log(np.finfo(float).eps)
+        logp_cfwe_values = -np.log10(p_cfwe_values)
+        logp_cfwe_values[np.isinf(logp_cfwe_values)] = -np.log10(np.finfo(float).eps)
         z_cfwe_values = p_to_z(p_cfwe_values, tail="one")
 
         # Voxel-level FWE
@@ -363,8 +363,8 @@ class ALE(CBMAEstimator):
             )
 
         z_vfwe_values = p_to_z(p_vfwe_values, tail="one")
-        logp_vfwe_values = -np.log(p_vfwe_values)
-        logp_vfwe_values[np.isinf(logp_vfwe_values)] = -np.log(np.finfo(float).eps)
+        logp_vfwe_values = -np.log10(p_vfwe_values)
+        logp_vfwe_values[np.isinf(logp_vfwe_values)] = -np.log10(np.finfo(float).eps)
 
         # Write out unthresholded value images
         images = {
@@ -627,8 +627,8 @@ class SCALE(CBMAEstimator):
         perm_scale_values = np.stack(perm_scale_values)
 
         p_values, z_values = self._scale_to_p(ale_values, perm_scale_values)
-        logp_values = -np.log(p_values)
-        logp_values[np.isinf(logp_values)] = -np.log(np.finfo(float).eps)
+        logp_values = -np.log10(p_values)
+        logp_values[np.isinf(logp_values)] = -np.log10(np.finfo(float).eps)
 
         # Write out unthresholded value images
         images = {

--- a/nimare/meta/mkda.py
+++ b/nimare/meta/mkda.py
@@ -199,8 +199,8 @@ class MKDADensity(CBMAEstimator):
         for i_clust in range(1, n_clusters + 1):
             clust_size = np.sum(labeled_matrix == i_clust)
             clust_idx = np.where(labeled_matrix == i_clust)
-            cfwe_map[clust_idx] = -np.log(null_to_p(clust_size, perm_clust_sizes, "upper"))
-        cfwe_map[np.isinf(cfwe_map)] = -np.log(np.finfo(float).eps)
+            cfwe_map[clust_idx] = -np.log10(null_to_p(clust_size, perm_clust_sizes, "upper"))
+        cfwe_map[np.isinf(cfwe_map)] = -np.log10(np.finfo(float).eps)
         cfwe_map = np.squeeze(
             self.masker.transform(nib.Nifti1Image(cfwe_map, self.masker.mask_img.affine))
         )
@@ -208,8 +208,8 @@ class MKDADensity(CBMAEstimator):
         # Voxel-level FWE
         vfwe_map = np.squeeze(self.masker.transform(of_map))
         for i_vox, val in enumerate(vfwe_map):
-            vfwe_map[i_vox] = -np.log(null_to_p(val, perm_max_values, "upper"))
-        vfwe_map[np.isinf(vfwe_map)] = -np.log(np.finfo(float).eps)
+            vfwe_map[i_vox] = -np.log10(null_to_p(val, perm_max_values, "upper"))
+        vfwe_map[np.isinf(vfwe_map)] = -np.log10(np.finfo(float).eps)
 
         images = {"logp_level-cluster": cfwe_map, "logp_level-voxel": vfwe_map}
         return images
@@ -666,8 +666,8 @@ class KDA(CBMAEstimator):
         # Voxel-level FWE
         vfwe_map = of_values.copy()
         for i_vox, val in enumerate(of_values):
-            vfwe_map[i_vox] = -np.log(null_to_p(val, perm_max_values, "upper"))
-        vfwe_map[np.isinf(vfwe_map)] = -np.log(np.finfo(float).eps)
+            vfwe_map[i_vox] = -np.log10(null_to_p(val, perm_max_values, "upper"))
+        vfwe_map[np.isinf(vfwe_map)] = -np.log10(np.finfo(float).eps)
 
         images = {"logp_level-voxel": vfwe_map}
         return images


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None, but references #133.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Change natural logarithms in ALE and MKDA modules to base-ten logarithms to match NiMARE's broader convention.
- Create `docs/outputs.rst` to document output naming convention.
- Reorder items in documentation sidebar to better reflect their importance. Namely, the CLI is a useful item, but most users should use the Python functions directly, so the API should be at the top of the sidebar, and CLI should be at the bottom.
