### PR TITLE
[TST] Do not download test peaks2maps to tmpdir

### DIFF
--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -6,8 +6,9 @@ import shutil
 import numpy as np
 from scipy.ndimage.measurements import center_of_mass
 
+import nimare
 from nimare.dataset import Dataset
-from nimare.meta import kernel
+from nimare.meta import kernel, MKDADensity
 from nimare import extract
 
 
@@ -381,3 +382,18 @@ def test_Peaks2MapsKernel(testdata_cbma, tmp_path_factory):
     assert np.array_equal(ma_arr, ma_maps_from_dset_arr)
     assert np.array_equal(ma_arr, ma_arr_from_dset)
     shutil.rmtree(model_dir)
+
+
+def test_Peaks2MapsKernel_MKDADensity(testdata_cbma, tmp_path_factory):
+    """Test that the Peaks2Maps kernel can work with an estimator."""
+    tmpdir = tmp_path_factory.mktemp("test_Peaks2MapsKernel_MKDADensity")
+
+    model_dir = extract.download_peaks2maps_model()
+
+    testdata_cbma.update_path(tmpdir)
+    kern = kernel.Peaks2MapsKernel(model_dir=model_dir)
+
+    est = MKDADensity(kernel_transformer=kern, null_method="analytic")
+    res = est.fit(testdata_cbma)
+    assert isinstance(res, nimare.results.MetaResult)
+    assert res.get_map("p", return_type="array").dtype == np.float64

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -358,7 +358,7 @@ def test_Peaks2MapsKernel(testdata_cbma, tmp_path_factory):
     """
     tmpdir = tmp_path_factory.mktemp("test_Peaks2MapsKernel")
 
-    model_dir = extract.download_peaks2maps_model(data_dir=str(tmpdir))
+    model_dir = extract.download_peaks2maps_model()
 
     testdata_cbma.update_path(tmpdir)
     kern = kernel.Peaks2MapsKernel(model_dir=model_dir)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #367 and supersedes #368 (if it works).

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Allow Peaks2Maps test to download the model to the NiMARE resources folder instead of a temporary directory.
    - This will keep the test from downloading the model every time it's run locally.
- Add new test for P2M + MKDA.
