### PR TITLE
[FIX] Add work-around for maskers that do not accept 1D input

### DIFF
--- a/nimare/results.py
+++ b/nimare/results.py
@@ -3,6 +3,8 @@ import copy
 import logging
 import os
 
+from nibabel.funcs import squeeze_image
+
 from .utils import get_masker
 
 LGR = logging.getLogger(__name__)
@@ -49,7 +51,13 @@ class MetaResult(object):
         m = self.maps.get(name)
         if m is None:
             raise ValueError("No map with name '{}' found.".format(name))
-        return self.masker.inverse_transform(m) if return_type == "image" else m
+        if return_type == 'image':
+            # pending resolution of https://github.com/nilearn/nilearn/issues/2724
+            try:
+                return self.masker.inverse_transform(m)
+            except IndexError:
+                return squeeze_image(self.masker.inverse_transform([m]))
+        return m
 
     def save_maps(self, output_dir=".", prefix="", prefix_sep="_", names=None):
         """Save results to files.

--- a/nimare/results.py
+++ b/nimare/results.py
@@ -51,7 +51,7 @@ class MetaResult(object):
         m = self.maps.get(name)
         if m is None:
             raise ValueError("No map with name '{}' found.".format(name))
-        if return_type == 'image':
+        if return_type == "image":
             # pending resolution of https://github.com/nilearn/nilearn/issues/2724
             try:
                 return self.masker.inverse_transform(m)

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -117,6 +117,7 @@ def test_ibma_with_custom_masker(testdata_ibma):
     meta.fit(testdata_ibma)
     assert isinstance(meta.results, nimare.results.MetaResult)
     assert meta.results.maps["z"].shape == (5,)
+    assert meta.results.get_map("z").shape == (10, 10, 10)
 
 
 @pytest.mark.parametrize(

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -98,10 +98,12 @@ def test_ibma_smoke(testdata_ibma, meta, meta_kwargs, corrector, corrector_kwarg
     """Smoke test for IBMA estimators."""
     meta = meta(**meta_kwargs)
     res = meta.fit(testdata_ibma)
+    z_img = res.get_map("z")
     assert isinstance(meta.results, nimare.results.MetaResult)
     assert isinstance(res, nimare.results.MetaResult)
     assert res.get_map("z", return_type="array").ndim == 1
-    assert res.get_map("z").ndim == 3
+    assert z_img.ndim == 3
+    assert z_img.shape == (10, 10, 10)
     if corrector:
         corr = corrector(**corrector_kwargs)
         cres = corr.transform(res)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #454.

upstream fix nilearn/nilearn#2725

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- treat input as 2D for maskers that do not support 1D inputs and squeeze the result
- ensure the dimensions are correct in test
