### PR TITLE
[FIX] Neurovault name collisions

### DIFF
--- a/nimare/io.py
+++ b/nimare/io.py
@@ -357,7 +357,9 @@ def convert_neurovault_to_dataset(
                 ):
                     continue
 
-                filename = img_dir / Path(img_dict["file"]).name
+                filename = img_dir / (
+                    f"collection-{img_dict['collection_id']}_" + Path(img_dict["file"]).name
+                )
 
                 if not filename.exists():
                     r = requests.get(img_dict["file"])

--- a/nimare/io.py
+++ b/nimare/io.py
@@ -358,7 +358,7 @@ def convert_neurovault_to_dataset(
                     continue
 
                 filename = img_dir / (
-                    f"collection-{img_dict['collection_id']}_" + Path(img_dict["file"]).name
+                    f"collection-{nv_coll}_id-{img_dict['id']}_" + Path(img_dict["file"]).name
                 )
 
                 if not filename.exists():

--- a/nimare/tests/test_io.py
+++ b/nimare/tests/test_io.py
@@ -114,6 +114,13 @@ def test_convert_neurosynth_to_json_smoke():
                 "mask": get_template("mni152_2mm", mask="brain"),
             }
         ),
+        (
+            {
+                "collection_ids": (6348, 6419),
+                "contrasts": {"action": "action"},
+                "map_type_conversion": {"univariate-beta map": "beta"},
+            }
+        ),
     ],
 )
 def test_convert_neurovault_to_dataset(kwargs):
@@ -129,10 +136,11 @@ def test_convert_neurovault_to_dataset(kwargs):
 
     assert study_ids == dset_ids
 
-    # check if images were downloaded
+    # check if images were downloaded and are unique
     if kwargs.get("map_type_conversion"):
         for img_type in kwargs.get("map_type_conversion").values():
             assert not dset.images[img_type].empty
+            assert len(set(dset.images[img_type])) == len(dset.images[img_type])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #456 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- add collection_id and image_id to filename to prevent name collisions when downloading the data 
- add test to ensure failing case now works
