### PR TITLE
[FIX] Convert histogram weights to null distribution in p-to-stat conversion

### DIFF
--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -260,10 +260,16 @@ class CBMAEstimator(MetaEstimator):
             assert "histogram_bins" in self.null_distributions_.keys()
             assert "histogram_weights" in self.null_distributions_.keys()
 
-            hist_weights = self.null_distributions_["histogram_weights"]
+            # Convert unnormalized histogram weights to null distribution
+            histogram_weights = self.null_distributions_["histogram_weights"]
+            null_distribution = histogram_weights / np.sum(histogram_weights)
+            null_distribution = np.cumsum(null_distribution[::-1])[::-1]
+            null_distribution /= np.max(null_distribution)
+            null_distribution = np.squeeze(null_distribution)
+
             # Desired bin is the first one _before_ the target p-value (for consistency
             # with the empirical null).
-            ss_idx = np.maximum(0, np.where(hist_weights <= p)[0][0] - 1)
+            ss_idx = np.maximum(0, np.where(null_distribution <= p)[0][0] - 1)
             ss = self.null_distributions_["histogram_bins"][ss_idx]
 
         elif null_method == "empirical":


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #429. Essentially, in #409, I changed the internal storage of the analytic null from a null distribution (i.e., normalized reversed cumulatively summed histogram weights) to the raw histogram weights, with the conversion to a null distribution happening in `stats.nullhist_to_p()`. However, I neglected to _also_ update `CBMAEstimator._p_to_summarystat()`, which uses the same attribute.

As a result, cFWE-corrected maps were empty.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Convert the analytic null histogram weights to a null distribution before calculating the appropriate summary statistic in `CBMAEstimator._p_to_summarystat()`.
