### PR TITLE
[ENH] Add uncorrected Monte Carlo method

### DIFF
--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -83,12 +83,13 @@ class ALE(CBMAEstimator):
     """
 
     def __init__(
-        self, kernel_transformer=ALEKernel, null_method="analytic", n_iters=10000, **kwargs
+        self, kernel_transformer=ALEKernel, null_method="analytic", n_iters=10000, n_cores=1, **kwargs
     ):
         # Add kernel transformer attribute and process keyword arguments
         super().__init__(kernel_transformer=kernel_transformer, **kwargs)
         self.null_method = null_method
         self.n_iters = n_iters
+        self.n_cores = n_cores
         self.dataset = None
         self.results = None
 

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -83,7 +83,12 @@ class ALE(CBMAEstimator):
     """
 
     def __init__(
-        self, kernel_transformer=ALEKernel, null_method="analytic", n_iters=10000, n_cores=1, **kwargs
+        self,
+        kernel_transformer=ALEKernel,
+        null_method="analytic",
+        n_iters=10000,
+        n_cores=1,
+        **kwargs,
     ):
         # Add kernel transformer attribute and process keyword arguments
         super().__init__(kernel_transformer=kernel_transformer, **kwargs)

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -193,7 +193,7 @@ class ALE(CBMAEstimator):
         # histBins) of that value or lower.
         null_distribution = np.cumsum(ale_hist[::-1])[::-1]
         null_distribution /= np.max(null_distribution)
-        self.null_distributions_["histogram_weights"] = null_distribution
+        self.null_distributions_["histweights_corr-none_method-approximate"] = null_distribution
 
 
 class ALESubtraction(PairwiseCBMAEstimator):

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -13,14 +13,14 @@ from nimare.correct import FDRCorrector, FWECorrector
 from nimare.meta import ale
 
 
-def test_ALE_analytic_null_unit(testdata_cbma, tmp_path_factory):
+def test_ALE_approximate_null_unit(testdata_cbma, tmp_path_factory):
     """
-    Unit test for ALE with analytic null_method
+    Unit test for ALE with approximate null_method
     """
     tmpdir = tmp_path_factory.mktemp("test_ALE_analytic_null_unit")
     out_file = os.path.join(tmpdir, "file.pkl.gz")
 
-    meta = ale.ALE(null_method="analytic")
+    meta = ale.ALE(null_method="approximate")
     res = meta.fit(testdata_cbma)
     assert "stat" in res.maps.keys()
     assert "p" in res.maps.keys()
@@ -85,14 +85,14 @@ def test_ALE_analytic_null_unit(testdata_cbma, tmp_path_factory):
     assert isinstance(cres.get_map("z_corr-FDR_method-indep", return_type="array"), np.ndarray)
 
 
-def test_ALE_empirical_null_unit(testdata_cbma, tmp_path_factory):
+def test_ALE_montecarlo_null_unit(testdata_cbma, tmp_path_factory):
     """
     Unit test for ALE with an empirical null_method
     """
     tmpdir = tmp_path_factory.mktemp("test_ALE_empirical_null_unit")
     out_file = os.path.join(tmpdir, "file.pkl.gz")
 
-    meta = ale.ALE(null_method="empirical", n_iters=1000)
+    meta = ale.ALE(null_method="montecarlo", n_iters=1000)
     res = meta.fit(testdata_cbma)
     assert "stat" in res.maps.keys()
     assert "p" in res.maps.keys()

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -92,7 +92,7 @@ def test_ALE_montecarlo_null_unit(testdata_cbma, tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("test_ALE_empirical_null_unit")
     out_file = os.path.join(tmpdir, "file.pkl.gz")
 
-    meta = ale.ALE(null_method="montecarlo", n_iters=1000)
+    meta = ale.ALE(null_method="montecarlo", n_iters=100, n_cores=1)
     res = meta.fit(testdata_cbma)
     assert "stat" in res.maps.keys()
     assert "p" in res.maps.keys()


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
References #389. This should address everything in #389 except for the inter-peak distance management.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Rename "empirical" null method to "montecarlo."
- Rename "analytic" null method to "approximate."
- Implement full coordinate shuffling in montecarlo null method.
- Use shared "histogram_bins" attribute for both "approximate" and "montecarlo" null methods.
- Infer vFWE correction from montecarlo null method, and add argument to FWE corrector to _skip_ cFWE (and thus additional permutations) if only vFWE is desired.
- Add new `_determine_histogram_bins()` method that must be implemented in each Estimator (rather than in the CBMAEstimator base class). This defines the histograms for both the "montecarlo" and "approximate" null methods.
