### PR TITLE
[FIX] Add nullhist_to_p and crop invalid p-values

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
   codecov: codecov/codecov@1.0.5
 jobs:
 
-  build_py36:
+  make_py36_env:
     working_directory: /tmp/src/NiMARE
     docker:
       - image: continuumio/miniconda3
@@ -148,7 +148,7 @@ jobs:
             make unittest
       - codecov/upload:
           file: /tmp/src/NiMARE/coverage.xml
-        
+
   test_performance:
     working_directory: /tmp/src/NiMARE
     docker:
@@ -194,19 +194,19 @@ workflows:
   version: 2.1
   run_tests:
     jobs:
-      - build_py36:
+      - make_py36_env:
           filters:
             tags:
               only: /.*/
       - test_py36_and_coverage:
           requires:
-            - build_py36
+            - make_py36_env
           filters:
             tags:
               only: /.*/
       - test_performance:
           requires:
-            - build_py36
+            - make_py36_env
           filters:
             tags:
               only: /.*/
@@ -220,13 +220,13 @@ workflows:
               only: /.*/
       - build_docs:
           requires:
-            - build_py36
+            - make_py36_env
           filters:
             tags:
               only: /.*/
       - style_check:
           requires:
-            - build_py36
+            - make_py36_env
           filters:
             tags:
               only: /.*/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -216,6 +216,7 @@ API
    stats.two_way
    stats.pearson
    stats.null_to_p
+   stats.nullhist_to_p
    stats.fdr
 
 

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -9,9 +9,8 @@ from tqdm.auto import tqdm
 
 from ... import references
 from ...due import due
-from ...stats import null_to_p
+from ...stats import null_to_p, nullhist_to_p
 from ...transforms import p_to_z
-from ...utils import round2
 from ..kernel import ALEKernel
 from .base import CBMAEstimator, PairwiseCBMAEstimator
 
@@ -157,12 +156,7 @@ class ALE(CBMAEstimator):
             ale_hist = np.zeros(ale_hist.shape)
             np.add.at(ale_hist, score_idx, probabilities)
 
-        # Convert aleHist into null distribution. The value in each bin
-        # represents the probability of finding an ALE value (stored in
-        # histBins) of that value or lower.
-        null_distribution = np.cumsum(ale_hist[::-1])[::-1]
-        null_distribution /= np.max(null_distribution)
-        self.null_distributions_["histogram_weights"] = null_distribution
+        self.null_distributions_["histogram_weights"] = ale_hist
 
 
 class ALESubtraction(PairwiseCBMAEstimator):
