### PR TITLE
[TST] Do not download test peaks2maps to tmpdir

### DIFF
--- a/nimare/extract/extract.py
+++ b/nimare/extract/extract.py
@@ -387,7 +387,8 @@ def download_peaks2maps_model(data_dir=None, overwrite=False, verbose=1):
     temp_data_dir = _get_dataset_dir(temp_dataset_name, data_dir=data_dir, verbose=verbose)
 
     dataset_name = "peaks2maps_model_ohbm2018"
-    if dataset_name not in data_dir:  # allow data_dir to include model folder
+    # allow data_dir to include model folder
+    if (data_dir is not None) and (dataset_name not in data_dir):
         data_dir = temp_data_dir.replace(temp_dataset_name, dataset_name)
 
     desc_file = op.join(data_dir, "description.txt")

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -358,7 +358,7 @@ def test_Peaks2MapsKernel(testdata_cbma, tmp_path_factory):
     """
     tmpdir = tmp_path_factory.mktemp("test_Peaks2MapsKernel")
 
-    model_dir = extract.download_peaks2maps_model(data_dir=str(tmpdir))
+    model_dir = extract.download_peaks2maps_model()
 
     testdata_cbma.update_path(tmpdir)
     kern = kernel.Peaks2MapsKernel(model_dir=model_dir)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #367.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Allow Peaks2Maps test to download the model to the NiMARE resources folder instead of a temporary directory.
    - This will keep the test from downloading the model every time it's run locally.
