### PR TITLE
[ENH] Improve convergence between ALE null methods

### DIFF
--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -125,6 +125,7 @@ class ALE(CBMAEstimator):
         # round up based on resolution
         max_ma_values = np.ceil(max_ma_values * inv_step_size) / inv_step_size
         max_poss_ale = self.compute_summarystat(max_ma_values)
+        self.max_poss_ale = max_poss_ale
         # create bin centers, then shift them into bin edges
         hist_bins = np.round(np.arange(0, max_poss_ale + step_size, step_size), 5) - (
             step_size / 2

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -118,7 +118,7 @@ class ALE(CBMAEstimator):
 
         # Determine bins for null distribution histogram
         # Remember that numpy histogram bins are bin edges, not centers
-        # Assuming values of 0, .001, .002, etc., bins are -.0005-.0005, .0005-.001, etc.
+        # Assuming values of 0, .001, .002, etc., bins are -.0005-.0005, .0005-.0015, etc.
         inv_step_size = 100000
         step_size = 1 / inv_step_size
         max_ma_values = np.max(ma_values, axis=1)

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -125,9 +125,8 @@ class ALE(CBMAEstimator):
         # round up based on resolution
         max_ma_values = np.ceil(max_ma_values * inv_step_size) / inv_step_size
         max_poss_ale = self.compute_summarystat(max_ma_values)
-        self.max_poss_ale = max_poss_ale
         # create bin centers, then shift them into bin edges
-        hist_bins = np.round(np.arange(0, max_poss_ale + step_size, step_size), 5) - (
+        hist_bins = np.round(np.arange(0, max_poss_ale + (1.5 * step_size), step_size), 5) - (
             step_size / 2
         )
 

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -360,7 +360,7 @@ class SCALE(CBMAEstimator):
         max_ma_values = np.max(ma_maps, axis=1)
         max_poss_ale = self._compute_summarystat(max_ma_values)
         self.null_distributions_["histogram_bins"] = np.round(
-            np.arange(0, max_poss_ale + 0.001, 0.0001), 4
+            np.arange(0, max_poss_ale + 0.0001, 0.00001), 5
         )
 
         stat_values = self._compute_summarystat(ma_maps)

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -120,7 +120,7 @@ class ALE(CBMAEstimator):
         max_ma_values = np.max(ma_values, axis=1)
         max_poss_ale = self.compute_summarystat(max_ma_values)
         step_size = 0.00001
-        hist_bins = np.round(np.arange(0, max_poss_ale + 0.0001, step_size), 5)
+        hist_bins = np.round(np.arange(0, max_poss_ale + 0.001, step_size), 5)
         self.null_distributions_["histogram_bins"] = hist_bins
 
         ma_hists = np.zeros((ma_values.shape[0], hist_bins.shape[0]))

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -126,7 +126,7 @@ class ALE(CBMAEstimator):
         max_ma_values = np.ceil(max_ma_values * inv_step_size) / inv_step_size
         max_poss_ale = self.compute_summarystat(max_ma_values)
         # create bin centers, then shift them into bin edges
-        hist_bins = np.round(np.arange(0, max_poss_ale + (1.5 * step_size), step_size), 5) - (
+        hist_bins = np.round(np.arange(0, max_poss_ale + (2.5 * step_size), step_size), 5) - (
             step_size / 2
         )
 

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -119,8 +119,8 @@ class ALE(CBMAEstimator):
         # Determine bins for null distribution histogram
         max_ma_values = np.max(ma_values, axis=1)
         max_poss_ale = self.compute_summarystat(max_ma_values)
-        step_size = 0.0001
-        hist_bins = np.round(np.arange(0, max_poss_ale + 0.001, step_size), 4)
+        step_size = 0.00001
+        hist_bins = np.round(np.arange(0, max_poss_ale + 0.0001, step_size), 5)
         self.null_distributions_["histogram_bins"] = hist_bins
 
         ma_hists = np.zeros((ma_values.shape[0], hist_bins.shape[0]))

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -360,7 +360,7 @@ class SCALE(CBMAEstimator):
         max_ma_values = np.max(ma_maps, axis=1)
         max_poss_ale = self._compute_summarystat(max_ma_values)
         self.null_distributions_["histogram_bins"] = np.round(
-            np.arange(0, max_poss_ale + 0.0001, 0.00001), 5
+            np.arange(0, max_poss_ale + 0.001, 0.0001), 4
         )
 
         stat_values = self._compute_summarystat(ma_maps)

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -126,9 +126,9 @@ class ALE(CBMAEstimator):
         max_ma_values = np.ceil(max_ma_values * inv_step_size) / inv_step_size
         max_poss_ale = self.compute_summarystat(max_ma_values)
         # create bin centers, then shift them into bin edges
-        hist_bins = np.round(
-            np.arange(0, max_poss_ale + step_size, step_size), 5
-        ) - (step_size / 2)
+        hist_bins = np.round(np.arange(0, max_poss_ale + step_size, step_size), 5) - (
+            step_size / 2
+        )
 
         def just_histogram(*args, **kwargs):
             """Collect the first output (weights) from numpy histogram."""
@@ -137,7 +137,7 @@ class ALE(CBMAEstimator):
         ma_hists = np.apply_along_axis(just_histogram, 1, ma_values, bins=hist_bins, density=False)
 
         # Shift the bins to correspond to centers instead of edges
-        hist_bins += (step_size / 2)
+        hist_bins += step_size / 2
         self.null_distributions_["histogram_bins"] = hist_bins
 
         # Normalize MA histograms to get probabilities

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -136,8 +136,9 @@ class ALE(CBMAEstimator):
 
         ma_hists = np.apply_along_axis(just_histogram, 1, ma_values, bins=hist_bins, density=False)
 
-        # Shift the bins to correspond to centers instead of edges
+        # Shift and crop the bins to correspond to centers instead of edges
         hist_bins += step_size / 2
+        hist_bins = hist_bins[:-1]
         self.null_distributions_["histogram_bins"] = hist_bins
 
         # Normalize MA histograms to get probabilities

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -227,12 +227,7 @@ class CBMAEstimator(MetaEstimator):
             p_values = np.ones(stat_values.shape)
             idx = np.where(stat_values > 0)[0]
             stat_bins = round2(stat_values[idx] * inv_step_size)
-            try:
-                p_values[idx] = self.null_distributions_["histogram_weights"][stat_bins]
-            except:
-                raise Exception("Max possible value is {}, max observed is {}".format(
-                    self.max_poss_ale, np.max(stat_values))
-                )
+            p_values[idx] = self.null_distributions_["histogram_weights"][stat_bins]
 
         elif null_method == "empirical":
             assert "empirical_null" in self.null_distributions_.keys()

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -221,13 +221,18 @@ class CBMAEstimator(MetaEstimator):
             assert "histogram_bins" in self.null_distributions_.keys()
             assert "histogram_weights" in self.null_distributions_.keys()
 
-            step = 1 / np.mean(np.diff(self.null_distributions_["histogram_bins"]))
+            inv_step_size = round2(1 / np.diff(self.null_distributions_["histogram_bins"])[0])
 
             # Determine p- and z-values from stat values and null distribution.
             p_values = np.ones(stat_values.shape)
             idx = np.where(stat_values > 0)[0]
-            stat_bins = round2(stat_values[idx] * step)
-            p_values[idx] = self.null_distributions_["histogram_weights"][stat_bins]
+            stat_bins = round2(stat_values[idx] * inv_step_size)
+            try:
+                p_values[idx] = self.null_distributions_["histogram_weights"][stat_bins]
+            except:
+                raise Exception("Max possible value is {}, max observed is {}".format(
+                    self.max_poss_ale, np.max(stat_values))
+                )
 
         elif null_method == "empirical":
             assert "empirical_null" in self.null_distributions_.keys()


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #396.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Increase resolution of ALE analytic null histogram from bins of 0.0001 to bins of 0.00001.
- Round up maximum MA values based on target resolution in ALE histogram generation so that we don't need an arbitrary buffer.
    - This involves including one extra bin in the histogram that has an impossible value (e.g., 1.000001). See https://github.com/neurostuff/NiMARE/pull/411#issuecomment-736996415 for rationale.
- Simplify histogram generation in ALE.
    - This involves cropping histogram bins when shifting from edges to centers.
- ~~Also increase resolution of SCALE analytic null histogram by same factor.~~ Reverted since it was too memory-intensive for the CI.
