### PR TITLE
[DOC] Warn users about Peaks2MapsKernel and KDA Estimator

### DIFF
--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -456,10 +456,12 @@ class KDA(CBMAEstimator):
     Kernel density analysis was first introduced in [1]_ and [2]_.
 
     Available correction methods: :func:`KDA.correct_fwe_montecarlo`
+
     Warning
     -------
-    The KDA meta-analytic algorithm is objectively inferior to the MKDA algorithm.
-    Please do not use this Estimator for serious meta-analyses.
+    The KDA algorithm has been replaced in the literature with the MKDA algorithm.
+    As such, this estimator should almost never be used, outside of systematic
+    comparisons between algorithms.
 
     References
     ----------
@@ -476,8 +478,9 @@ class KDA(CBMAEstimator):
         self, kernel_transformer=KDAKernel, null_method="empirical", n_iters=10000, **kwargs
     ):
         LGR.warning(
-            "The KDA meta-analytic algorithm is objectively inferior to the MKDA algorithm. "
-            "Please do not use this Estimator for serious meta-analyses."
+            "The KDA algorithm has been replaced in the literature with the MKDA algorithm. "
+            "As such, this estimator should almost never be used, outside of systematic "
+            "comparisons between algorithms."
         )
         if not isinstance(kernel_transformer, KDAKernel):
             LGR.warning(

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -456,6 +456,11 @@ class KDA(CBMAEstimator):
     Kernel density analysis was first introduced in [1]_ and [2]_.
 
     Available correction methods: :func:`KDA.correct_fwe_montecarlo`
+    
+    Warning
+    -------
+    The KDA meta-analytic algorithm is objectively inferior to the MKDA algorithm.
+    Please do not use this Estimator for serious meta-analyses.
 
     References
     ----------
@@ -471,6 +476,10 @@ class KDA(CBMAEstimator):
     def __init__(
         self, kernel_transformer=KDAKernel, null_method="empirical", n_iters=10000, **kwargs
     ):
+        LGR.warning(
+            "The KDA meta-analytic algorithm is objectively inferior to the MKDA algorithm. "
+            "Please do not use this Estimator for serious meta-analyses."
+        )
         if not isinstance(kernel_transformer, KDAKernel):
             LGR.warning(
                 f"The KernelTransformer being used ({kernel_transformer}) is not optimized "

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -456,7 +456,6 @@ class KDA(CBMAEstimator):
     Kernel density analysis was first introduced in [1]_ and [2]_.
 
     Available correction methods: :func:`KDA.correct_fwe_montecarlo`
-    
     Warning
     -------
     The KDA meta-analytic algorithm is objectively inferior to the MKDA algorithm.

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -319,12 +319,21 @@ class Peaks2MapsKernel(KernelTransformer):
     resample_to_mask : :obj:`bool`, optional
         If True, will resample the MA maps to the mask's header.
         Default is True.
+
+    Warning
+    -------
+    Peaks2MapsKernel is not intended for serious research.
+    We strongly recommend against using it for any meaningful analyses.
     """
 
     def __init__(self, model_dir="auto"):
         # Use private attribute to hide value from get_params.
         # get_params will find model_dir=None, which is *very important* when a path is provided.
         self._model_dir = model_dir
+        LGR.warning(
+            "The Peaks2Maps kernel transformer is not intended for serious research. "
+            "We strongly recommend against using it for any meaningful analyses."
+        )
 
     def _transform(self, mask, coordinates):
         transformed = []


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #417, in that we will not test Peaks2MapsKernel in conjunction with any meta-analytic estimators, so any issues with memory usage can be ignored.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add warning to docstring and log warning at initialization of Peaks2MapsKernel, to clarify to users that they should **not** use the kernel for any serious research.
- Add warning to docstring and log warning at initialization of KDA estimator, to make it clear that the KDA estimator is inferior to MKDA and should not be used for real meta-analyses.
