### PR TITLE
[FIX,REF] start changing how to handle resampling

### DIFF
--- a/nimare/base.py
+++ b/nimare/base.py
@@ -290,9 +290,9 @@ class MetaEstimator(Estimator):
         self.resample = kwargs.get("resample", False)
 
         # defaults for resampling images (nilearn's defaults do not work well)
-        self.resample_kwargs = kwargs.get(
-            "resample_kwargs", {"clip": True, "interpolation": "linear"}
-        )
+        self.resample_kwargs = {
+            k.split("resample__")[1]: v for k, v in kwargs.items() if k.startswith("resample__")
+        } or {"clip": True, "interpolation": "linear"}
 
     def _preprocess_input(self, dataset):
         """Preprocess inputs to the Estimator from the Dataset as needed."""

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -287,24 +287,23 @@ class MetaEstimator(Estimator):
             mask = get_masker(mask)
         self.masker = mask
 
-    def _preprocess_input(self, dataset, resample=False, **resample_kwargs):
+        self.resample = kwargs.get("resample", False)
+
+        # defaults for resampling images (nilearn's defaults do not work well)
+        self.resample_kwargs = kwargs.get(
+            "resample_kwargs", {"clip": True, "interpolation": "linear"}
+        )
+
+    def _preprocess_input(self, dataset):
         """Preprocess inputs to the Estimator from the Dataset as needed."""
         masker = self.masker or dataset.masker
         for name, (type_, _) in self._required_inputs.items():
             if type_ == "image":
-                # Mask required input images using either the dataset's mask or
-                # the estimator's.
-                # make this explicit instead of implicit
-                # resample_imgs = True
                 # If no resampling is requested, check if resampling is required
-                if not resample:
+                if not self.resample:
                     check_imgs = {img: nb.load(img) for img in self.inputs_[name]}
-                    check_imgs['reference_masker'] = masker.mask_img
+                    check_imgs["reference_masker"] = masker.mask_img
                     _check_same_fov(**check_imgs, raise_error=True)
-
-                # defaults for resampling images (nilearn's defaults do not work well)
-                if not resample_kwargs:
-                    resample_kwargs = {'clip': True, interpolation: 'linear'}
 
                 # resampling will only occur if shape/affines are different
                 # making this harmless if all img shapes/affines are the same
@@ -313,9 +312,10 @@ class MetaEstimator(Estimator):
                     resample_to_img(nb.load(img), masker.mask_img, **resample_kwargs)
                     for img in self.inputs_[name]
                 ]
-                temp_arr = np.vstack(
-                    [masker.transform(img) for img in imgs]
-                )
+
+                # Mask required input images using either the dataset's mask or
+                # the estimator's.
+                temp_arr = np.vstack([masker.transform(img) for img in imgs])
 
                 # An intermediate step to mask out bad voxels. Can be dropped
                 # once PyMARE is able to handle masked arrays or missing data.

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -9,7 +9,7 @@ import pickle
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
-from nilearn.image import resample_to_img
+from nilearn.image import resample_to_img, concat_imgs
 from nilearn._utils.niimg_conversions import _check_same_fov
 
 import nibabel as nb
@@ -321,9 +321,12 @@ class MetaEstimator(Estimator):
                         for img in self.inputs_[name]
                     ]
 
+                # input to NiFtiLabelsMasker must be 4d
+                img4d = concat_imgs(imgs, ensure_ndim=4)
+
                 # Mask required input images using either the dataset's mask or
                 # the estimator's.
-                temp_arr = np.vstack([masker.transform(img) for img in imgs])
+                temp_arr = masker.transform(img4d)
 
                 # An intermediate step to mask out bad voxels. Can be dropped
                 # once PyMARE is able to handle masked arrays or missing data.

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -9,11 +9,10 @@ import pickle
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 
-from nilearn.image import resample_to_img, concat_imgs
-from nilearn._utils.niimg_conversions import _check_same_fov
-
 import nibabel as nb
 import numpy as np
+from nilearn._utils.niimg_conversions import _check_same_fov
+from nilearn.image import concat_imgs, resample_to_img
 
 from .results import MetaResult
 from .utils import get_masker

