### PR TITLE
[ENH] Add empirical null method to density-based CBMA Estimators

### DIFF
--- a/examples/02_meta-analyses/plot_cbma.py
+++ b/examples/02_meta-analyses/plot_cbma.py
@@ -19,7 +19,6 @@ uploaded by Dr. Camille Maumet.
 """
 import os
 
-import numpy as np
 from nilearn.plotting import plot_stat_map
 
 import nimare
@@ -36,7 +35,11 @@ mask_img = dset.masker.mask_img
 ###############################################################################
 # MKDA density analysis
 # --------------------------------------------------
-mkda = nimare.meta.mkda.MKDADensity(kernel__r=10)
+mkda = nimare.meta.mkda.MKDADensity(
+    kernel__r=10,
+    null="empirical",
+    n_iters=100
+)
 mkda.fit(dset)
 corr = nimare.correct.FWECorrector(method="montecarlo", n_iters=10, n_cores=1)
 cres = corr.transform(mkda.results)
@@ -82,7 +85,11 @@ plot_stat_map(
 ###############################################################################
 # KDA
 # --------------------------------------------------
-kda = nimare.meta.mkda.KDA(kernel__r=10)
+kda = nimare.meta.mkda.KDA(
+    kernel__r=10,
+    null="empirical",
+    n_iters=100
+)
 kda.fit(dset)
 corr = nimare.correct.FWECorrector(method="montecarlo", n_iters=10, n_cores=1)
 cres = corr.transform(kda.results)

--- a/examples/02_meta-analyses/plot_cbma.py
+++ b/examples/02_meta-analyses/plot_cbma.py
@@ -37,7 +37,7 @@ mask_img = dset.masker.mask_img
 # --------------------------------------------------
 mkda = nimare.meta.mkda.MKDADensity(
     kernel__r=10,
-    null="empirical",
+    null_method="empirical",
     n_iters=100
 )
 mkda.fit(dset)
@@ -87,7 +87,7 @@ plot_stat_map(
 # --------------------------------------------------
 kda = nimare.meta.mkda.KDA(
     kernel__r=10,
-    null="empirical",
+    null_method="empirical",
     n_iters=100
 )
 kda.fit(dset)

--- a/examples/02_meta-analyses/plot_cbma_combine_estimators_and_kernels.py
+++ b/examples/02_meta-analyses/plot_cbma_combine_estimators_and_kernels.py
@@ -48,7 +48,7 @@ for kt_name, kt in kernel_transformers.items():
     try:
         mkda = nimare.meta.mkda.MKDADensity(
             kernel_transformer=kt,
-            null="empirical",
+            null_method="empirical",
             n_iters=100
         )
         mkda.fit(dset)
@@ -107,7 +107,7 @@ for kt_name, kt in kernel_transformers.items():
     try:
         kda = nimare.meta.mkda.KDA(
             kernel_transformer=kt,
-            null="empirical",
+            null_method="empirical",
             n_iters=100
         )
         kda.fit(dset)

--- a/examples/02_meta-analyses/plot_cbma_combine_estimators_and_kernels.py
+++ b/examples/02_meta-analyses/plot_cbma_combine_estimators_and_kernels.py
@@ -19,7 +19,6 @@ uploaded by Dr. Camille Maumet.
 """
 import os
 
-import numpy as np
 from nilearn.plotting import plot_stat_map
 
 import nimare
