### PR TITLE
[REF] Write temporary files to the NiMARE data directory

### DIFF
--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -293,9 +293,12 @@ class ALESubtraction(PairwiseCBMAEstimator):
 
         # Calculate null distribution for each voxel based on group-assignment randomization
         if self.low_memory:
-            from tempfile import mkdtemp
+            import datetime
+            from ...extract.utils import _get_dataset_dir
 
-            filename = os.path.join(mkdtemp(), "iter_diff_values.dat")
+            start_time = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
+            dataset_dir = _get_dataset_dir("temporary_files", data_dir=None)
+            filename = os.path.join(dataset_dir, f"ALESubtraction_{start_time}.dat")
             iter_diff_values = np.memmap(
                 filename, dtype=ma_arr.dtype, mode="w+", shape=(self.n_iters, n_voxels)
             )

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -299,6 +299,9 @@ class ALESubtraction(PairwiseCBMAEstimator):
             start_time = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
             dataset_dir = _get_dataset_dir("temporary_files", data_dir=None)
             filename = os.path.join(dataset_dir, f"ALESubtraction_{start_time}.dat")
+            LGR.info(f"Temporary file written to {filename}")
+
+            # Use a memmapped 4D array
             iter_diff_values = np.memmap(
                 filename, dtype=ma_arr.dtype, mode="w+", shape=(self.n_iters, n_voxels)
             )

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -294,11 +294,13 @@ class ALESubtraction(PairwiseCBMAEstimator):
         # Calculate null distribution for each voxel based on group-assignment randomization
         if self.low_memory:
             import datetime
+            from tempfile import mkdtemp
             from ...extract.utils import _get_dataset_dir
 
             start_time = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
             dataset_dir = _get_dataset_dir("temporary_files", data_dir=None)
-            filename = os.path.join(dataset_dir, f"ALESubtraction_{start_time}.dat")
+            temp_dir = mkdtemp(prefix="ALESubtraction", dir=dataset_dir)
+            filename = os.path.join(temp_dir, f"ALESubtraction_{start_time}.dat")
             LGR.info(f"Temporary file written to {filename}")
 
             # Use a memmapped 4D array

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -331,6 +331,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
         del iter_diff_values
         if self.low_memory:
             # Get rid of memmap
+            LGR.info(f"Removing {filename}")
             os.remove(filename)
 
         z_arr = p_to_z(p_arr, tail="two") * diff_signs

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -1,7 +1,6 @@
 """CBMA methods from the ALE and MKDA families."""
 import logging
 import multiprocessing as mp
-import os
 import inspect
 
 import nibabel as nib

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -79,6 +79,8 @@ class CBMAEstimator(MetaEstimator):
         ma_values = self.kernel_transformer.transform(
             self.inputs_["coordinates"], masker=self.masker, return_type="array"
         )
+        if isinstance(ma_values, np.memmap):
+            raise Exception("Output of transformer is a memmap!")
 
         self.weight_vec_ = self._compute_weights(ma_values)
 
@@ -94,9 +96,6 @@ class CBMAEstimator(MetaEstimator):
 
         else:
             self._compute_null_reduced_empirical(ma_values, n_iters=self.n_iters)
-
-        if self.kernel_transformer.low_memory:
-            os.remove(ma_values.filename)
 
         p_values, z_values = self._summarystat_to_p(stat_values, null_method=self.null_method)
 

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -1,6 +1,7 @@
 """CBMA methods from the ALE and MKDA families."""
 import logging
 import multiprocessing as mp
+import os
 import inspect
 
 import nibabel as nib
@@ -93,6 +94,9 @@ class CBMAEstimator(MetaEstimator):
 
         else:
             self._compute_null_reduced_empirical(ma_values, n_iters=self.n_iters)
+
+        if self.kernel_transformer.low_memory:
+            os.remove(ma_values.filename)
 
         p_values, z_values = self._summarystat_to_p(stat_values, null_method=self.null_method)
 

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -159,7 +159,12 @@ class KernelTransformer(Transformer):
 
         if not isinstance(transformed_maps[0], (list, tuple)):
             if return_type == "array":
-                return transformed_maps[0][:, mask_data]
+                masked_ma_arr = transformed_maps[0][:, mask_data]
+                if isinstance(transformed_maps[0], np.memmap):
+                    LGR.info(f"Removing {transformed_maps[0].filename}")
+                    os.remove(transformed_maps[0].filename)
+
+                return masked_ma_arr
             else:
                 transformed_maps = list(zip(*transformed_maps))
 
@@ -177,6 +182,10 @@ class KernelTransformer(Transformer):
                 out_file = os.path.join(dataset.basepath, self.filename_pattern.format(id=id_))
                 img.to_filename(out_file)
                 dataset.images.loc[dataset.images["id"] == id_, self.image_type] = out_file
