### PR TITLE
[ENH] Implement full coordinate-set empirical null method 

### DIFF
--- a/examples/02_meta-analyses/plot_cbma.py
+++ b/examples/02_meta-analyses/plot_cbma.py
@@ -35,7 +35,7 @@ mask_img = dset.masker.mask_img
 ###############################################################################
 # MKDA density analysis
 # --------------------------------------------------
-mkda = nimare.meta.MKDADensity(kernel__r=10, null_method="empirical", n_iters=100)
+mkda = nimare.meta.MKDADensity(kernel__r=10, null_method="analytic")
 mkda.fit(dset)
 corr = nimare.correct.FWECorrector(method="montecarlo", n_iters=10, n_cores=1)
 cres = corr.transform(mkda.results)
@@ -81,7 +81,7 @@ plot_stat_map(
 ###############################################################################
 # KDA
 # --------------------------------------------------
-kda = nimare.meta.KDA(kernel__r=10, null_method="empirical", n_iters=100)
+kda = nimare.meta.KDA(kernel__r=10, null_method="analytic")
 kda.fit(dset)
 corr = nimare.correct.FWECorrector(method="montecarlo", n_iters=10, n_cores=1)
 cres = corr.transform(kda.results)
@@ -95,7 +95,7 @@ plot_stat_map(
 ###############################################################################
 # ALE
 # --------------------------------------------------
-ale = nimare.meta.ALE()
+ale = nimare.meta.ALE(null_method="analytic")
 ale.fit(dset)
 corr = nimare.correct.FWECorrector(method="montecarlo", n_iters=10, n_cores=1)
 cres = corr.transform(ale.results)

--- a/examples/02_meta-analyses/plot_cbma_combine_estimators_and_kernels.py
+++ b/examples/02_meta-analyses/plot_cbma_combine_estimators_and_kernels.py
@@ -58,7 +58,7 @@ for kt_name, kt in kernel_transformers.items():
             title="MKDA estimator with %s" % kt_name,
         )
 
-    except IndexError:
+    except AttributeError:
         print(
             "\nError: the %s does not currently work with the MKDA meta-analysis method\n"
             % kt_name
@@ -84,7 +84,7 @@ for kt_name, kt in kernel_transformers.items():
             title="MKDA Chi2 estimator with %s" % kt_name,
         )
 
-    except IndexError:
+    except AttributeError:
         print(
             "\nError: the %s does not currently work with the MKDA Chi2 meta-analysis method\n"
             % kt_name
@@ -107,7 +107,7 @@ for kt_name, kt in kernel_transformers.items():
             title="KDA estimator with %s" % kt_name,
         )
 
-    except IndexError:
+    except AttributeError:
         print(
             "\nError: the %s does not currently work with the KDA meta-analysis method\n" % kt_name
         )
@@ -129,7 +129,7 @@ for kt_name, kt in kernel_transformers.items():
             title="ALE estimator with %s" % kt_name,
         )
 
-    except IndexError:
+    except AttributeError:
         print(
             "\nError: the %s does not currently work with the ALE meta-analysis method\n" % kt_name
         )

