### PR TITLE
[FIX] Fix the warnings about mismatched kernels and estimators

### DIFF
--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -84,7 +84,7 @@ class ALE(CBMAEstimator):
     def __init__(
         self, kernel_transformer=ALEKernel, null_method="analytic", n_iters=10000, **kwargs
     ):
-        if not isinstance(kernel_transformer, ALEKernel):
+        if not (isinstance(kernel_transformer, ALEKernel) or kernel_transformer == ALEKernel):
             LGR.warning(
                 f"The KernelTransformer being used ({kernel_transformer}) is not optimized "
                 f"for the {type(self).__name__} algorithm. "
@@ -219,7 +219,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
     """
 
     def __init__(self, kernel_transformer=ALEKernel, n_iters=10000, low_memory=False, **kwargs):
-        if not isinstance(kernel_transformer, ALEKernel):
+        if not (isinstance(kernel_transformer, ALEKernel) or kernel_transformer == ALEKernel):
             LGR.warning(
                 f"The KernelTransformer being used ({kernel_transformer}) is not optimized "
                 f"for the {type(self).__name__} algorithm. "
@@ -347,7 +347,7 @@ class SCALE(CBMAEstimator):
         low_memory=False,
         **kwargs,
     ):
-        if not isinstance(kernel_transformer, ALEKernel):
+        if not (isinstance(kernel_transformer, ALEKernel) or kernel_transformer == ALEKernel):
             LGR.warning(
                 f"The KernelTransformer being used ({kernel_transformer}) is not optimized "
                 f"for the {type(self).__name__} algorithm. "

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -47,6 +47,13 @@ class MKDADensity(CBMAEstimator):
     def __init__(
         self, kernel_transformer=MKDAKernel, null_method="empirical", n_iters=10000, **kwargs
     ):
+        if not (isinstance(kernel_transformer, MKDAKernel) or kernel_transformer == MKDAKernel):
+            LGR.warning(
+                f"The KernelTransformer being used ({kernel_transformer}) is not optimized "
+                f"for the {type(self).__name__} algorithm. "
+                "Expect suboptimal performance and beware bugs."
+            )
+
         # Add kernel transformer attribute and process keyword arguments
         super().__init__(kernel_transformer=kernel_transformer, **kwargs)
         self.null_method = null_method
@@ -149,7 +156,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
     """
 
     def __init__(self, kernel_transformer=MKDAKernel, prior=0.5, **kwargs):
-        if not isinstance(kernel_transformer, MKDAKernel):
+        if not (isinstance(kernel_transformer, MKDAKernel) or kernel_transformer == MKDAKernel):
             LGR.warning(
                 f"The KernelTransformer being used ({kernel_transformer}) is not optimized "
                 f"for the {type(self).__name__} algorithm. "
@@ -469,7 +476,7 @@ class KDA(CBMAEstimator):
     def __init__(
         self, kernel_transformer=KDAKernel, null_method="empirical", n_iters=10000, **kwargs
     ):
-        if not isinstance(kernel_transformer, KDAKernel):
+        if not (isinstance(kernel_transformer, KDAKernel) or kernel_transformer == KDAKernel):
             LGR.warning(
                 f"The KernelTransformer being used ({kernel_transformer}) is not optimized "
                 f"for the {type(self).__name__} algorithm. "


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None, but fixes a documentation bug I introduced in #416.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Check kernel transformer as both an instance and a class. Before it just checked for instances.