@@ -453,8 +447,6 @@ class SCALE(CBMAEstimator):
         -----
         This method also uses the "histogram_bins" element in the null_distributions_ attribute.
         """
-        step = 1 / np.mean(np.diff(self.null_distributions_["histogram_bins"]))
-
         scale_zeros = scale_values == 0
         n_zeros = np.sum(scale_zeros, axis=0)
         scale_values[scale_values == 0] = np.nan
@@ -464,23 +456,11 @@ class SCALE(CBMAEstimator):
         scale_hists[0, :] = n_zeros
         scale_hists[1:, :] = np.apply_along_axis(self._make_hist, 0, scale_values)
 
-        # Convert voxel-wise histograms to voxel-wise null distributions.
-        null_distribution = scale_hists / np.sum(scale_hists, axis=0)
-        null_distribution = np.cumsum(null_distribution[::-1, :], axis=0)[::-1, :]
-        null_distribution /= np.max(null_distribution, axis=0)
-
-        # Get the hist bins associated with each voxel's ale value, in order to
-        # get the p-value from the associated bin in the null distribution.
-        n_bins = len(self.null_distributions_["histogram_bins"])
-        ale_bins = round2(stat_values * step).astype(int)
-        ale_bins[ale_bins > n_bins] = n_bins
-
-        # Get p-values by getting the ale_bin-th value in null_distribution
-        # per voxel.
-        p_values = np.empty_like(ale_bins).astype(float)
-        for i, (x, y) in enumerate(zip(null_distribution.transpose(), ale_bins)):
-            p_values[i] = x[y]
-
+        p_values = nullhist_to_p(
+            stat_values,
+            scale_hists,
+            self.null_distributions_["histogram_bins"]
+        )
         z_values = p_to_z(p_values, tail="one")
         return p_values, z_values
 

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -457,9 +457,7 @@ class SCALE(CBMAEstimator):
         scale_hists[1:, :] = np.apply_along_axis(self._make_hist, 0, scale_values)
 
         p_values = nullhist_to_p(
-            stat_values,
-            scale_hists,
-            self.null_distributions_["histogram_bins"]
+            stat_values, scale_hists, self.null_distributions_["histogram_bins"]
         )
         z_values = p_to_z(p_values, tail="one")
         return p_values, z_values

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -11,9 +11,8 @@ from tqdm.auto import tqdm
 
 from ...base import MetaEstimator
 from ...results import MetaResult
-from ...stats import null_to_p
+from ...stats import null_to_p, nullhist_to_p
 from ...transforms import p_to_z
-from ...utils import round2
 
 LGR = logging.getLogger(__name__)
 
@@ -221,14 +220,11 @@ class CBMAEstimator(MetaEstimator):
             assert "histogram_bins" in self.null_distributions_.keys()
             assert "histogram_weights" in self.null_distributions_.keys()
 
-            step = 1 / np.mean(np.diff(self.null_distributions_["histogram_bins"]))
-
-            # Determine p- and z-values from stat values and null distribution.
-            p_values = np.ones(stat_values.shape)
-            idx = np.where(stat_values > 0)[0]
-            stat_bins = round2(stat_values[idx] * step)
-            p_values[idx] = self.null_distributions_["histogram_weights"][stat_bins]
-
+            p_values = nullhist_to_p(
+                stat_values,
+                self.null_distributions_["histogram_weights"],
+                self.null_distributions_["histogram_bins"]
+            )
         elif null_method == "empirical":
             assert "empirical_null" in self.null_distributions_.keys()
             p_values = null_to_p(

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -223,7 +223,7 @@ class CBMAEstimator(MetaEstimator):
             p_values = nullhist_to_p(
                 stat_values,
                 self.null_distributions_["histogram_weights"],
-                self.null_distributions_["histogram_bins"]
+                self.null_distributions_["histogram_bins"],
             )
         elif null_method == "empirical":
             assert "empirical_null" in self.null_distributions_.keys()

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -584,7 +584,7 @@ class KDA(CBMAEstimator):
             p_values = nullhist_to_p(
                 stat_values,
                 self.null_distributions_["histogram_weights"],
-                self.null_distributions_["histogram_bins"]
+                self.null_distributions_["histogram_bins"],
             )
         elif null_method == "empirical":
             assert "empirical_null" in self.null_distributions_.keys()

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -542,7 +542,7 @@ class KDA(CBMAEstimator):
         ma_hists = np.apply_along_axis(just_histogram, 1, ma_values, bins=hist_bins, density=False)
 
         # Shift the bins to correspond to bins centers instead of bin edges.
-        hist_bins -= np.min(hist_bins)
+        hist_bins += step_size / 2
         hist_bins = hist_bins[:-1]
         self.null_distributions_["histogram_bins"] = hist_bins
 
@@ -570,9 +570,4 @@ class KDA(CBMAEstimator):
             stat_hist = np.zeros(stat_hist.shape)
             np.add.at(stat_hist, score_idx, probabilities)
 
-        # Convert stat_hist into null distribution. The value in each bin
-        # represents the probability of finding a summary statistic value
-        # (stored in histogram_bins) of that value or lower.
-        null_distribution = np.cumsum(stat_hist[::-1])[::-1]
-        null_distribution /= np.max(null_distribution)
-        self.null_distributions_["histogram_weights"] = null_distribution
+        self.null_distributions_["histogram_weights"] = stat_hist

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -541,8 +541,9 @@ class KDA(CBMAEstimator):
 
         ma_hists = np.apply_along_axis(just_histogram, 1, ma_values, bins=hist_bins, density=False)
 
-        # Shift the bins to correspond to actual values instead of centers of bins of values.
+        # Shift the bins to correspond to bins centers instead of bin edges.
         hist_bins -= np.min(hist_bins)
+        hist_bins = hist_bins[:-1]
         self.null_distributions_["histogram_bins"] = hist_bins
 
         # Normalize MA histograms to get probabilities

--- a/nimare/stats.py
+++ b/nimare/stats.py
@@ -198,7 +198,6 @@ def nullhist_to_p(test_values, histogram_weights, histogram_bins):
     P-values are clipped based on the number of elements in the null array.
     Therefore no p-values of 0 or 1 should be produced.
     """