+
+        if isinstance(kernel_data, np.memmap):
+            LGR.info(f"Removing {kernel_data.filename}")
+            os.remove(kernel_data.filename)
 
         if return_type == "array":
             return np.vstack(imgs)

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -161,8 +161,7 @@ class KernelTransformer(Transformer):
 
         if not isinstance(transformed_maps[0], (list, tuple)):
             if return_type == "array":
-                masked_ma_arr = transformed_maps[0][:, mask_data]
-                return masked_ma_arr
+                return transformed_maps[0][:, mask_data]
             else:
                 transformed_maps = list(zip(*transformed_maps))
 

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -242,10 +242,14 @@ class ALEKernel(KernelTransformer):
         exp_ids = coordinates["id"].unique()
 
         if self.low_memory:
-            # Use a memmapped 4D array
-            from tempfile import mkdtemp
+            import datetime
+            from ..extract.utils import _get_dataset_dir
 
-            filename = os.path.join(mkdtemp(), "ale_ma_values.dat")
+            start_time = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
+            dataset_dir = _get_dataset_dir("temporary_files", data_dir=None)
+            filename = os.path.join(dataset_dir, f"ALEKernel_{start_time}.dat")
+
+            # Use a memmapped 4D array
             transformed_shape = (len(exp_ids),) + mask.shape
             transformed = np.memmap(filename, dtype=float, mode="w+", shape=transformed_shape)
         else:

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -330,7 +330,7 @@ class KDAKernel(KernelTransformer):
             self.value,
             exp_idx,
             sum_overlap=self._sum_overlap,
-            memmap_filename=self.memmap_filename
+            memmap_filename=self.memmap_filename,
         )
         exp_ids = np.unique(exp_idx)
         return transformed, exp_ids

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -243,11 +243,13 @@ class ALEKernel(KernelTransformer):
 
         if self.low_memory:
             import datetime
+            from tempfile import mkdtemp
             from ..extract.utils import _get_dataset_dir
 
             start_time = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
             dataset_dir = _get_dataset_dir("temporary_files", data_dir=None)
-            filename = os.path.join(dataset_dir, f"ALEKernel_{start_time}.dat")
+            temp_dir = mkdtemp(prefix="ALEKernel", dir=dataset_dir)
+            filename = os.path.join(temp_dir, f"ALEKernel_{start_time}.dat")
             LGR.info(f"Temporary file written to {filename}")
 
             # Use a memmapped 4D array

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -248,6 +248,7 @@ class ALEKernel(KernelTransformer):
             start_time = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
             dataset_dir = _get_dataset_dir("temporary_files", data_dir=None)
             filename = os.path.join(dataset_dir, f"ALEKernel_{start_time}.dat")
+            LGR.info(f"Temporary file written to {filename}")
 
             # Use a memmapped 4D array
             transformed_shape = (len(exp_ids),) + mask.shape

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -161,8 +161,12 @@ class KernelTransformer(Transformer):
             if return_type == "array":
                 masked_ma_arr = transformed_maps[0][:, mask_data]
                 if isinstance(transformed_maps[0], np.memmap):
+                    temp_dir = os.path.dirname(transformed_maps[0].filename)
                     LGR.info(f"Removing {transformed_maps[0].filename}")
                     os.remove(transformed_maps[0].filename)
+                    if len(os.listdir(temp_dir)) == 0:
+                        LGR.info(f"Removing empty directory {temp_dir}")
+                        os.rmdir(temp_dir)
 
                 return masked_ma_arr
             else:
@@ -184,8 +188,14 @@ class KernelTransformer(Transformer):
                 dataset.images.loc[dataset.images["id"] == id_, self.image_type] = out_file
 
         if isinstance(kernel_data, np.memmap):
+            temp_dir = os.path.dirname(kernel_data.filename)
             LGR.info(f"Removing {kernel_data.filename}")
             os.remove(kernel_data.filename)
