### PR TITLE
[FIX] Permutation p-values

### DIFF
--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -316,8 +316,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
         p_arr = np.ones(n_voxels)
         for voxel in range(n_voxels):
             p_arr[voxel] = null_to_p(
-                diff_ale_values[voxel], iter_diff_values[:, voxel], tail="two",
-                symmetric=True
+                diff_ale_values[voxel], iter_diff_values[:, voxel], tail="two", symmetric=True
             )
         diff_signs = np.sign(diff_ale_values - np.median(iter_diff_values, axis=0))
 

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -316,7 +316,8 @@ class ALESubtraction(PairwiseCBMAEstimator):
         p_arr = np.ones(n_voxels)
         for voxel in range(n_voxels):
             p_arr[voxel] = null_to_p(
-                diff_ale_values[voxel], iter_diff_values[:, voxel], tail="two"
+                diff_ale_values[voxel], iter_diff_values[:, voxel], tail="two",
+                symmetric=True
             )
         diff_signs = np.sign(diff_ale_values - np.median(iter_diff_values, axis=0))
 

--- a/nimare/stats.py
+++ b/nimare/stats.py
@@ -3,7 +3,6 @@ import logging
 import warnings
 
 import numpy as np
-from scipy import stats
 
 from . import utils
 
@@ -149,7 +148,7 @@ def null_to_p(test_value, null_array, tail="two", symmetric=False):
     approximately twice as efficient computationally, and has lower variance.
     """
 
-    if tail not in {'two', 'upper', 'lower'}:
+    if tail not in {"two", "upper", "lower"}:
         raise ValueError('Argument "tail" must be one of ["two", "upper", "lower"]')
 
     return_first = isinstance(test_value, (float, int))
@@ -166,7 +165,7 @@ def null_to_p(test_value, null_array, tail="two", symmetric=False):
 
     def compute_p(t, null):
         null = np.sort(null)
-        idx = np.searchsorted(null, t, side='left').astype(float)
+        idx = np.searchsorted(null, t, side="left").astype(float)
         return 1 - idx / len(null)
 
     if tail == "two":

--- a/nimare/stats.py
+++ b/nimare/stats.py
@@ -110,7 +110,7 @@ def pearson(x, y):
     return rs
 
 
-def null_to_p(test_value, null_array, tail="two"):
+def null_to_p(test_value, null_array, tail="two", symmetric=False):
     """Return p-value for test value(s) against null array.
 
     Parameters
@@ -125,17 +125,28 @@ def null_to_p(test_value, null_array, tail="two"):
         If 'upper', then higher values for the test_value are more significant.
         If 'lower', then lower values for the test_value are more significant.
         Default is 'two'.
+    symmetric : bool
+        When tail="two", indicates how to compute p-values. When False (default),
+        both one-tailed p-values are computed, and the two-tailed p is double
+        the minimum one-tailed p. When True, it is assumed that the null
+        distribution is zero-centered and symmetric, and the two-tailed p-value
+        is computed as P(abs(test_value) >= abs(null_array)).
 
     Returns
     -------
     p_value : :obj:`float`
-        P-value associated with the test value when compared against the null
-        distribution.
+        P-value(s) associated with the test value when compared against the null
+        distribution. Return type matches input type (i.e., a float if
+        test_value is a single float, and an array if test_value is an array).
 
     Notes
     -----
     P-values are clipped based on the number of elements in the null array.
     Therefore no p-values of 0 or 1 should be produced.