-    shape = histogram_weights.shape
     test_values = np.asarray(test_values)
     return_value = False
     if test_values.ndim == 0:

--- a/nimare/stats.py
+++ b/nimare/stats.py
@@ -170,7 +170,7 @@ def null_to_p(test_value, null_array, tail="two"):
 
 
 def nullhist_to_p(test_values, histogram_weights, histogram_bins):
-    """Return p-value for test value against null histogram.
+    """Return one-sided p-value for test value against null histogram.
 
     Parameters
     ----------
@@ -180,14 +180,18 @@ def nullhist_to_p(test_values, histogram_weights, histogram_bins):
         dimension.
     histogram_weights : (B [x V]) array
         Histogram weights representing the null distribution against which test_value is compared.
+        These should be raw weights or counts, not a cumulatively-summed null distribution.
     histogram_bins : (B) array
-        Histogram bins
+        Histogram bin centers. Note that this differs from numpy.histogram's behavior, which uses
+        bin *edges*. Histogram bins created with numpy will need to be adjusted accordingly.
 
     Returns
     -------
     p_value : :obj:`float`
-        P-value associated with the test value when compared against the null
-        distribution.
+        P-value associated with the test value when compared against the null distribution.
+        P-values reflect the probability of a test value at or above the observed value if the
+        test value was drawn from the null distribution.
+        This is a one-sided p-value.
 
     Notes
     -----