@@ -47,7 +46,11 @@ kernel_transformers = {
 # --------------------------------------------------
 for kt_name, kt in kernel_transformers.items():
     try:
-        mkda = nimare.meta.mkda.MKDADensity(kernel_transformer=kt)
+        mkda = nimare.meta.mkda.MKDADensity(
+            kernel_transformer=kt,
+            null="empirical",
+            n_iters=100
+        )
         mkda.fit(dset)
         corr = nimare.correct.FWECorrector(
             method="montecarlo", n_iters=10, n_cores=1
@@ -102,7 +105,11 @@ for kt_name, kt in kernel_transformers.items():
 # --------------------------------------------------
 for kt_name, kt in kernel_transformers.items():
     try:
-        kda = nimare.meta.mkda.KDA(kernel_transformer=kt)
+        kda = nimare.meta.mkda.KDA(
+            kernel_transformer=kt,
+            null="empirical",
+            n_iters=100
+        )
         kda.fit(dset)
         corr = nimare.correct.FWECorrector(
             method="montecarlo", n_iters=10, n_cores=1

--- a/nimare/meta/ale.py
+++ b/nimare/meta/ale.py
@@ -46,6 +46,10 @@ class ALE(CBMAEstimator):
         ALEKernel.
     null : {"analytic", "empirical"}, optional
         Method by which to determine uncorrected p-values.
+    n_iters : int, optional
+        Number of iterations to use to define the null distribution.
+        This is only used if ``null=="empirical"``.
+        Default is 10000.
     **kwargs
         Keyword arguments. Arguments for the kernel_transformer can be assigned
         here, with the prefix '\kernel__' in the variable name.

--- a/nimare/meta/ale.py
+++ b/nimare/meta/ale.py
@@ -127,9 +127,10 @@ class ALE(CBMAEstimator):
 
         Parameters
         ----------
-        data : array, pandas.DataFrame, or list of img_like
+        data : (S [x V]) array, pandas.DataFrame, or list of img_like
             Data from which to estimate ALE scores.
-            The data can be (1) a contrast-by-voxel array of MA values,
+            The data can be:
+            (1) a 1d contrast-len or 2d contrast-by-voxel array of MA values,
             (2) a DataFrame containing coordinates to produce MA values,
             or (3) a list of imgs containing MA values.
 
@@ -145,6 +146,7 @@ class ALE(CBMAEstimator):
         elif isinstance(data, list):
             ma_values = self.masker.transform(data)
         elif isinstance(data, np.ndarray):
+            assert data.ndim in (1, 2)
             ma_values = data.copy()
         else:
             raise ValueError('Unsupported data type "{}"'.format(type(data)))
@@ -175,10 +177,9 @@ class ALE(CBMAEstimator):
             null_ijk = np.random.choice(np.arange(n_voxels), n_studies)
             iter_ma_values = ma_maps[np.arange(n_studies), null_ijk]
             # Calculate ALE
-            iter_ma_values = 1 - iter_ma_values
-            iter_ale_value = 1 - np.prod(iter_ma_values)
+            iter_ss_value = self._compute_summarystat(iter_ma_values)
             # Retain value in null distribution
-            null_distribution[i_iter] = iter_ale_value
+            null_distribution[i_iter] = iter_ss_value
         self.null_distributions_["empirical_null"] = null_distribution
 
     def _compute_null_analytic(self, ma_maps):

--- a/nimare/meta/ale.py
+++ b/nimare/meta/ale.py
@@ -590,9 +590,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
 
 @due.dcite(
     references.SCALE,
-    description=(
-        "Introduces the specific co-activation likelihood estimation (SCALE) algorithm."
-    ),
+    description=("Introduces the specific co-activation likelihood estimation (SCALE) algorithm."),
 )
 class SCALE(CBMAEstimator):
     r"""

--- a/nimare/meta/ale.py
+++ b/nimare/meta/ale.py
@@ -115,7 +115,7 @@ class ALE(CBMAEstimator):
             self._compute_null_analytic(ma_maps)
         else:
             self._compute_null_empirical(ma_maps, n_iters=self.n_iters)
-        p_values, z_values = self._summarystat_to_p(stat_values, method=self.null_method)
+        p_values, z_values = self._summarystat_to_p(stat_values, null_method=self.null_method)
 
         images = {
             "stat": stat_values,
@@ -316,7 +316,7 @@ class ALE(CBMAEstimator):
         iter_ijk = np.squeeze(iter_ijk)
         iter_df[["i", "j", "k"]] = iter_ijk
         stat_values = self._compute_summarystat(iter_df)
-        _, z_values = self._summarystat_to_p(stat_values, method=self.null_method)
+        _, z_values = self._summarystat_to_p(stat_values, null_method=self.null_method)
         iter_max_value = np.max(stat_values)
 
         # Begin cluster-extent thresholding by thresholding matrix at cluster-

--- a/nimare/meta/ale.py
+++ b/nimare/meta/ale.py
@@ -91,9 +91,7 @@ class ALE(CBMAEstimator):
 
     def __init__(self, kernel_transformer=ALEKernel, null="analytic", n_iters=10000, **kwargs):
         # Add kernel transformer attribute and process keyword arguments
-        super().__init__(
-            kernel_transformer=kernel_transformer, **kwargs
-        )
+        super().__init__(kernel_transformer=kernel_transformer, **kwargs)
         self.null = null
         self.n_iters = n_iters
         self.dataset = None
@@ -109,6 +107,7 @@ class ALE(CBMAEstimator):
             self.inputs_["coordinates"], masker=self.masker, return_type="array"
         )
         ale_values = self._compute_summarystat(ma_maps)
+
         # Determine null distributions for summary stat (ALE) to p conversion
         if self.null == "analytic":
             self._compute_null_analytic(ma_maps)

--- a/nimare/meta/mkda.py
+++ b/nimare/meta/mkda.py
@@ -822,7 +822,7 @@ class KDA(CBMAEstimator):
         ----------
         stat_values : 1D array_like
             Array of summary statistic values from estimator.
-        method : {"analytic", "empirical"}, optional
+        null_method : {"analytic", "empirical"}, optional
             Whether to use analytic null or empirical null.
             Default is "analytic".
 
@@ -834,7 +834,7 @@ class KDA(CBMAEstimator):
         """
         p_values = np.ones(stat_values.shape)
 
-        if method == "analytic":
+        if null_method == "analytic":
             assert "histogram_bins" in self.null_distributions_.keys()
             assert "histogram_weights" in self.null_distributions_.keys()
 
@@ -844,7 +844,7 @@ class KDA(CBMAEstimator):
             idx = np.where(stat_values > 0)[0]
             stat_bins = round2(stat_values[idx] * step)
             p_values[idx] = self.null_distributions_["histogram_weights"][stat_bins]
-        elif method == "empirical":
+        elif null_method == "empirical":
             assert "empirical_null" in self.null_distributions_.keys()
 
             for i_voxel in range(stat_values.shape[0]):
@@ -854,7 +854,7 @@ class KDA(CBMAEstimator):
                     tail="upper",
                 )
         else:
-            raise ValueError("Argument 'method' must be one of: 'analytic', 'empirical'.")
+            raise ValueError("Argument 'null_method' must be one of: 'analytic', 'empirical'.")
 
         z_values = p_to_z(p_values, tail="one")
         return p_values, z_values

--- a/nimare/meta/mkda.py
+++ b/nimare/meta/mkda.py
@@ -105,7 +105,7 @@ class MKDADensity(CBMAEstimator):
             raise ValueError("'analytic' null distribution estimation is not yet supported.")
         else:
             self._compute_null_empirical(ma_values, n_iters=self.n_iters)
-        p_values, z_values = self._summarystat_to_p(stat_values, method=self.null_method)
+        p_values, z_values = self._summarystat_to_p(stat_values, null_method=self.null_method)
 
         images = {
             "stat": stat_values,
@@ -746,7 +746,7 @@ class KDA(CBMAEstimator):
             raise ValueError("'analytic' null distribution estimation is not yet supported.")
         else:
             self._compute_null_empirical(ma_values, n_iters=self.n_iters)
-        p_values, z_values = self._summarystat_to_p(stat_values, method=self.null_method)
+        p_values, z_values = self._summarystat_to_p(stat_values, null_method=self.null_method)
 
         images = {
             "stat": stat_values,
@@ -812,7 +812,7 @@ class KDA(CBMAEstimator):
             null_distribution[i_iter] = iter_ss_value
         self.null_distributions_["empirical_null"] = null_distribution
 
-    def _summarystat_to_p(self, stat_values, method="analytic"):
+    def _summarystat_to_p(self, stat_values, null_method="analytic"):
         """
         Compute p- and z-values from summary statistics (e.g., ALE scores) and
         either histograms from analytic null or null distribution from

--- a/nimare/meta/mkda.py
+++ b/nimare/meta/mkda.py
@@ -150,7 +150,8 @@ class MKDADensity(CBMAEstimator):
         Parameters
         ----------
         ma_maps : (C x V) array
-            Contrast by voxel array of MA values.
+            Contrast by voxel array of MA values, after weighting with
+            weight_vec.
 
         Notes
         -----
@@ -158,15 +159,12 @@ class MKDADensity(CBMAEstimator):
         "empirical_null".
         """
         n_studies, n_voxels = ma_maps.shape
-        weight_vec = np.squeeze(self.weight_vec_)  # cannot have singleton
-        assert weight_vec.ndim == 1
         null_distribution = np.zeros(n_iters)
         for i_iter in range(n_iters):
             # One random MA value per study
             null_ijk = np.random.choice(np.arange(n_voxels), n_studies)
             iter_ma_values = ma_maps[np.arange(n_studies), null_ijk]
             # Calculate summary statistic
-            iter_ma_values *= weight_vec
             iter_ss_value = self._compute_summarystat(iter_ma_values)
             # Retain value in null distribution
             null_distribution[i_iter] = iter_ss_value

--- a/nimare/meta/mkda.py
+++ b/nimare/meta/mkda.py
@@ -93,8 +93,8 @@ class MKDADensity(CBMAEstimator):
             )
         else:
             weight_vec = np.ones((ma_values.shape[0], 1))
-        self.weight_vec_ = weight_vec
-
+        self.weight_vec_ = weight_vec  # C x 1 array
+        assert self.weight_vec_.shape[0] == ma_values.shape[0]
         ma_values = ma_values * self.weight_vec_
         of_values = self._compute_summarystat(ma_values)
 
@@ -158,13 +158,15 @@ class MKDADensity(CBMAEstimator):
         "empirical_null".
         """
         n_studies, n_voxels = ma_maps.shape
+        weight_vec = np.squeeze(self.weight_vec_)  # cannot have singleton
+        assert weight_vec.ndim == 1
         null_distribution = np.zeros(n_iters)
         for i_iter in range(n_iters):
             # One random MA value per study
             null_ijk = np.random.choice(np.arange(n_voxels), n_studies)
             iter_ma_values = ma_maps[np.arange(n_studies), null_ijk]
             # Calculate summary statistic
-            iter_ma_values *= self.weight_vec_
+            iter_ma_values *= weight_vec
             iter_ss_value = self._compute_summarystat(iter_ma_values)
             # Retain value in null distribution
             null_distribution[i_iter] = iter_ss_value

--- a/nimare/tests/test_decode_continuous.py
+++ b/nimare/tests/test_decode_continuous.py
@@ -31,7 +31,7 @@ def test_CorrelationDecoder_smoke(testdata_laird, tmp_path_factory):
     # Make an image to decode
     meta = mkda.KDA()
     res = meta.fit(testdata_laird)
-    img = res.get_map("of")
+    img = res.get_map("stat")
     decoded_df = decoder.transform(img)
     assert isinstance(decoded_df, pd.DataFrame)
 
@@ -65,6 +65,6 @@ def test_CorrelationDistributionDecoder_smoke(testdata_laird, tmp_path_factory):
     # Make an image to decode
     meta = mkda.KDA()
     res = meta.fit(testdata_laird)
-    img = res.get_map("of")
+    img = res.get_map("stat")
     decoded_df = decoder.transform(img)
     assert isinstance(decoded_df, pd.DataFrame)

--- a/nimare/tests/test_estimator_performance.py
+++ b/nimare/tests/test_estimator_performance.py
@@ -207,13 +207,7 @@ def test_meta_fit_p_values(meta_res, signal_masks, simulatedata_cbma):
     ]
 
     # all estimators generate p-values
-    p_val_expectation = does_not_raise()
-
-    with p_val_expectation:
-        p_array = meta_res.get_map("p", return_type="array")
-
-    if isinstance(p_val_expectation, type(pytest.raises(ValueError))):
-        pytest.xfail("this meta-analysis estimator does not generate p-values")
+    p_array = meta_res.get_map("p", return_type="array")
 
     # poor performer(s)
     if isinstance(meta_res.estimator, ale.ALE) and isinstance(

--- a/nimare/tests/test_estimator_performance.py
+++ b/nimare/tests/test_estimator_performance.py
@@ -386,26 +386,10 @@ def _transform_res(meta, meta_res, corr):
     #######################################
     # all combinations of meta-analysis estimators and multiple comparison correctors
     # that do not work together
-    if isinstance(meta, mkda.MKDADensity) and isinstance(corr, FDRCorrector):
-        # ValueError: <class 'nimare.correct.FDRCorrector'> requires "p" maps
-        # to be present in the MetaResult, but none were found.
-        corr_expectation = pytest.raises(ValueError)
-    elif isinstance(meta, mkda.KDA) and isinstance(corr, FDRCorrector):
-        # ValueError: <class 'nimare.correct.FDRCorrector'> requires "p" maps
-        # to be present in the MetaResult, but none were found.
-        corr_expectation = pytest.raises(ValueError)
-    elif isinstance(meta, mkda.MKDADensity) and corr.method == "bonferroni":
-        # ValueError: <class 'nimare.correct.FWECorrector'> requires "p" maps
-        # to be present in the MetaResult, but none were found.
-        corr_expectation = pytest.raises(ValueError)
-    elif isinstance(meta, mkda.KDA) and corr.method == "montecarlo":
+    if isinstance(meta, mkda.KDA) and corr.method == "montecarlo":
         # TypeError: correct_fwe_montecarlo() got an unexpected keyword argument 'voxel_thresh'
         voxel_thresh = corr.parameters.pop("voxel_thresh")
         corr_expectation = does_not_raise()
-    elif isinstance(meta, mkda.KDA) and corr.method == "bonferroni":
-        # ValueError: <class 'nimare.correct.FWECorrector'> requires "p" maps
-        # to be present in the MetaResult, but none were found.
-        corr_expectation = pytest.raises(ValueError)
     elif (
         isinstance(meta, ale.ALE)
         and isinstance(meta.kernel_transformer, kernel.KDAKernel)

--- a/nimare/tests/test_estimator_performance.py
+++ b/nimare/tests/test_estimator_performance.py
@@ -206,13 +206,8 @@ def test_meta_fit_p_values(meta_res, signal_masks, simulatedata_cbma):
         meta_res.masker.transform(img).astype(bool).squeeze() for img in signal_masks
     ]
 
-    # kda and mkda estimators do not generate p-values
-    if isinstance(meta_res.estimator, mkda.MKDADensity):
-        p_val_expectation = pytest.raises(ValueError)
-    elif isinstance(meta_res.estimator, mkda.KDA):
-        p_val_expectation = pytest.raises(ValueError)
-    else:
-        p_val_expectation = does_not_raise()
+    # all estimators generate p-values
+    p_val_expectation = does_not_raise()
 
     with p_val_expectation:
         p_array = meta_res.get_map("p", return_type="array")

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -15,12 +15,12 @@ from nimare.meta import ale
 
 def test_ALE_analytic_null_unit(testdata_cbma, tmp_path_factory):
     """
-    Unit test for ALE with analytic null
+    Unit test for ALE with analytic null_method
     """
     tmpdir = tmp_path_factory.mktemp("test_ALE_analytic_null_unit")
     out_file = os.path.join(tmpdir, "file.pkl.gz")
 
-    meta = ale.ALE(null="analytic")
+    meta = ale.ALE(null_method="analytic")
     res = meta.fit(testdata_cbma)
     assert "stat" in res.maps.keys()
     assert "p" in res.maps.keys()
@@ -89,12 +89,12 @@ def test_ALE_analytic_null_unit(testdata_cbma, tmp_path_factory):
 
 def test_ALE_empirical_null_unit(testdata_cbma, tmp_path_factory):
     """
-    Unit test for ALE with an empirical null
+    Unit test for ALE with an empirical null_method
     """
     tmpdir = tmp_path_factory.mktemp("test_ALE_empirical_null_unit")
     out_file = os.path.join(tmpdir, "file.pkl.gz")
 
-    meta = ale.ALE(null="empirical", n_iters=1000)
+    meta = ale.ALE(null_method="empirical", n_iters=1000)
     res = meta.fit(testdata_cbma)
     assert "stat" in res.maps.keys()
     assert "p" in res.maps.keys()

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -13,14 +13,88 @@ from nimare.correct import FDRCorrector, FWECorrector
 from nimare.meta import ale
 
 
-def test_ALE_unit(testdata_cbma, tmp_path_factory):
+def test_ALE_analytic_null_unit(testdata_cbma, tmp_path_factory):
     """
-    Unit test for ALE
+    Unit test for ALE with analytic null
     """
-    tmpdir = tmp_path_factory.mktemp("test_ale")
+    tmpdir = tmp_path_factory.mktemp("test_ALE_analytic_null_unit")
     out_file = os.path.join(tmpdir, "file.pkl.gz")
 
-    meta = ale.ALE()
+    meta = ale.ALE(null="analytic")
+    res = meta.fit(testdata_cbma)
+    assert "ale" in res.maps.keys()
+    assert "p" in res.maps.keys()
+    assert "z" in res.maps.keys()
+    assert isinstance(res, nimare.results.MetaResult)
+    assert isinstance(res.get_map("z", return_type="image"), nib.Nifti1Image)
+    assert isinstance(res.get_map("z", return_type="array"), np.ndarray)
+    res2 = res.copy()
+    assert res2 != res
+    assert isinstance(res, nimare.results.MetaResult)
+
+    # Test saving/loading
+    meta.save(out_file, compress=True)
+    assert os.path.isfile(out_file)
+    meta2 = ale.ALE.load(out_file, compressed=True)
+    assert isinstance(meta2, ale.ALE)
+    with pytest.raises(pickle.UnpicklingError):
+        ale.ALE.load(out_file, compressed=False)
+
+    meta.save(out_file, compress=False)
+    assert os.path.isfile(out_file)
+    meta2 = ale.ALE.load(out_file, compressed=False)
+    assert isinstance(meta2, ale.ALE)
+    with pytest.raises(OSError):
+        ale.ALE.load(out_file, compressed=True)
+
+    # Test MCC methods
+    # Monte Carlo FWE
+    corr = FWECorrector(method="montecarlo", voxel_thresh=0.001, n_iters=5, n_cores=-1)
+    cres = corr.transform(meta.results)
+    assert isinstance(cres, nimare.results.MetaResult)
+    assert "z_level-cluster_corr-FWE_method-montecarlo" in cres.maps.keys()
+    assert "z_level-voxel_corr-FWE_method-montecarlo" in cres.maps.keys()
+    assert "logp_level-cluster_corr-FWE_method-montecarlo" in cres.maps.keys()
+    assert "logp_level-voxel_corr-FWE_method-montecarlo" in cres.maps.keys()
+    assert isinstance(
+        cres.get_map("z_level-cluster_corr-FWE_method-montecarlo", return_type="image"),
+        nib.Nifti1Image,
+    )
+    assert isinstance(
+        cres.get_map("z_level-cluster_corr-FWE_method-montecarlo", return_type="array"), np.ndarray
+    )
+
+    # Bonferroni FWE
+    corr = FWECorrector(method="bonferroni")
+    cres = corr.transform(res)
+    assert isinstance(cres, nimare.results.MetaResult)
+    assert isinstance(
+        cres.get_map("z_corr-FWE_method-bonferroni", return_type="image"),
+        nib.Nifti1Image,
+    )
+    assert isinstance(
+        cres.get_map("z_corr-FWE_method-bonferroni", return_type="array"), np.ndarray
+    )
+
+    # FDR
+    corr = FDRCorrector(method="indep", alpha=0.05)
+    cres = corr.transform(meta.results)
+    assert isinstance(cres, nimare.results.MetaResult)
+    assert isinstance(
+        cres.get_map("z_corr-FDR_method-indep", return_type="image"),
+        nib.Nifti1Image,
+    )
+    assert isinstance(cres.get_map("z_corr-FDR_method-indep", return_type="array"), np.ndarray)
+
+
+def test_ALE_empirical_null_unit(testdata_cbma, tmp_path_factory):
+    """
+    Unit test for ALE with an empirical null
+    """
+    tmpdir = tmp_path_factory.mktemp("test_ALE_empirical_null_unit")
+    out_file = os.path.join(tmpdir, "file.pkl.gz")
+
+    meta = ale.ALE(null="empirical", n_iters=1000)
     res = meta.fit(testdata_cbma)
     assert "ale" in res.maps.keys()
     assert "p" in res.maps.keys()

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -22,7 +22,7 @@ def test_ALE_analytic_null_unit(testdata_cbma, tmp_path_factory):
 
     meta = ale.ALE(null="analytic")
     res = meta.fit(testdata_cbma)
-    assert "ale" in res.maps.keys()
+    assert "stat" in res.maps.keys()
     assert "p" in res.maps.keys()
     assert "z" in res.maps.keys()
     assert isinstance(res, nimare.results.MetaResult)
@@ -96,7 +96,7 @@ def test_ALE_empirical_null_unit(testdata_cbma, tmp_path_factory):
 
     meta = ale.ALE(null="empirical", n_iters=1000)
     res = meta.fit(testdata_cbma)
-    assert "ale" in res.maps.keys()
+    assert "stat" in res.maps.keys()
     assert "p" in res.maps.keys()
     assert "z" in res.maps.keys()
     assert isinstance(res, nimare.results.MetaResult)

--- a/nimare/tests/test_meta_mkda.py
+++ b/nimare/tests/test_meta_mkda.py
@@ -15,7 +15,7 @@ def test_mkda_density_kernel_instance_with_kwargs(testdata_cbma):
     object's parameters should remain untouched.
     """
     kern = kernel.MKDAKernel(r=2)
-    meta = mkda.MKDADensity(kern, kernel__r=6)
+    meta = mkda.MKDADensity(kern, kernel__r=6, null="empirical", n_iters=100)
 
     assert meta.kernel_transformer.get_params().get("r") == 2
 
@@ -24,7 +24,7 @@ def test_mkda_density_kernel_class(testdata_cbma):
     """
     Smoke test for MKDADensity with a kernel transformer class.
     """
-    meta = mkda.MKDADensity(kernel.MKDAKernel, kernel__r=5)
+    meta = mkda.MKDADensity(kernel.MKDAKernel, kernel__r=5, null="empirical", n_iters=100)
     res = meta.fit(testdata_cbma)
     assert isinstance(res, nimare.results.MetaResult)
 
@@ -34,7 +34,7 @@ def test_mkda_density_kernel_instance(testdata_cbma):
     Smoke test for MKDADensity with a kernel transformer object.
     """
     kern = kernel.MKDAKernel(r=5)
-    meta = mkda.MKDADensity(kern)
+    meta = mkda.MKDADensity(kern, null="empirical", n_iters=100)
     res = meta.fit(testdata_cbma)
     assert isinstance(res, nimare.results.MetaResult)
 
@@ -43,7 +43,7 @@ def test_mkda_density(testdata_cbma):
     """
     Smoke test for MKDADensity
     """
-    meta = mkda.MKDADensity()
+    meta = mkda.MKDADensity(null="empirical", n_iters=100)
     res = meta.fit(testdata_cbma)
     corr = FWECorrector(method="montecarlo", voxel_thresh=0.001, n_iters=5, n_cores=1)
     cres = corr.transform(res)
@@ -91,7 +91,7 @@ def test_kda_density_fwe_1core(testdata_cbma):
     """
     Smoke test for KDA
     """
-    meta = mkda.KDA()
+    meta = mkda.KDA(null="empirical", n_iters=100)
     res = meta.fit(testdata_cbma)
     corr = FWECorrector(method="montecarlo", n_iters=5, n_cores=1)
     cres = corr.transform(res)

--- a/nimare/tests/test_meta_mkda.py
+++ b/nimare/tests/test_meta_mkda.py
@@ -96,10 +96,7 @@ def test_kda_density_fwe_1core(testdata_cbma):
     corr = FWECorrector(method="montecarlo", n_iters=5, n_cores=1)
     cres = corr.transform(res)
     assert isinstance(res, nimare.results.MetaResult)
-    assert (
-        res.get_map("p", return_type="array").dtype
-        == np.float64
-    )
+    assert res.get_map("p", return_type="array").dtype == np.float64
     assert isinstance(cres, nimare.results.MetaResult)
     assert (
         cres.get_map("logp_level-voxel_corr-FWE_method-montecarlo", return_type="array").dtype

--- a/nimare/tests/test_meta_mkda.py
+++ b/nimare/tests/test_meta_mkda.py
@@ -15,7 +15,7 @@ def test_mkda_density_kernel_instance_with_kwargs(testdata_cbma):
     object's parameters should remain untouched.
     """
     kern = kernel.MKDAKernel(r=2)
-    meta = mkda.MKDADensity(kern, kernel__r=6, null="empirical", n_iters=100)
+    meta = mkda.MKDADensity(kern, kernel__r=6, null_method="empirical", n_iters=100)
 
     assert meta.kernel_transformer.get_params().get("r") == 2
 
@@ -24,7 +24,7 @@ def test_mkda_density_kernel_class(testdata_cbma):
     """
     Smoke test for MKDADensity with a kernel transformer class.
     """
-    meta = mkda.MKDADensity(kernel.MKDAKernel, kernel__r=5, null="empirical", n_iters=100)
+    meta = mkda.MKDADensity(kernel.MKDAKernel, kernel__r=5, null_method="empirical", n_iters=100)
     res = meta.fit(testdata_cbma)
     assert isinstance(res, nimare.results.MetaResult)
 
@@ -34,7 +34,7 @@ def test_mkda_density_kernel_instance(testdata_cbma):
     Smoke test for MKDADensity with a kernel transformer object.
     """
     kern = kernel.MKDAKernel(r=5)
-    meta = mkda.MKDADensity(kern, null="empirical", n_iters=100)
+    meta = mkda.MKDADensity(kern, null_method="empirical", n_iters=100)
     res = meta.fit(testdata_cbma)
     assert isinstance(res, nimare.results.MetaResult)
 
@@ -43,7 +43,7 @@ def test_mkda_density(testdata_cbma):
     """
     Smoke test for MKDADensity
     """
-    meta = mkda.MKDADensity(null="empirical", n_iters=100)
+    meta = mkda.MKDADensity(null_method="empirical", n_iters=100)
     res = meta.fit(testdata_cbma)
     corr = FWECorrector(method="montecarlo", voxel_thresh=0.001, n_iters=5, n_cores=1)
     cres = corr.transform(res)
@@ -91,7 +91,7 @@ def test_kda_density_fwe_1core(testdata_cbma):
     """
     Smoke test for KDA
     """
-    meta = mkda.KDA(null="empirical", n_iters=100)
+    meta = mkda.KDA(null_method="empirical", n_iters=100)
     res = meta.fit(testdata_cbma)
     corr = FWECorrector(method="montecarlo", n_iters=5, n_cores=1)
     cres = corr.transform(res)

--- a/nimare/tests/test_meta_mkda.py
+++ b/nimare/tests/test_meta_mkda.py
@@ -96,6 +96,10 @@ def test_kda_density_fwe_1core(testdata_cbma):
     corr = FWECorrector(method="montecarlo", n_iters=5, n_cores=1)
     cres = corr.transform(res)
     assert isinstance(res, nimare.results.MetaResult)
+    assert (
+        res.get_map("p", return_type="array").dtype
+        == np.float64
+    )
     assert isinstance(cres, nimare.results.MetaResult)
     assert (
         cres.get_map("logp_level-voxel_corr-FWE_method-montecarlo", return_type="array").dtype


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #371, closes #348, closes #349.

TODO:
- Validate method. I'm thinking a close code review and an example should be sufficient.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add an empirical null-based approach to the ALE, MKDADensity, and KDA Estimators.
- Add tests for empirical null method.
- Simplify ALE calculation (I'm kicking myself over this).