--- a/nimare/tests/conftest.py
+++ b/nimare/tests/conftest.py
@@ -6,6 +6,8 @@ from shutil import copyfile
 
 import pytest
 import nibabel as nib
+import numpy as np
+from nilearn.image import resample_img
 
 import nimare
 from nimare.tests.utils import get_test_data_path
@@ -79,3 +81,40 @@ def mni_mask():
     return nib.load(
         os.path.join(get_resource_path(), "templates", "MNI152_2x2x2_brainmask.nii.gz")
     )
+
+
+@pytest.fixture(scope="session")
+def testdata_ibma_resample(tmp_path_factory):
+    tmpdir = tmp_path_factory.mktemp("testdata_ibma_resample")
+
+    # Load dataset
+    dset_file = os.path.join(get_test_data_path(), "test_pain_dataset.json")
+    dset_dir = os.path.join(get_test_data_path(), "test_pain_dataset")
+    mask_file = os.path.join(dset_dir, "mask.nii.gz")
+    dset = nimare.dataset.Dataset(dset_file, mask=mask_file)
+    dset.update_path(dset_dir)
+    # Move image contents of Dataset to temporary directory
+    for c in dset.images.columns:
+        if c.endswith("__relative"):
+            continue
+        for f in dset.images[c].values:
+            if (f is None) or not os.path.isfile(f):
+                continue
+            new_f = f.replace(
+                dset_dir.rstrip(os.path.sep), str(tmpdir.absolute()).rstrip(os.path.sep)
+            )
+            dirname = os.path.dirname(new_f)
+            if not os.path.isdir(dirname):
+                os.makedirs(dirname)
+            # create random affine to make images different shapes
+            affine = np.eye(3)
+            np.fill_diagonal(affine, np.random.choice([1, 2, 3]))
+            img = resample_img(
+                nib.load(f),
+                target_affine=affine,
+                interpolation="linear",
+                clip=True,
+            )
+            nib.save(img, new_f)
+    dset.update_path(tmpdir)
+    return dset

--- a/nimare/tests/conftest.py
+++ b/nimare/tests/conftest.py
@@ -93,6 +93,9 @@ def testdata_ibma_resample(tmp_path_factory):
     mask_file = os.path.join(dset_dir, "mask.nii.gz")
     dset = nimare.dataset.Dataset(dset_file, mask=mask_file)
     dset.update_path(dset_dir)
+
+    # create reproducible random number generator for resampling
+    rng = np.random.default_rng(seed=123)
     # Move image contents of Dataset to temporary directory
     for c in dset.images.columns:
         if c.endswith("__relative"):
@@ -108,7 +111,7 @@ def testdata_ibma_resample(tmp_path_factory):
                 os.makedirs(dirname)
             # create random affine to make images different shapes
             affine = np.eye(3)
-            np.fill_diagonal(affine, np.random.choice([1, 2, 3]))
+            np.fill_diagonal(affine, rng.choice([1, 2, 3]))
             img = resample_img(
                 nib.load(f),
                 target_affine=affine,

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -145,11 +145,15 @@ def test_ibma_with_custom_masker(testdata_ibma):
         (False, {}, pytest.raises(ValueError)),
         (None, {}, pytest.raises(ValueError)),
         (True, {}, does_not_raise()),
-        (True, {"clip": False, "interpolation": "continuous"}, does_not_raise()),
+        (
+            True,
+            {"resample__clip": False, "resample__interpolation": "continuous"},
+            does_not_raise(),
+        ),
     ],
 )
 def test_ibma_resampling(testdata_ibma_resample, resample, resample_kwargs, expectation):
-    meta = ibma.Fishers(resample=resample, resample_kwargs=resample_kwargs)
+    meta = ibma.Fishers(resample=resample, **resample_kwargs)
     with expectation:
         meta.fit(testdata_ibma_resample)
     if isinstance(expectation, does_not_raise):


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #438

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- check if resampling is necessary (and raise error if resampling is not requested)
- add resampling kwargs for user flexibility
- TODO: decide where to pass resampling arguments (should they be passed through the `fit` method or should we make it a part of initializing the estimator object so the user's decision is saved in a more permanent way? and to keep the `fit` method clean)