+
+    When the null distribution is known to be symmetric and centered on zero,
+    and two-tailed p-values are desired, use symmetric=True, as it is
+    approximately twice as efficient computationally, and has lower variance.
     """
 
     if tail not in {'two', 'upper', 'lower'}:
@@ -153,16 +164,22 @@ def null_to_p(test_value, null_array, tail="two"):
     else:
         reconstruct = False
 
-    if tail == "two":
-        test_value = np.abs(test_value)
-        null_array = np.abs(null_array)
-    elif tail == "lower":
-        test_value *= -1
-        null_array *= -1
+    def compute_p(t, null):
+        null = np.sort(null)
+        idx = np.searchsorted(null, t, side='left').astype(float)
+        return 1 - idx / len(null)
 
-    null_array = np.sort(null_array)
-    idx = np.searchsorted(null_array, test_value, side='left').astype(float)
-    p = 1 - idx / len(null_array)
+    if tail == "two":
+        if symmetric:
+            p = compute_p(np.abs(test_value), np.abs(null_array))
+        else:
+            p_l = compute_p(test_value, null_array)
+            p_r = compute_p(test_value * -1, null_array * -1)
+            p = 2 * np.minimum(p_l, p_r)
+    elif tail == "lower":
+        p = compute_p(test_value * -1, null_array * -1)
+    else:
+        p = compute_p(test_value, null_array)
 
     # ensure p_value in the following range:
     # smallest_value <= p_value <= (1.0 - smallest_value)

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -5,34 +5,55 @@ import math
 
 import numpy as np
 
-from nimare import stats
+from nimare.stats import null_to_p, nullhist_to_p
 
 
-def test_null_to_p():
-    """
-    Test nimare.stats.null_to_p.
-    """
-    data = np.arange(1, 101)
-    assert math.isclose(stats.null_to_p(0, data, "lower"), 0.01)
-    assert math.isclose(stats.null_to_p(0, data, "upper"), 0.99)
-    assert math.isclose(stats.null_to_p(0, data, "two"), 0.01)
-    assert math.isclose(stats.null_to_p(5.1, data, "lower"), 0.05)
-    assert math.isclose(stats.null_to_p(5.1, data, "upper"), 0.95)
-    assert math.isclose(stats.null_to_p(5.1, data, "two"), 0.1)
-    assert math.isclose(stats.null_to_p(95.1, data, "lower"), 0.95)
-    assert math.isclose(stats.null_to_p(95.1, data, "upper"), 0.05)
-    assert math.isclose(stats.null_to_p(95.1, data, "two"), 0.1)
-    assert math.isclose(stats.null_to_p(101.1, data, "lower"), 0.99)
-    assert math.isclose(stats.null_to_p(101.1, data, "upper"), 0.01)
-    assert math.isclose(stats.null_to_p(101.1, data, "two"), 0.01)
+def test_null_to_p_float():
+    """Test nimare.stats.null_to_p with single float input."""
 
-    # modify data to handle edge case
-    data[98] = 100
-    assert math.isclose(stats.null_to_p(1, data, "lower"), 0.01)
-    assert math.isclose(stats.null_to_p(1, data, "upper"), 0.99)
-    assert math.isclose(stats.null_to_p(100.1, data, "lower"), 0.99)
-    assert math.isclose(stats.null_to_p(100.1, data, "upper"), 0.01)
-    assert math.isclose(stats.null_to_p(100.1, data, "two"), 0.01)
+    null = [-10, -9, -9, -3, -2, -1, -1, 0, 1, 1, 1, 2, 3, 3, 4, 4, 7, 8, 8, 9]
+
+    # Two-tailed
+    assert math.isclose(null_to_p(0, null, "two"), 0.95)
+    result = null_to_p(9, null, "two")
+    assert result == null_to_p(-9, null, "two")
+    assert math.isclose(result, 0.2)
+    result = null_to_p(10, null, "two")
+    assert result == null_to_p(-10, null, "two")
+    assert math.isclose(result, 0.05)
+    # Still 0.05 because minimum valid p-value is 1 / len(null)
+    result = null_to_p(20, null, "two")
+    assert result == null_to_p(-20, null, "two")
+    assert math.isclose(result, 0.05)
+
+    # Left/lower-tailed
+    assert math.isclose(null_to_p(9, null, "lower"), 0.95)
+    assert math.isclose(null_to_p(-9, null, "lower"), 0.15)
+    assert math.isclose(null_to_p(0, null, "lower"), 0.4)
+
+    # Right/upper-tailed
+    assert math.isclose(null_to_p(9, null, "upper"), 0.05)
+    assert math.isclose(null_to_p(-9, null, "upper"), 0.95)
+    assert math.isclose(null_to_p(0, null, "upper"), 0.65)
+
+    # Test that 1/n(null) is preserved with extreme values
+    nulldist = np.random.normal(size=10000)
+    assert math.isclose(null_to_p(20, nulldist, "two"), 1/10000)
+    assert math.isclose(null_to_p(20, nulldist, "lower"), 1 - 1/10000)
+
+
+def test_null_to_p_array():
+    """Test nimare.stats.null_to_p with 1d array input."""
+    N = 10000
+    nulldist = np.random.normal(size=N)
+    t = np.sort(np.random.normal(size=N))
+    p = np.sort(null_to_p(t, nulldist))
+    assert p.shape == (N,)
+    assert (p < 1).all()
+    assert (p > 0).all()
+    # Resulting distribution should be roughly uniform
+    assert np.abs(p.mean() - 0.5) < 0.02
+    assert np.abs(p.var() - 1/12) < 0.02
 
 
 def test_nullhist_to_p():
@@ -45,14 +66,14 @@ def test_nullhist_to_p():
     histogram_weights[-1] = 0  # last bin is outside range, so there are 100 bins with values
 
     # When input is a single value
-    assert math.isclose(stats.nullhist_to_p(0, histogram_weights, histogram_bins), 1.0)
-    assert math.isclose(stats.nullhist_to_p(1, histogram_weights, histogram_bins), 0.99)
-    assert math.isclose(stats.nullhist_to_p(99, histogram_weights, histogram_bins), 0.01)
-    assert math.isclose(stats.nullhist_to_p(100, histogram_weights, histogram_bins), 0.01)
+    assert math.isclose(nullhist_to_p(0, histogram_weights, histogram_bins), 1.0)
+    assert math.isclose(nullhist_to_p(1, histogram_weights, histogram_bins), 0.99)
+    assert math.isclose(nullhist_to_p(99, histogram_weights, histogram_bins), 0.01)
+    assert math.isclose(nullhist_to_p(100, histogram_weights, histogram_bins), 0.01)
 
     # When input is an array
     assert np.allclose(
-        stats.nullhist_to_p([0, 1, 99, 100, 101], histogram_weights, histogram_bins),
+        nullhist_to_p([0, 1, 99, 100, 101], histogram_weights, histogram_bins),
         np.array([1.0, 0.99, 0.01, 0.01, 0.01]),
     )
 
@@ -61,6 +82,6 @@ def test_nullhist_to_p():
     histogram_weights[-1, :] = 0  # last bin is outside range, so there are 100 bins with values
 
     assert np.allclose(
-        stats.nullhist_to_p([0, 1, 99, 100, 101], histogram_weights, histogram_bins),
+        nullhist_to_p([0, 1, 99, 100, 101], histogram_weights, histogram_bins),
         np.array([1.0, 0.99, 0.01, 0.01, 0.01]),
     )

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -3,7 +3,6 @@ Test nimare.stats
 """
 import math
 