--- a/nimare/tests/test_estimator_performance.py
+++ b/nimare/tests/test_estimator_performance.py
@@ -221,6 +221,12 @@ def test_meta_fit_performance(meta_res, signal_masks, simulatedata_cbma):
     ):
         good_performance = False
     elif (
+        isinstance(meta_res.estimator, ale.ALE)
+        and isinstance(meta_res.estimator.kernel_transformer, kernel.KDAKernel)
+        and meta_res.estimator.get_params().get("null_method") == "analytic"
+    ):
+        good_performance = False
+    elif (
         isinstance(meta_res.estimator, mkda.MKDADensity)
         and isinstance(meta_res.estimator.kernel_transformer, kernel.ALEKernel)
         and meta_res.estimator.get_params().get("null_method") == "analytic"
@@ -271,6 +277,12 @@ def test_corr_transform_performance(meta_cres, corr, signal_masks, simulatedata_
         isinstance(meta_cres.estimator, ale.ALE)
         and isinstance(meta_cres.estimator.kernel_transformer, kernel.KDAKernel)
         and meta_cres.estimator.get_params().get("null_method") == "empirical"
+    ):
+        good_performance = False
+    elif (
+        isinstance(meta_cres.estimator, ale.ALE)
+        and isinstance(meta_cres.estimator.kernel_transformer, kernel.KDAKernel)
+        and meta_cres.estimator.get_params().get("null_method") == "analytic"
     ):
         good_performance = False
     elif (
@@ -391,17 +403,7 @@ def _transform_res(meta, meta_res, corr):
     #######################################
     # all combinations of meta-analysis estimators and multiple comparison correctors
     # that do not work together
-    if (
-        isinstance(meta, ale.ALE)
-        and isinstance(meta.kernel_transformer, kernel.KDAKernel)
-        and not isinstance(meta.kernel_transformer, kernel.MKDAKernel)
-        and corr.method == "montecarlo"
-        and meta.get_params().get("null_method") == "analytic"
-    ):
-        # IndexError: index 20000 is out of bounds for axis 0 with size 10010
-        corr_expectation = pytest.raises(IndexError)
-    else:
-        corr_expectation = does_not_raise()
+    corr_expectation = does_not_raise()
 
     with corr_expectation:
         cres = corr.transform(meta_res)

--- a/nimare/tests/test_estimator_performance.py
+++ b/nimare/tests/test_estimator_performance.py
@@ -161,16 +161,7 @@ def meta_res(simulatedata_cbma, meta, random):
     _, (_, dataset) = simulatedata_cbma
     # CHECK IF META/KERNEL WORK TOGETHER
     ####################################
-    # peaks2MapsKernel does not work with any meta-analysis estimator
-    if (
-        isinstance(meta, ale.ALE)
-        and isinstance(meta.kernel_transformer, kernel.KDAKernel)
-        and meta.get_params().get("null_method") == "analytic"
-        and not isinstance(meta.kernel_transformer, kernel.MKDAKernel)
-    ):
-        meta_expectation = pytest.raises(IndexError)
-    else:
-        meta_expectation = does_not_raise()
+    meta_expectation = does_not_raise()
 
     with meta_expectation:
         res = meta.fit(dataset)

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -45,20 +45,12 @@ def test_nullhist_to_p():
     histogram_weights[-1] = 0
 
     assert math.isclose(
-        stats.nullhist_to_p(0, histogram_weights, histogram_bins),
-        1 - np.finfo(float).eps
+        stats.nullhist_to_p(0, histogram_weights, histogram_bins), 1 - np.finfo(float).eps
     )
+    assert math.isclose(stats.nullhist_to_p(1, histogram_weights, histogram_bins), 0.99)
+    assert math.isclose(stats.nullhist_to_p(99, histogram_weights, histogram_bins), 0.01)
     assert math.isclose(
-        stats.nullhist_to_p(1, histogram_weights, histogram_bins),
-        0.99
-    )
-    assert math.isclose(
-        stats.nullhist_to_p(99, histogram_weights, histogram_bins),
-        0.01
-    )
-    assert math.isclose(
-        stats.nullhist_to_p(100, histogram_weights, histogram_bins),
-        np.finfo(float).eps
+        stats.nullhist_to_p(100, histogram_weights, histogram_bins), np.finfo(float).eps
     )
     histogram_weights = np.ones((histogram_bins.shape[0], n_voxels))
     histogram_weights[-1, :] = 0
@@ -68,13 +60,13 @@ def test_nullhist_to_p():
     )
     assert np.allclose(
         stats.nullhist_to_p([1, 1, 1, 1, 1], histogram_weights, histogram_bins),
-        np.ones(n_voxels) * 0.99
+        np.ones(n_voxels) * 0.99,
     )
     assert np.allclose(
         stats.nullhist_to_p([99, 99, 99, 99, 99], histogram_weights, histogram_bins),
-        np.ones(n_voxels) * 0.01
+        np.ones(n_voxels) * 0.01,
     )
     assert np.allclose(
         stats.nullhist_to_p([100, 100, 100, 100, 100], histogram_weights, histogram_bins),
-        np.ones(n_voxels) * np.finfo(float).eps
+        np.ones(n_voxels) * np.finfo(float).eps,
     )

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -36,14 +36,15 @@ def test_null_to_p():
 
 
 def test_nullhist_to_p():
-    """
-    Test nimare.stats.nullhist_to_p.
-    """
+    """Test nimare.stats.nullhist_to_p."""
     n_voxels = 5
-    histogram_bins = np.arange(0, 101, 1)
-    histogram_weights = np.ones(histogram_bins.shape)
-    histogram_weights[-1] = 0
 
+    # Test cross-voxel null distribution
+    histogram_bins = np.arange(0, 101, 1)  # 101 bins
+    histogram_weights = np.ones(histogram_bins.shape)
+    histogram_weights[-1] = 0  # last bin is outside range, so there are 100 bins with values
+
+    # When input is a single value
     assert math.isclose(
         stats.nullhist_to_p(0, histogram_weights, histogram_bins), 1 - np.finfo(float).eps
     )
@@ -52,21 +53,18 @@ def test_nullhist_to_p():
     assert math.isclose(
         stats.nullhist_to_p(100, histogram_weights, histogram_bins), np.finfo(float).eps
     )
+
+    # When input is an array
+    assert np.allclose(
+        stats.nullhist_to_p([0, 1, 99, 100, 101], histogram_weights, histogram_bins),
+        np.array([1 - np.finfo(float).eps, 0.99, 0.01, np.finfo(float).eps, np.finfo(float).eps])
+    )
+
+    # Test voxel-wise null distributions
     histogram_weights = np.ones((histogram_bins.shape[0], n_voxels))
-    histogram_weights[-1, :] = 0
+    histogram_weights[-1, :] = 0  # last bin is outside range, so there are 100 bins with values
+
     assert np.allclose(
-        stats.nullhist_to_p([0, 0, 0, 0, 0], histogram_weights, histogram_bins),
-        np.ones(n_voxels) * (1 - np.finfo(float).eps),
-    )
-    assert np.allclose(
-        stats.nullhist_to_p([1, 1, 1, 1, 1], histogram_weights, histogram_bins),
-        np.ones(n_voxels) * 0.99,
-    )
-    assert np.allclose(
-        stats.nullhist_to_p([99, 99, 99, 99, 99], histogram_weights, histogram_bins),
-        np.ones(n_voxels) * 0.01,
-    )
-    assert np.allclose(
-        stats.nullhist_to_p([100, 100, 100, 100, 100], histogram_weights, histogram_bins),
-        np.ones(n_voxels) * np.finfo(float).eps,
+        stats.nullhist_to_p([0, 1, 99, 100, 101], histogram_weights, histogram_bins),
+        np.array([1 - np.finfo(float).eps, 0.99, 0.01, np.finfo(float).eps, np.finfo(float).eps])
     )

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -45,14 +45,10 @@ def test_nullhist_to_p():
     histogram_weights[-1] = 0  # last bin is outside range, so there are 100 bins with values
 
     # When input is a single value
-    assert math.isclose(
-        stats.nullhist_to_p(0, histogram_weights, histogram_bins), 1.0
-    )
+    assert math.isclose(stats.nullhist_to_p(0, histogram_weights, histogram_bins), 1.0)
     assert math.isclose(stats.nullhist_to_p(1, histogram_weights, histogram_bins), 0.99)
     assert math.isclose(stats.nullhist_to_p(99, histogram_weights, histogram_bins), 0.01)
-    assert math.isclose(
-        stats.nullhist_to_p(100, histogram_weights, histogram_bins), 0.01
-    )
+    assert math.isclose(stats.nullhist_to_p(100, histogram_weights, histogram_bins), 0.01)
 
     # When input is an array
     assert np.allclose(

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -33,3 +33,48 @@ def test_null_to_p():
     assert math.isclose(stats.null_to_p(100.1, data, "lower"), 0.99)
     assert math.isclose(stats.null_to_p(100.1, data, "upper"), 0.01)
     assert math.isclose(stats.null_to_p(100.1, data, "two"), 0.01)
+
+
+def test_nullhist_to_p():
+    """
+    Test nimare.stats.nullhist_to_p.
+    """
+    n_voxels = 5
+    histogram_bins = np.arange(0, 101, 1)
+    histogram_weights = np.ones(histogram_bins.shape)
+    histogram_weights[-1] = 0
+
+    assert math.isclose(
+        stats.nullhist_to_p(0, histogram_weights, histogram_bins),
+        1 - np.finfo(float).eps
+    )
+    assert math.isclose(
+        stats.nullhist_to_p(1, histogram_weights, histogram_bins),
+        0.99
+    )
+    assert math.isclose(
+        stats.nullhist_to_p(99, histogram_weights, histogram_bins),
+        0.01
+    )
+    assert math.isclose(
+        stats.nullhist_to_p(100, histogram_weights, histogram_bins),
+        np.finfo(float).eps
+    )
+    histogram_weights = np.ones((histogram_bins.shape[0], n_voxels))
+    histogram_weights[-1, :] = 0
+    assert np.allclose(
+        stats.nullhist_to_p([0, 0, 0, 0, 0], histogram_weights, histogram_bins),
+        np.ones(n_voxels) * (1 - np.finfo(float).eps),
+    )
+    assert np.allclose(
+        stats.nullhist_to_p([1, 1, 1, 1, 1], histogram_weights, histogram_bins),
+        np.ones(n_voxels) * 0.99
+    )
+    assert np.allclose(
+        stats.nullhist_to_p([99, 99, 99, 99, 99], histogram_weights, histogram_bins),
+        np.ones(n_voxels) * 0.01
+    )
+    assert np.allclose(
+        stats.nullhist_to_p([100, 100, 100, 100, 100], histogram_weights, histogram_bins),
+        np.ones(n_voxels) * np.finfo(float).eps
+    )

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -57,7 +57,7 @@ def test_nullhist_to_p():
     # When input is an array
     assert np.allclose(
         stats.nullhist_to_p([0, 1, 99, 100, 101], histogram_weights, histogram_bins),
-        np.array([1 - np.finfo(float).eps, 0.99, 0.01, np.finfo(float).eps, np.finfo(float).eps])
+        np.array([1 - np.finfo(float).eps, 0.99, 0.01, np.finfo(float).eps, np.finfo(float).eps]),
     )
 
     # Test voxel-wise null distributions
@@ -66,5 +66,5 @@ def test_nullhist_to_p():
 
     assert np.allclose(
         stats.nullhist_to_p([0, 1, 99, 100, 101], histogram_weights, histogram_bins),
-        np.array([1 - np.finfo(float).eps, 0.99, 0.01, np.finfo(float).eps, np.finfo(float).eps])
+        np.array([1 - np.finfo(float).eps, 0.99, 0.01, np.finfo(float).eps, np.finfo(float).eps]),
     )

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -46,18 +46,18 @@ def test_nullhist_to_p():
 
     # When input is a single value
     assert math.isclose(
-        stats.nullhist_to_p(0, histogram_weights, histogram_bins), 1 - np.finfo(float).eps
+        stats.nullhist_to_p(0, histogram_weights, histogram_bins), 1.0
     )
     assert math.isclose(stats.nullhist_to_p(1, histogram_weights, histogram_bins), 0.99)
     assert math.isclose(stats.nullhist_to_p(99, histogram_weights, histogram_bins), 0.01)
     assert math.isclose(
-        stats.nullhist_to_p(100, histogram_weights, histogram_bins), np.finfo(float).eps
+        stats.nullhist_to_p(100, histogram_weights, histogram_bins), 0.01
     )
 
     # When input is an array
     assert np.allclose(
         stats.nullhist_to_p([0, 1, 99, 100, 101], histogram_weights, histogram_bins),
-        np.array([1 - np.finfo(float).eps, 0.99, 0.01, np.finfo(float).eps, np.finfo(float).eps]),
+        np.array([1.0, 0.99, 0.01, 0.01, 0.01]),
     )
 
     # Test voxel-wise null distributions
@@ -66,5 +66,5 @@ def test_nullhist_to_p():
 
     assert np.allclose(
         stats.nullhist_to_p([0, 1, 99, 100, 101], histogram_weights, histogram_bins),
-        np.array([1 - np.finfo(float).eps, 0.99, 0.01, np.finfo(float).eps, np.finfo(float).eps]),
+        np.array([1.0, 0.99, 0.01, 0.01, 0.01]),
     )


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #403. 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add `nimare.stats.nullhist_to_p()` function for converting test statistics to p-values using a null distribution stored in a histogram.
- Use `nimare.stats.nullhist_to_p()` in CBMA estimators.
- Crop out-of-bounds p-values to ~~epsilon~~ smallest observed non-zero p-value.

TODO:

- [X] Replace epsilon with better value when cropping.