### PR TITLE
[FIX] enforce correct lowest p-value

### DIFF
--- a/nimare/stats.py
+++ b/nimare/stats.py
@@ -148,7 +148,7 @@ def null_to_p(test_value, null_array, tail="two"):
         raise ValueError('Argument "tail" must be one of ["two", "upper", ' '"lower"]')
 
     smallest_value = np.maximum(np.finfo(float).eps, 1.0 / len(null_array))
-    if p_value == 0:
+    if p_value < smallest_value:
         p_value = smallest_value
     elif p_value == 1:
         p_value = 1.0 - smallest_value

--- a/nimare/stats.py
+++ b/nimare/stats.py
@@ -149,6 +149,8 @@ def null_to_p(test_value, null_array, tail="two"):
 
     smallest_value = np.maximum(np.finfo(float).eps, 1.0 / len(null_array))
 
+    # ensure p_value in the following range:
+    # smallest_value <= p_value <= (1.0 - smallest_value)
     p_value = max(smallest_value, min(p_value, 1.0 - smallest_value))
 
     return p_value

--- a/nimare/stats.py
+++ b/nimare/stats.py
@@ -148,10 +148,8 @@ def null_to_p(test_value, null_array, tail="two"):
         raise ValueError('Argument "tail" must be one of ["two", "upper", ' '"lower"]')
 
     smallest_value = np.maximum(np.finfo(float).eps, 1.0 / len(null_array))
-    if p_value < smallest_value:
-        p_value = smallest_value
-    elif p_value == 1:
-        p_value = 1.0 - smallest_value
+
+    p_value = max(smallest_value, min(p_value, 1.0 - smallest_value))
 
     return p_value
 

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -28,4 +28,8 @@ def test_null_to_p():
 
     # modify data to handle edge case
     data[98] = 100
+    assert math.isclose(stats.null_to_p(1, data, "lower"), 0.01)
+    assert math.isclose(stats.null_to_p(1, data, "upper"), 0.99)
+    assert math.isclose(stats.null_to_p(100, data, "lower"), 0.99)
     assert math.isclose(stats.null_to_p(100, data, "upper"), 0.01)
+    assert math.isclose(stats.null_to_p(100, data, "two"), 0.01)

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -25,3 +25,7 @@ def test_null_to_p():
     assert math.isclose(stats.null_to_p(101, data, "lower"), 0.99)
     assert math.isclose(stats.null_to_p(101, data, "upper"), 0.01)
     assert math.isclose(stats.null_to_p(101, data, "two"), 0.01)
+
+    # modify data to handle edge case
+    data[98] = 100
+    assert math.isclose(stats.null_to_p(100, data, "upper"), 0.01)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #364 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- p-values are clipped in null_to_p such that they have to be in the range [smallest_value, (1 - smallest_value)]
- added test to check behavior.

[the solution came from stackoverflow](https://stackoverflow.com/questions/4092528/how-to-clamp-an-integer-to-some-range)