--- a/examples/02_meta-analyses/plot_cbma_combine_estimators_and_kernels.py
+++ b/examples/02_meta-analyses/plot_cbma_combine_estimators_and_kernels.py
@@ -46,9 +46,7 @@ kernel_transformers = {
 # --------------------------------------------------
 for kt_name, kt in kernel_transformers.items():
     try:
-        mkda = nimare.meta.MKDADensity(
-            kernel_transformer=kt, null_method="empirical", n_iters=100
-        )
+        mkda = nimare.meta.MKDADensity(kernel_transformer=kt, null_method="analytic")
         mkda.fit(dset)
         corr = nimare.correct.FWECorrector(method="montecarlo", n_iters=10, n_cores=1)
         cres = corr.transform(mkda.results)
@@ -97,7 +95,7 @@ for kt_name, kt in kernel_transformers.items():
 # --------------------------------------------------
 for kt_name, kt in kernel_transformers.items():
     try:
-        kda = nimare.meta.KDA(kernel_transformer=kt, null_method="empirical", n_iters=100)
+        kda = nimare.meta.KDA(kernel_transformer=kt, null_method="analytic")
         kda.fit(dset)
         corr = nimare.correct.FWECorrector(method="montecarlo", n_iters=10, n_cores=1)
         cres = corr.transform(kda.results)
@@ -119,7 +117,7 @@ for kt_name, kt in kernel_transformers.items():
 # --------------------------------------------------
 for kt_name, kt in kernel_transformers.items():
     try:
-        ale = nimare.meta.ALE(kernel_transformer=kt)
+        ale = nimare.meta.ALE(kernel_transformer=kt, null_method="analytic")
         ale.fit(dset)
         corr = nimare.correct.FWECorrector(method="montecarlo", n_iters=10, n_cores=1)
         cres = corr.transform(ale.results)

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -89,9 +89,7 @@ class CBMAEstimator(MetaEstimator):
             self._compute_null_analytic(ma_values)
 
         elif self.null_method == "empirical":
-            self._compute_null_empirical(
-                ma_values, n_iters=self.n_iters, n_cores=self.n_cores
-            )
+            self._compute_null_empirical(ma_values, n_iters=self.n_iters, n_cores=self.n_cores)
 
         else:
             self._compute_null_reduced_empirical(ma_values, n_iters=self.n_iters)
@@ -228,7 +226,7 @@ class CBMAEstimator(MetaEstimator):
             p_values = null_to_p(
                 stat_values,
                 self.null_distributions_["values_corr-none_method-reducedEmpirical"],
-                tail="upper"
+                tail="upper",
             )
 
         else:
@@ -537,8 +535,7 @@ class CBMAEstimator(MetaEstimator):
                 with mp.Pool(n_cores) as p:
                     perm_results = list(
                         tqdm(
-                            p.imap(self._correct_fwe_montecarlo_permutation, params),
-                            total=n_iters
+                            p.imap(self._correct_fwe_montecarlo_permutation, params), total=n_iters
                         )
                     )
 

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -89,7 +89,7 @@ class CBMAEstimator(MetaEstimator):
             self._compute_null_analytic(ma_values)
 
         elif self.null_method == "empirical":
-            self._compute_null_empirical(ma_values, n_iters=self.n_iters, n_cores=self.n_cores)
+            self._compute_null_empirical(n_iters=self.n_iters, n_cores=self.n_cores)
 
         else:
             self._compute_null_reduced_empirical(ma_values, n_iters=self.n_iters)

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -45,12 +45,18 @@ class MKDADensity(CBMAEstimator):
     """
 
     def __init__(
-        self, kernel_transformer=MKDAKernel, null_method="empirical", n_iters=10000, **kwargs
+        self,
+        kernel_transformer=MKDAKernel,
+        null_method="empirical",
+        n_iters=10000,
+        n_cores=1,
+        **kwargs,
     ):
         # Add kernel transformer attribute and process keyword arguments
         super().__init__(kernel_transformer=kernel_transformer, **kwargs)
         self.null_method = null_method
         self.n_iters = n_iters
+        self.n_cores = n_cores
         self.dataset = None
         self.results = None
 
@@ -488,7 +494,12 @@ class KDA(CBMAEstimator):
     """
 
     def __init__(
-        self, kernel_transformer=KDAKernel, null_method="empirical", n_iters=10000, **kwargs
+        self,
+        kernel_transformer=KDAKernel,
+        null_method="empirical",
+        n_iters=10000,
+        n_cores=1,
+        **kwargs,
     ):
         if not isinstance(kernel_transformer, KDAKernel):
             LGR.warning(
@@ -501,6 +512,7 @@ class KDA(CBMAEstimator):
         super().__init__(kernel_transformer=kernel_transformer, **kwargs)
         self.null_method = null_method
         self.n_iters = n_iters
+        self.n_cores = n_cores
         self.dataset = None
         self.results = None
 

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -86,7 +86,7 @@ class MKDADensity(CBMAEstimator):
         # return ma_values.T.dot(self.weight_vec_).ravel()
         weighted_ma_vals = ma_values * self.weight_vec_
         return weighted_ma_vals.sum(0)
-    
+
     def _determine_histogram_bins(self, ma_maps):
         """Determine histogram bins for null distribution methods.
 
@@ -104,7 +104,7 @@ class MKDADensity(CBMAEstimator):
             ma_values = ma_maps.copy()
         else:
             raise ValueError('Unsupported data type "{}"'.format(type(ma_maps)))
-    
+
         prop_active = ma_values.mean(1)
         self.null_distributions_["histogram_bins"] = np.arange(len(prop_active) + 1, step=1)
 
@@ -525,7 +525,7 @@ class KDA(CBMAEstimator):
         # OF is just a sum of MA values.
         stat_values = np.sum(ma_values, axis=0)
         return stat_values
-    
+
     def _determine_histogram_bins(self, ma_maps):
         """Determine histogram bins for null distribution methods.
 
@@ -543,7 +543,7 @@ class KDA(CBMAEstimator):
             ma_values = ma_maps.copy()
         else:
             raise ValueError('Unsupported data type "{}"'.format(type(ma_maps)))
-    
+
         # assumes that groupby results in same order as MA maps
         n_foci_per_study = self.inputs_["coordinates"].groupby("id").size().values
 
@@ -558,15 +558,11 @@ class KDA(CBMAEstimator):
             min_ma_values[i_study] = np.min(temp_ma_values[temp_ma_values != 0])
 
         step_size = np.mean(min_ma_values)  # typically 1
-        inv_step_size = int(np.ceil(1 / step_size))  # only useful when weight != 1
-
         max_ma_values = min_ma_values * n_foci_per_study
         max_poss_value = self._compute_summarystat(max_ma_values)
         # Weighting is not supported yet, so I'm going to build my bins around the min MA value.
         # The histogram bins are bin *centers*, not edges.
-        hist_bins = np.arange(
-            0, max_poss_value + (step_size * 1.5) + 0.001, step_size
-        )
+        hist_bins = np.arange(0, max_poss_value + (step_size * 1.5) + 0.001, step_size)
         self.null_distributions_["histogram_bins"] = hist_bins
 
     def _compute_null_analytic(self, ma_maps):
@@ -617,7 +613,7 @@ class KDA(CBMAEstimator):
             exp_idx = np.where(exp_hist > 0)[0]
 
             # Compute output MA values, stat_hist indices, and probabilities
-            stat_scores = np.add.outer(hist_bins[exp_idx], hist_bins[stat_idx]).ravel()
+            stat_scores = np.add.outer(bin_centers[exp_idx], bin_centers[stat_idx]).ravel()
             score_idx = np.floor(stat_scores * inv_step_size).astype(int)
             probabilities = np.outer(exp_hist[exp_idx], stat_hist[stat_idx]).ravel()
 

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -47,7 +47,7 @@ class MKDADensity(CBMAEstimator):
     def __init__(
         self,
         kernel_transformer=MKDAKernel,
-        null_method="empirical",
+        null_method="analytic",
         n_iters=10000,
         n_cores=1,
         **kwargs,
@@ -496,7 +496,7 @@ class KDA(CBMAEstimator):
     def __init__(
         self,
         kernel_transformer=KDAKernel,
-        null_method="empirical",
+        null_method="analytic",
         n_iters=10000,
         n_cores=1,
         **kwargs,

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -570,8 +570,10 @@ class KDA(CBMAEstimator):
             max_poss_value = self._compute_summarystat(max_ma_values)
         else:
             # Continuous-sphere kernels (ALE)
-            LGR.info("A non-binary kernel has been detected. Parameters for the null distribution "
-                     "will be guesstimated.")
+            LGR.info(
+                "A non-binary kernel has been detected. Parameters for the null distribution "
+                "will be guesstimated."
+            )
 
             N_BINS = 100000
             # The maximum possible MA value is the max value from each MA map,

--- a/nimare/tests/test_decode_continuous.py
+++ b/nimare/tests/test_decode_continuous.py
@@ -63,7 +63,7 @@ def test_CorrelationDistributionDecoder_smoke(testdata_laird, tmp_path_factory):
     decoder.fit(dset)
 
     # Make an image to decode
-    meta = mkda.KDA()
+    meta = mkda.KDA(null_method="analytic")
     res = meta.fit(testdata_laird)
     img = res.get_map("stat")
     decoded_df = decoder.transform(img)

--- a/nimare/tests/test_decode_continuous.py
+++ b/nimare/tests/test_decode_continuous.py
@@ -29,7 +29,7 @@ def test_CorrelationDecoder_smoke(testdata_laird, tmp_path_factory):
     decoder.fit(testdata_laird)
 
     # Make an image to decode
-    meta = mkda.KDA()
+    meta = mkda.KDA(null_method="analytic")
     res = meta.fit(testdata_laird)
     img = res.get_map("stat")
     decoded_df = decoder.transform(img)

--- a/nimare/tests/test_estimator_performance.py
+++ b/nimare/tests/test_estimator_performance.py
@@ -73,11 +73,14 @@ def signal_masks(simulatedata_cbma):
 @pytest.fixture(
     scope="session",
     params=[
-        pytest.param((ale.ALE, {"null_method": "empirical", "n_iters": 1000}), id="ale+empirical"),
+        pytest.param((ale.ALE, {"null_method": "empirical", "n_iters": 100}), id="ale+empirical"),
         pytest.param((ale.ALE, {"null_method": "analytic"}), id="ale+analytic"),
-        pytest.param((mkda.MKDADensity, {"null_method": "empirical"}), id="mkda+empirical"),
+        pytest.param(
+            (mkda.MKDADensity, {"null_method": "empirical", "n_iters": 100}), id="mkda+empirical"
+        ),
         pytest.param((mkda.MKDADensity, {"null_method": "analytic"}), id="mkda+analytic"),
-        pytest.param((mkda.KDA, {}), id="kda"),
+        pytest.param((mkda.KDA, {"null_method": "empirical", "n_iters": 100}), id="kda+empirical"),
+        pytest.param((mkda.KDA, {"null_method": "analytic"}), id="kda+analytic"),
     ],
 )
 def meta_est(request):

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -92,7 +92,7 @@ def test_ALE_empirical_null_unit(testdata_cbma, tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("test_ALE_empirical_null_unit")
     out_file = os.path.join(tmpdir, "file.pkl.gz")
 
-    meta = ale.ALE(null_method="empirical", n_iters=100)
+    meta = ale.ALE(null_method="empirical", n_iters=10)
     res = meta.fit(testdata_cbma)
     assert "stat" in res.maps.keys()
     assert "p" in res.maps.keys()

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -92,7 +92,7 @@ def test_ALE_empirical_null_unit(testdata_cbma, tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("test_ALE_empirical_null_unit")
     out_file = os.path.join(tmpdir, "file.pkl.gz")
 
-    meta = ale.ALE(null_method="empirical", n_iters=1000)
+    meta = ale.ALE(null_method="empirical", n_iters=100)
     res = meta.fit(testdata_cbma)
     assert "stat" in res.maps.keys()
     assert "p" in res.maps.keys()

--- a/nimare/tests/test_meta_mkda.py
+++ b/nimare/tests/test_meta_mkda.py
@@ -15,7 +15,7 @@ def test_mkda_density_kernel_instance_with_kwargs(testdata_cbma):
     object's parameters should remain untouched.
     """
     kern = MKDAKernel(r=2)
-    meta = MKDADensity(kern, kernel__r=6, null_method="empirical", n_iters=100)
+    meta = MKDADensity(kern, kernel__r=6, null_method="empirical", n_iters=10)
 
     assert meta.kernel_transformer.get_params().get("r") == 2
 
@@ -24,7 +24,7 @@ def test_mkda_density_kernel_class(testdata_cbma):
     """
     Smoke test for MKDADensity with a kernel transformer class.
     """
-    meta = MKDADensity(MKDAKernel, kernel__r=5, null_method="empirical", n_iters=100)
+    meta = MKDADensity(MKDAKernel, kernel__r=5, null_method="empirical", n_iters=10)
     res = meta.fit(testdata_cbma)
     assert isinstance(res, nimare.results.MetaResult)
 
@@ -34,7 +34,7 @@ def test_mkda_density_kernel_instance(testdata_cbma):
     Smoke test for MKDADensity with a kernel transformer object.
     """
     kern = MKDAKernel(r=5)
-    meta = MKDADensity(kern, null_method="empirical", n_iters=100)
+    meta = MKDADensity(kern, null_method="empirical", n_iters=10)
     res = meta.fit(testdata_cbma)
     assert isinstance(res, nimare.results.MetaResult)
 
@@ -55,7 +55,7 @@ def test_mkda_density(testdata_cbma):
     """
     Smoke test for MKDADensity
     """
-    meta = MKDADensity(null_method="empirical", n_iters=100)
+    meta = MKDADensity(null_method="empirical", n_iters=10)
     res = meta.fit(testdata_cbma)
     corr = FWECorrector(method="montecarlo", voxel_thresh=0.001, n_iters=5, n_cores=1)
     cres = corr.transform(res)
@@ -120,7 +120,7 @@ def test_kda_density_fwe_1core(testdata_cbma):
     """
     Smoke test for KDA with empirical null and FWE correction.
     """
-    meta = KDA(null_method="empirical", n_iters=100)
+    meta = KDA(null_method="empirical", n_iters=10)
     res = meta.fit(testdata_cbma)
     corr = FWECorrector(method="montecarlo", n_iters=5, n_cores=1)
     cres = corr.transform(res)
@@ -135,7 +135,7 @@ def test_kda_density_fwe_1core(testdata_cbma):
 
 def test_mkda_analytic_empirical_convergence(testdata_cbma_full):
     est_a = MKDADensity(null_method="analytic")
-    n_iters = 100
+    n_iters = 10
     est_e = MKDADensity(null_method="empirical", n_iters=n_iters)
     res_a = est_a.fit(testdata_cbma_full)
     res_e = est_e.fit(testdata_cbma_full)
@@ -152,7 +152,7 @@ def test_mkda_analytic_empirical_convergence(testdata_cbma_full):
 
 def test_kda_analytic_empirical_convergence(testdata_cbma_full):
     est_a = KDA(null_method="analytic")
-    n_iters = 100
+    n_iters = 10
     est_e = KDA(null_method="empirical", n_iters=n_iters)
     res_a = est_a.fit(testdata_cbma_full)
     res_e = est_e.fit(testdata_cbma_full)

--- a/nimare/tests/test_meta_mkda.py
+++ b/nimare/tests/test_meta_mkda.py
@@ -135,13 +135,13 @@ def test_kda_density_fwe_1core(testdata_cbma):
 
 def test_mkda_analytic_empirical_convergence(testdata_cbma_full):
     est_a = MKDADensity(null_method="analytic")
-    n_iter = 10000
-    est_e = MKDADensity(null_method="empirical", n_iter=n_iter)
+    n_iters = 100
+    est_e = MKDADensity(null_method="empirical", n_iters=n_iters)
     res_a = est_a.fit(testdata_cbma_full)
     res_e = est_e.fit(testdata_cbma_full)
     # Get smallest p-value above 0 from the empirical estimator; above this,
     # the two should converge reasonably closely.
-    min_p = 1 / n_iter
+    min_p = 1 / n_iters
     p_idx = res_e.maps["p"] > min_p
     p_analytical = res_a.maps["p"][p_idx]
     p_empirical = res_e.maps["p"][p_idx]
@@ -152,13 +152,13 @@ def test_mkda_analytic_empirical_convergence(testdata_cbma_full):
 
 def test_kda_analytic_empirical_convergence(testdata_cbma_full):
     est_a = KDA(null_method="analytic")
-    n_iter = 10000
-    est_e = KDA(null_method="empirical", n_iter=n_iter)
+    n_iters = 100
+    est_e = KDA(null_method="empirical", n_iters=n_iters)
     res_a = est_a.fit(testdata_cbma_full)
     res_e = est_e.fit(testdata_cbma_full)
     # Get smallest p-value above 0 from the empirical estimator; above this,
     # the two should converge reasonably closely.
-    min_p = 1 / n_iter
+    min_p = 1 / n_iters
     p_idx = res_e.maps["p"] > min_p
     p_analytical = res_a.maps["p"][p_idx]
     p_empirical = res_e.maps["p"][p_idx]


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #389.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add `_determine_histogram_bins()` method to CBMA Estimators. This method determines the bins for the analytic null and the full empirical null, but not the basic (single-coordinate) empirical null, which doesn't use a histogram.
- Add `_run_montecarlo_permutation()` and `_compute_null_reduced_empirical()` methods to base CBMAEstimator.
- Edit `_compute_null_empirical()` to run full coordinate-set method.
- Add `vfwe_only` parameter to the standard Monte Carlo permutation method for FWE correction.
- Directly infer the weighting factor for the kernel in the KDA estimator instead of trying to guess it from MA values.
    - This is currently incompatible with continuous kernels, but I may change that before merging this PR.
