### PR TITLE
[ENH] Add low-memory option for kernel transformers

### DIFF
--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -143,7 +143,7 @@ class CorrelationDecoder(Decoder):
     ):
 
         if meta_estimator is None:
-            meta_estimator = MKDAChi2()
+            meta_estimator = MKDAChi2(kernel__low_memory=True)
 
         self.feature_group = feature_group
         self.features = features

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -225,6 +225,9 @@ class ALEKernel(KernelTransformer):
         formulae from Eickhoff et al. (2012). This sample size overwrites
         the Contrast-specific sample sizes in the dataset, in order to hold
         kernel constant across Contrasts. Mutually exclusive with ``fwhm``.
+    low_memory : :obj:`bool`, optional
+        Whether to employ mem-mapped arrays to reduce memory usage or not.
+        Default=False.
     """
 
     def __init__(self, fwhm=None, sample_size=None, low_memory=False):
@@ -243,9 +246,7 @@ class ALEKernel(KernelTransformer):
             from tempfile import mkdtemp
 
             filename = os.path.join(mkdtemp(), "kda_ma_values.dat")
-            transformed = np.memmap(
-                filename, dtype=float, mode="w+", shape=transformed_shape
-            )
+            transformed = np.memmap(filename, dtype=float, mode="w+", shape=transformed_shape)
         else:
             transformed = np.zeros(transformed_shape, dtype=float)
 
@@ -284,8 +285,6 @@ class ALEKernel(KernelTransformer):
                 # Write changes to disk
                 transformed.flush()
 
-            exp_ids.append(id_)
-
         return transformed, exp_ids
 
 
@@ -298,6 +297,9 @@ class KDAKernel(KernelTransformer):
         Sphere radius, in mm.
     value : :obj:`int`, optional
         Value for sphere.
+    low_memory : :obj:`bool`, optional
+        Whether to employ mem-mapped arrays to reduce memory usage or not.
+        Default=False.
     """
 
     _sum_overlap = True
@@ -336,6 +338,9 @@ class MKDAKernel(KDAKernel):
         Sphere radius, in mm.
     value : :obj:`int`, optional
         Value for sphere.
+    low_memory : :obj:`bool`, optional
+        Whether to employ mem-mapped arrays to reduce memory usage or not.
+        Default=False.
     """
 
     _sum_overlap = False

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -245,7 +245,7 @@ class ALEKernel(KernelTransformer):
             # Use a memmapped 4D array
             from tempfile import mkdtemp
 
-            filename = os.path.join(mkdtemp(), "kda_ma_values.dat")
+            filename = os.path.join(mkdtemp(), "ale_ma_values.dat")
             transformed_shape = (len(exp_ids),) + mask.shape
             transformed = np.memmap(filename, dtype=float, mode="w+", shape=transformed_shape)
         else:
@@ -285,7 +285,10 @@ class ALEKernel(KernelTransformer):
             else:
                 transformed.append((kernel_data, id_))
 
-        return transformed, exp_ids
+        if self.low_memory:
+            return transformed, exp_ids
+        else:
+            return transformed
 
 
 class KDAKernel(KernelTransformer):

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -241,7 +241,7 @@ class ALEKernel(KernelTransformer):
         kernels = {}  # retain kernels in dictionary to speed things up
         exp_ids = coordinates["id"].unique()
 
-        transformed_shape = mask.shape + (len(exp_ids),)
+        transformed_shape = (len(exp_ids),) + mask.shape
         if self.low_memory:
             from tempfile import mkdtemp
 
@@ -280,7 +280,7 @@ class ALEKernel(KernelTransformer):
                 else:
                     kern = kernels[sample_size]
             kernel_data = compute_ale_ma(mask.shape, ijk, kern)
-            transformed[:, :, :, i_exp] = kernel_data
+            transformed[i_exp, :, :, :] = kernel_data
             if self.low_memory:
                 # Write changes to disk
                 transformed.flush()

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -224,11 +224,12 @@ class ALEKernel(KernelTransformer):
         kernel constant across Contrasts. Mutually exclusive with ``fwhm``.
     """
 
-    def __init__(self, fwhm=None, sample_size=None):
+    def __init__(self, fwhm=None, sample_size=None, low_memory=False):
         if fwhm is not None and sample_size is not None:
             raise ValueError('Only one of "fwhm" and "sample_size" may be provided.')
         self.fwhm = fwhm
         self.sample_size = sample_size
+        self.low_memory = low_memory
 
     def _transform(self, mask, coordinates):
         transformed = []
@@ -273,9 +274,10 @@ class KDAKernel(KernelTransformer):
 
     _sum_overlap = True
 
-    def __init__(self, r=10, value=1):
+    def __init__(self, r=10, value=1, low_memory=False):
         self.r = float(r)
         self.value = value
+        self.low_memory = low_memory
 
     def _transform(self, mask, coordinates):
         dims = mask.shape