-import pytest
 import numpy as np
 
 from nimare.stats import null_to_p, nullhist_to_p
@@ -37,8 +36,8 @@ def test_null_to_p_float():
 
     # Test that 1/n(null) is preserved with extreme values
     nulldist = np.random.normal(size=10000)
-    assert math.isclose(null_to_p(20, nulldist, "two"), 1/10000)
-    assert math.isclose(null_to_p(20, nulldist, "lower"), 1 - 1/10000)
+    assert math.isclose(null_to_p(20, nulldist, "two"), 1 / 10000)
+    assert math.isclose(null_to_p(20, nulldist, "lower"), 1 - 1 / 10000)
 
 
 def test_null_to_p_float_symmetric():
@@ -71,7 +70,7 @@ def test_null_to_p_array():
     assert (p > 0).all()
     # Resulting distribution should be roughly uniform
     assert np.abs(p.mean() - 0.5) < 0.02
-    assert np.abs(p.var() - 1/12) < 0.02
+    assert np.abs(p.var() - 1 / 12) < 0.02
 
 
 def test_nullhist_to_p():

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -3,24 +3,23 @@ Test nimare.stats
 """
 import math
 
+import pytest
 import numpy as np
 
 from nimare.stats import null_to_p, nullhist_to_p
 
 
 def test_null_to_p_float():
-    """Test nimare.stats.null_to_p with single float input."""
+    """Test null_to_p with single float input, assuming asymmetric null dist."""
 
     null = [-10, -9, -9, -3, -2, -1, -1, 0, 1, 1, 1, 2, 3, 3, 4, 4, 7, 8, 8, 9]
 
     # Two-tailed
-    assert math.isclose(null_to_p(0, null, "two"), 0.95)
-    result = null_to_p(9, null, "two")
-    assert result == null_to_p(-9, null, "two")
-    assert math.isclose(result, 0.2)
-    result = null_to_p(10, null, "two")
-    assert result == null_to_p(-10, null, "two")
-    assert math.isclose(result, 0.05)
+    assert math.isclose(null_to_p(0, null, "two"), 0.8)
+    assert math.isclose(null_to_p(9, null, "two"), 0.1)
+    assert math.isclose(null_to_p(10, null, "two"), 0.05)
+    assert math.isclose(null_to_p(-9, null, "two"), 0.3)
+    assert math.isclose(null_to_p(-10, null, "two"), 0.1)
     # Still 0.05 because minimum valid p-value is 1 / len(null)
     result = null_to_p(20, null, "two")
     assert result == null_to_p(-20, null, "two")
@@ -40,6 +39,25 @@ def test_null_to_p_float():
     nulldist = np.random.normal(size=10000)
     assert math.isclose(null_to_p(20, nulldist, "two"), 1/10000)
     assert math.isclose(null_to_p(20, nulldist, "lower"), 1 - 1/10000)
+
+
+def test_null_to_p_float_symmetric():
+    """Test null_to_p with single float input, assuming symmetric null dist."""
+
+    null = [-10, -9, -9, -3, -2, -1, -1, 0, 1, 1, 1, 2, 3, 3, 4, 4, 7, 8, 8, 9]
+
+    # Only need to test two-tailed; symmetry is irrelevant for one-tailed
+    assert math.isclose(null_to_p(0, null, "two", symmetric=True), 0.95)
+    result = null_to_p(9, null, "two", symmetric=True)
+    assert result == null_to_p(-9, null, "two", symmetric=True)
+    assert math.isclose(result, 0.2)
+    result = null_to_p(10, null, "two", symmetric=True)
+    assert result == null_to_p(-10, null, "two", symmetric=True)
+    assert math.isclose(result, 0.05)
+    # Still 0.05 because minimum valid p-value is 1 / len(null)
+    result = null_to_p(20, null, "two", symmetric=True)
+    assert result == null_to_p(-20, null, "two", symmetric=True)
+    assert math.isclose(result, 0.05)
 
 
 def test_null_to_p_array():


### PR DESCRIPTION
Fixes the issue identified in #442, which turned out to stem from a bug in `stats.null_to_p`. I replaced the previous call to `scipy.stats.percentileofscore` with an alternative approach that relies on `np.searchsorted`; this approach has the benefit of being vectorized, so it should be much faster in cases where the null distribution is IID across voxels (though it won't help, and might even slow things down slightly, in cases where we need to loop in order to generate a different null distribution for each voxel).

I also updated/improved the tests to make sure they cover common use cases.

Closes #442.