### PR TITLE
[FIX] Allow no coordinates in a dataset

### DIFF
--- a/nimare/tests/test_dataset.py
+++ b/nimare/tests/test_dataset.py
@@ -32,3 +32,9 @@ def test_dataset_smoke():
     mask_data[40, 40, 40] = 1
     mask_img = nib.Nifti1Image(mask_data, dset.masker.mask_img.affine)
     assert isinstance(dset.get_studies_by_mask(mask_img), list)
+
+
+def test_empty_dset():
+    # dictionary with no information
+    minimal_dict = {"study-0": {"contrasts": {"1": {}}}}
+    dataset.Dataset(minimal_dict)

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -104,7 +104,17 @@ def dict_to_coordinates(data, masker, space):
             all_dfs.append(con_df)
 
     if not all_dfs:
-        return pd.DataFrame({"id": []})
+        return pd.DataFrame(
+            {
+                "id": [],
+                "study_id": [],
+                "contrast_id": [],
+                "x": [],
+                "y": [],
+                "z": [],
+                "space": [],
+            },
+        )
 
     df = pd.concat(all_dfs, axis=0, join="outer", sort=False)
     df = df[columns].reset_index(drop=True)

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -103,6 +103,9 @@ def dict_to_coordinates(data, masker, space):
             con_df = pd.DataFrame(temp_data.T, columns=exp_columns)
             all_dfs.append(con_df)
 
+    if not all_dfs:
+        return pd.DataFrame({"id": []})
+
     df = pd.concat(all_dfs, axis=0, join="outer", sort=False)
     df = df[columns].reset_index(drop=True)
     df = df.replace(to_replace="None", value=np.nan)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #405

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- return empty dataframe for coordinates to pass data validation during dataset creation.
- add test for empty dataset


I'm not sure if we want to allow an empty dataset object or explicitly test that at least one of either coordinates or images be set for this to be a valid "dataset" object.