@@ -284,7 +286,14 @@ class KDAKernel(KernelTransformer):
         ijks = coordinates[["i", "j", "k"]].values
         exp_idx = coordinates["id"].values
         transformed = compute_kda_ma(
-            dims, vox_dims, ijks, self.r, self.value, exp_idx, sum_overlap=self._sum_overlap
+            dims,
+            vox_dims,
+            ijks,
+            self.r,
+            self.value,
+            exp_idx,
+            sum_overlap=self._sum_overlap,
+            low_memory=self.low_memory,
         )
         exp_ids = np.unique(exp_idx)
         return transformed, exp_ids

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -257,7 +257,9 @@ def compute_p2m_ma(
     return niis
 
 
-def compute_kda_ma(shape, vox_dims, ijks, r, value=1.0, exp_idx=None, sum_overlap=False, low_memory=False):
+def compute_kda_ma(
+    shape, vox_dims, ijks, r, value=1.0, exp_idx=None, sum_overlap=False, low_memory=False
+):
     """Compute (M)KDA modeled activation (MA) map.
 
     Replaces the values around each focus in ijk with binary sphere.
@@ -298,14 +300,12 @@ def compute_kda_ma(shape, vox_dims, ijks, r, value=1.0, exp_idx=None, sum_overla
     uniq, exp_idx = np.unique(exp_idx, return_inverse=True)
     n_studies = len(uniq)
 
-    kernel_shape = [n_studies] + list(shape)
+    kernel_shape = (n_studies,) + shape
     if low_memory:
         from tempfile import mkdtemp
 
         filename = os.path.join(mkdtemp(), "kda_ma_values.dat")
-        kernel_data = np.memmap(
-            filename, dtype=type(value), mode="w+", shape=kernel_shape
-        )
+        kernel_data = np.memmap(filename, dtype=type(value), mode="w+", shape=kernel_shape)
     else:
         kernel_data = np.zeros(kernel_shape, dtype=type(value))
 

--- a/nimare/tests/test_estimator_performance.py
+++ b/nimare/tests/test_estimator_performance.py
@@ -167,9 +167,9 @@ def meta(simulatedata_cbma, meta_est, kern, meta_params):
     """Define estimator/kernel combinations for tests."""
     fwhm, (_, _) = simulatedata_cbma
     if kern == kernel.KDAKernel or kern == kernel.MKDAKernel:
-        kern = kern(r=fwhm / 2)
+        kern = kern(r=fwhm / 2, low_memory=True)
     else:
-        kern = kern()
+        kern = kern(low_memory=True)
 
     # instantiate meta-analysis estimator
     return meta_est(kern, **meta_params)

--- a/nimare/tests/test_estimator_performance.py
+++ b/nimare/tests/test_estimator_performance.py
@@ -167,9 +167,9 @@ def meta(simulatedata_cbma, meta_est, kern, meta_params):
     """Define estimator/kernel combinations for tests."""
     fwhm, (_, _) = simulatedata_cbma
     if kern == kernel.KDAKernel or kern == kernel.MKDAKernel:
-        kern = kern(r=fwhm / 2, low_memory=True)
+        kern = kern(r=fwhm / 2)
     else:
-        kern = kern(low_memory=True)
+        kern = kern()
 
     # instantiate meta-analysis estimator
     return meta_est(kern, **meta_params)

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -86,7 +86,7 @@ def test_ALE_empirical_null_unit(testdata_cbma, tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("test_ALE_empirical_null_unit")
     out_file = os.path.join(tmpdir, "file.pkl.gz")
 
-    meta = ale.ALE(null_method="empirical", n_iters=10)
+    meta = ale.ALE(null_method="empirical", n_iters=10, kernel__low_memory=True)
     res = meta.fit(testdata_cbma)
     assert "stat" in res.maps.keys()
     assert "p" in res.maps.keys()

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -2,6 +2,7 @@
 import shutil
 
 import numpy as np
+import pytest
 from scipy.ndimage.measurements import center_of_mass
 
 import nimare
@@ -371,3 +372,21 @@ def test_Peaks2MapsKernel_MKDADensity(testdata_cbma, tmp_path_factory):
     res = est.fit(testdata_cbma)
     assert isinstance(res, nimare.results.MetaResult)
     assert res.get_map("p", return_type="array").dtype == np.float64
+
+
+@pytest.mark.parametrize(
+    "kern, kwargs",
+    [
+        (kernel.ALEKernel, {"sample_size": 20}),
+        (kernel.KDAKernel, {}),
+        (kernel.MKDAKernel, {}),
+    ],
+)
+def test_kernel_low_high_memory(testdata_cbma, tmp_path_factory, kern, kwargs):
+    """Compare kernel results when low_memory is used vs. not."""
+    kern_low_mem = kern(low_memory=True, **kwargs)
+    kern_high_mem = kern(low_memory=False, **kwargs)
+    trans_kwargs = {"dataset": testdata_cbma, "return_type": "array"}
+    assert np.all(
+        kern_low_mem.transform(**trans_kwargs) == kern_high_mem.transform(**trans_kwargs)
+    )

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -144,7 +144,7 @@ def test_alekernel_inputdataset_returndataset(testdata_cbma, tmp_path_factory):
     """Check that all return types produce equivalent results (minus the masking element)."""
     tmpdir = tmp_path_factory.mktemp("test_alekernel_inputdataset_returndataset")
     testdata_cbma.update_path(tmpdir)
-    kern = kernel.ALEKernel(sample_size=20)
+    kern = kernel.ALEKernel(sample_size=20, low_memory=True)
     ma_maps = kern.transform(testdata_cbma, return_type="image")
     ma_arr = kern.transform(testdata_cbma, return_type="array")
     dset = kern.transform(testdata_cbma, return_type="dataset")
@@ -179,7 +179,7 @@ def test_mkdakernel_1mm(testdata_cbma):
     Test on 1mm template.
     """
     id_ = "pain_01.nidm-1"
-    kern = kernel.MKDAKernel(r=4, value=1)
+    kern = kernel.MKDAKernel(r=4, value=1, low_memory=True)
     ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="image")
 
     ijk = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["i", "j", "k"]]


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #452.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add low_memory option for kernel transformers that uses numpy.memmap.
- Use low_memory option in CorrelationDecoder.
