### PR TITLE
[FIX] Sort all arrays and DataFrames in Dataset by ID

### DIFF
--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -118,7 +118,7 @@ class Dataset(NiMAREBase):
 
     @ids.setter
     def _ids(self, ids):
-        ids = np.asarray(ids)
+        ids = np.sort(np.asarray(ids))
         assert isinstance(ids, np.ndarray) and ids.ndim == 1
         self.__ids = ids
 
@@ -159,7 +159,7 @@ class Dataset(NiMAREBase):
     @annotations.setter
     def annotations(self, df):
         validate_df(df)
-        self.__annotations = df
+        self.__annotations = df.sort_values(by="id")
 
     @property
     def coordinates(self):
@@ -175,7 +175,7 @@ class Dataset(NiMAREBase):
     @coordinates.setter
     def coordinates(self, df):
         validate_df(df)
-        self.__coordinates = df
+        self.__coordinates = df.sort_values(by="id")
 
     @property
     def images(self):
@@ -197,7 +197,7 @@ class Dataset(NiMAREBase):
     @images.setter
     def images(self, df):
         validate_df(df)
-        self.__images = validate_images_df(df)
+        self.__images = validate_images_df(df).sort_values(by="id")
 
     @property
     def metadata(self):
@@ -211,7 +211,7 @@ class Dataset(NiMAREBase):
     @metadata.setter
     def metadata(self, df):
         validate_df(df)
-        self.__metadata = df
+        self.__metadata = df.sort_values(by="id")
 
     @property
     def texts(self):
@@ -225,7 +225,7 @@ class Dataset(NiMAREBase):
     @texts.setter
     def texts(self, df):
         validate_df(df)
-        self.__texts = df
+        self.__texts = df.sort_values(by="id")
 
     def slice(self, ids):
         """


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None. I am working through the listings for the NiMARE manuscript, and I noticed that the MA maps for the first study in a Sleuth dataset didn't match up with the actual coordinates for that study.

I think there will still be an odd mismatch when there aren't coordinates for all studies in a Dataset, but I don't know what to do about that at the moment.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Sort `Dataset.ids` and rows of all DataFrame-based Dataset attributes based on the `id` column whenever they're set.