+            if len(os.listdir(temp_dir)) == 0:
+                LGR.info(f"Removing empty directory {temp_dir}")
+                os.rmdir(temp_dir)
+
+        del kernel_data
 
         if return_type == "array":
             return np.vstack(imgs)

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -302,9 +302,14 @@ def compute_kda_ma(
 
     kernel_shape = (n_studies,) + shape
     if low_memory:
-        from tempfile import mkdtemp
+        import datetime
+        from ..extract.utils import _get_dataset_dir
 
-        filename = os.path.join(mkdtemp(), "kda_ma_values.dat")
+        start_time = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
+        object_name = "KDAKernel" if sum_overlap else "MKDAKernel"
+        dataset_dir = _get_dataset_dir("temporary_files", data_dir=None)
+
+        filename = os.path.join(dataset_dir, f"{object_name}_{start_time}.dat")
         kernel_data = np.memmap(filename, dtype=type(value), mode="w+", shape=kernel_shape)
     else:
         kernel_data = np.zeros(kernel_shape, dtype=type(value))

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -303,12 +303,14 @@ def compute_kda_ma(
     kernel_shape = (n_studies,) + shape
     if low_memory:
         import datetime
+        from tempfile import mkdtemp
         from ..extract.utils import _get_dataset_dir
 
         start_time = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
         object_name = "KDAKernel" if sum_overlap else "MKDAKernel"
         dataset_dir = _get_dataset_dir("temporary_files", data_dir=None)
-        filename = os.path.join(dataset_dir, f"{object_name}_{start_time}.dat")
+        temp_dir = mkdtemp(prefix=object_name, dir=dataset_dir)
+        filename = os.path.join(temp_dir, f"{object_name}_{start_time}.dat")
         LGR.info(f"Temporary file written to {filename}")
 
         # Use a memmapped 4D array

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -308,8 +308,10 @@ def compute_kda_ma(
         start_time = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
         object_name = "KDAKernel" if sum_overlap else "MKDAKernel"
         dataset_dir = _get_dataset_dir("temporary_files", data_dir=None)
-
         filename = os.path.join(dataset_dir, f"{object_name}_{start_time}.dat")
+        LGR.info(f"Temporary file written to {filename}")
+
+        # Use a memmapped 4D array
         kernel_data = np.memmap(filename, dtype=type(value), mode="w+", shape=kernel_shape)
     else:
         kernel_data = np.zeros(kernel_shape, dtype=type(value))

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -258,7 +258,14 @@ def compute_p2m_ma(
 
 
 def compute_kda_ma(
-    shape, vox_dims, ijks, r, value=1.0, exp_idx=None, sum_overlap=False, memmap_filename=None,
+    shape,
+    vox_dims,
+    ijks,
+    r,
+    value=1.0,
+    exp_idx=None,
+    sum_overlap=False,
+    memmap_filename=None,
 ):
     """Compute (M)KDA modeled activation (MA) map.
 
@@ -305,9 +312,7 @@ def compute_kda_ma(
     kernel_shape = (n_studies,) + shape
     if memmap_filename:
         # Use a memmapped 4D array
-        kernel_data = np.memmap(
-            memmap_filename, dtype=type(value), mode="w+", shape=kernel_shape
-        )
+        kernel_data = np.memmap(memmap_filename, dtype=type(value), mode="w+", shape=kernel_shape)
     else:
         kernel_data = np.zeros(kernel_shape, dtype=type(value))
 

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -82,7 +82,10 @@ def test_ALE_analytic_null_unit(testdata_cbma, tmp_path_factory):
 
 
 def test_ALE_empirical_null_unit(testdata_cbma, tmp_path_factory):
-    """Unit test for ALE with an empirical null_method."""
+    """Unit test for ALE with an empirical null_method.
+
+    This test is run with low-memory kernel transformation as well.
+    """
     tmpdir = tmp_path_factory.mktemp("test_ALE_empirical_null_unit")
     out_file = os.path.join(tmpdir, "file.pkl.gz")
 

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -393,13 +393,13 @@ def uk_to_us(text):
 
 
 def use_memmap(logger):
-    """Woo."""
+    """Memory-map array to a file, and perform cleanup after."""
     from .extract.utils import _get_dataset_dir
 
     def inner_function(function):
         @wraps(function)
         def memmap_context(self, *args, **kwargs):
-            if self.low_memory:
+            if hasattr(self, "low_memory") and self.low_memory:
                 start_time = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
                 dataset_dir = _get_dataset_dir("temporary_files", data_dir=None)
                 _, filename = mkstemp(
@@ -409,13 +409,14 @@ def use_memmap(logger):
                 self.memmap_filename = filename
             else:
                 filename = self.memmap_filename = None
+
             try:
                 return function(self, *args, **kwargs)
             except:
                 logger.error(f"{function.__name__} failed, removing {filename}")
                 raise
             finally:
-                if self.low_memory and os.path.isfile(filename):
+                if hasattr(self, "low_memory") and self.low_memory and os.path.isfile(filename):
                     logger.info(f"Removing temporary file: {filename}")
                     os.remove(filename)
 

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -397,7 +397,6 @@ def use_memmap(logger):
     from .extract.utils import _get_dataset_dir
 
     def inner_function(function):
-
         @wraps(function)
         def memmap_context(self, *args, **kwargs):
             if self.low_memory:
@@ -421,4 +420,5 @@ def use_memmap(logger):
                     os.remove(filename)
 
         return memmap_context
+
     return inner_function


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None. In working on the NiMARE paper, I've had trouble with memory issues. At minimum, writing temporary files (created when the `low_memory` option is used) to the NiMARE data directory will make it easier for users to track the files and remove them as necessary.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Write temporary files created in `ALEKernel`, `MKDAKernel`, `KDAKernel`, and `ALESubtraction` to the NiMARE data directory instead of temporary directories.
- Log the temporary filenames. I'd love to log their sizes as well, but I'm not sure how to estimate the file size before it's created. It should just be a matter of the data type and the size though...
