### PR TITLE
[REF] Use saved MA maps, when available, in CBMA estimators

### DIFF
--- a/nimare/base.py
+++ b/nimare/base.py
@@ -6,6 +6,7 @@ import multiprocessing as mp
 import pickle
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
+from hashlib import md5
 
 import nibabel as nb
 import numpy as np
@@ -321,6 +322,14 @@ class MetaEstimator(Estimator):
 
                 self.inputs_[name] = temp_arr
             elif type_ == "coordinates":
+                # Try to load existing MA maps
+                if hasattr(self, "kernel_transformer"):
+                    self.kernel_transformer._infer_names(affine=md5(mask_img.affine).hexdigest())
+                    col = self.kernel_transformer.image_type
+                    if col in dataset.images.columns:
+                        self.inputs_["ma_maps"] = dataset.images[col].tolist()
+
+                # Set the coordinates directly as well
                 self.inputs_[name] = dataset.coordinates.copy()
 
 

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -325,9 +325,13 @@ class MetaEstimator(Estimator):
                 # Try to load existing MA maps
                 if hasattr(self, "kernel_transformer"):
                     self.kernel_transformer._infer_names(affine=md5(mask_img.affine).hexdigest())
-                    col = self.kernel_transformer.image_type
-                    if col in dataset.images.columns:
-                        self.inputs_["ma_maps"] = dataset.images[col].tolist()
+                    if self.kernel_transformer.image_type in dataset.images.columns:
+                        files = dataset.get_images(
+                            ids=dataset.ids,
+                            imtype=self.kernel_transformer.image_type,
+                        )
+                        if all(f is not None for f in files):
+                            self.inputs_["ma_maps"] = files
 
                 # Set the coordinates directly as well
                 self.inputs_[name] = dataset.coordinates.copy()

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -269,12 +269,27 @@ class ALESubtraction(PairwiseCBMAEstimator):
         self.dataset2 = dataset2
         self.masker = self.masker or dataset1.masker
 
-        ma_maps1 = self.kernel_transformer.transform(
-            self.inputs_["coordinates1"], masker=self.masker, return_type="array"
-        )
-        ma_maps2 = self.kernel_transformer.transform(
-            self.inputs_["coordinates2"], masker=self.masker, return_type="array"
-        )
+        if "ma_maps1" in self.inputs_.keys():
+            # Grab pre-generated MA maps
+            LGR.debug("Loading pre-generated MA maps for sample 1.")
+            ma_maps1 = self.masker.transform(self.inputs_["ma_maps1"])
+        else:
+            ma_maps1 = self.kernel_transformer.transform(
+                self.inputs_["coordinates1"],
+                masker=self.masker,
+                return_type="array",
+            )
+
+        if "ma_maps2" in self.inputs_.keys():
+            # Grab pre-generated MA maps
+            LGR.debug("Loading pre-generated MA maps for sample 2.")
+            ma_maps1 = self.masker.transform(self.inputs_["ma_maps2"])
+        else:
+            ma_maps2 = self.kernel_transformer.transform(
+                self.inputs_["coordinates2"],
+                masker=self.masker,
+                return_type="array",
+            )
 
         n_grp1 = ma_maps1.shape[0]
         ma_arr = np.vstack((ma_maps1, ma_maps2))

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -283,7 +283,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
         if "ma_maps2" in self.inputs_.keys():
             # Grab pre-generated MA maps
             LGR.debug("Loading pre-generated MA maps for sample 2.")
-            ma_maps1 = self.masker.transform(self.inputs_["ma_maps2"])
+            ma_maps2 = self.masker.transform(self.inputs_["ma_maps2"])
         else:
             ma_maps2 = self.kernel_transformer.transform(
                 self.inputs_["coordinates2"],

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -271,7 +271,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
 
         if "ma_maps1" in self.inputs_.keys():
             # Grab pre-generated MA maps
-            LGR.debug("Loading pre-generated MA maps for sample 1.")
+            LGR.debug("Loading pre-generated MA maps for Dataset 1.")
             ma_maps1 = self.masker.transform(self.inputs_["ma_maps1"])
         else:
             ma_maps1 = self.kernel_transformer.transform(
@@ -282,7 +282,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
 
         if "ma_maps2" in self.inputs_.keys():
             # Grab pre-generated MA maps
-            LGR.debug("Loading pre-generated MA maps for sample 2.")
+            LGR.debug("Loading pre-generated MA maps for Dataset 2.")
             ma_maps2 = self.masker.transform(self.inputs_["ma_maps2"])
         else:
             ma_maps2 = self.kernel_transformer.transform(

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -75,9 +75,16 @@ class CBMAEstimator(MetaEstimator):
         self.masker = self.masker or dataset.masker
         self.null_distributions_ = {}
 
-        ma_values = self.kernel_transformer.transform(
-            self.inputs_["coordinates"], masker=self.masker, return_type="array"
-        )
+        if "ma_maps" in self.inputs_.keys():
+            # Grab pre-generated MA maps
+            LGR.debug("Loading pre-generated MA maps.")
+            ma_values = self.masker.transform(self.inputs_["ma_maps"])
+        else:
+            ma_values = self.kernel_transformer.transform(
+                self.inputs_["coordinates"],
+                masker=self.masker,
+                return_type="array",
+            )
 
         self.weight_vec_ = self._compute_weights(ma_values)
 
@@ -644,11 +651,21 @@ class PairwiseCBMAEstimator(CBMAEstimator):
         """
         self._validate_input(dataset1)
         self._validate_input(dataset2)
+
         # grab and override
         self._preprocess_input(dataset1)
+        if "ma_maps" in self.inputs_.keys():
+            # Grab pre-generated MA maps
+            self.inputs_["ma_maps1"] = self.inputs_.pop("ma_maps")
+
         self.inputs_["coordinates1"] = self.inputs_.pop("coordinates")
+
         # grab and override
         self._preprocess_input(dataset2)
+        if "ma_maps" in self.inputs_.keys():
+            # Grab pre-generated MA maps
+            self.inputs_["ma_maps2"] = self.inputs_.pop("ma_maps")
+
         self.inputs_["coordinates2"] = self.inputs_.pop("coordinates")
 
         maps = self._fit(dataset1, dataset2)

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -201,12 +201,27 @@ class MKDAChi2(PairwiseCBMAEstimator):
         self.masker = self.masker or dataset1.masker
         self.null_distributions_ = {}
 
-        ma_maps1 = self.kernel_transformer.transform(
-            self.inputs_["coordinates1"], masker=self.masker, return_type="array"
-        )
-        ma_maps2 = self.kernel_transformer.transform(
-            self.inputs_["coordinates2"], masker=self.masker, return_type="array"
-        )
+        if "ma_maps1" in self.inputs_.keys():
+            # Grab pre-generated MA maps
+            LGR.debug("Loading pre-generated MA maps for Dataset 1.")
+            ma_maps1 = self.masker.transform(self.inputs_["ma_maps1"])
+        else:
+            ma_maps1 = self.kernel_transformer.transform(
+                self.inputs_["coordinates1"],
+                masker=self.masker,
+                return_type="array",
+            )
+
+        if "ma_maps2" in self.inputs_.keys():
+            # Grab pre-generated MA maps
+            LGR.debug("Loading pre-generated MA maps for Dataset 2.")
+            ma_maps2 = self.masker.transform(self.inputs_["ma_maps2"])
+        else:
+            ma_maps2 = self.kernel_transformer.transform(
+                self.inputs_["coordinates2"],
+                masker=self.masker,
+                return_type="array",
+            )
 
         # Calculate different count variables
         n_selected = ma_maps1.shape[0]

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -41,6 +41,32 @@ def test_ALE_ma_map_reuse(testdata_cbma, tmp_path_factory, caplog):
     assert "Loading pre-generated MA maps." in caplog.text
 
 
+def test_ALESubtraction_ma_map_reuse(testdata_cbma, tmp_path_factory, caplog):
+    """Test that MA maps are re-used when appropriate."""
+    from nimare.meta import kernel
+
+    tmpdir = tmp_path_factory.mktemp("test_ALESubtraction_ma_map_reuse")
+    testdata_cbma.update_path(tmpdir)
+
+    # ALEKernel cannot extract sample_size from a Dataset,
+    # so we need to set it for this kernel and for the later meta-analyses.
+    kern = kernel.ALEKernel(sample_size=20)
+    dset = kern.transform(testdata_cbma, return_type="dataset")
+
+    # The Dataset without the images will generate them from scratch.
+    sub_meta = ale.ALESubtraction(n_iters=10, kernel__sample_size=20)
+
+    with caplog.at_level(logging.DEBUG, logger="nimare.meta.cbma.ale"):
+        sub_meta.fit(testdata_cbma, testdata_cbma)
+    assert "Loading pre-generated MA maps" not in caplog.text
+
+    # The Dataset with the images will re-use them,
+    # as evidenced by the logger message.
+    with caplog.at_level(logging.DEBUG, logger="nimare.meta.cbma.ale"):
+        sub_meta.fit(dset, dset)
+    assert "Loading pre-generated MA maps" in caplog.text
+
+
 def test_ALE_analytic_null_unit(testdata_cbma, tmp_path_factory):
     """Unit test for ALE with analytic null_method."""
     tmpdir = tmp_path_factory.mktemp("test_ALE_analytic_null_unit")

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -1,4 +1,5 @@
 """Test nimare.meta.ale (ALE/SCALE meta-analytic algorithms)."""
+import logging
 import os
 import pickle
 
@@ -9,6 +10,35 @@ import pytest
 import nimare
 from nimare.correct import FDRCorrector, FWECorrector
 from nimare.meta import ale
+
+
+def test_ALE_ma_map_reuse(testdata_cbma, tmp_path_factory, caplog):
+    """Test that MA maps are re-used when appropriate."""
+    from nimare.meta import kernel
+
+    tmpdir = tmp_path_factory.mktemp("test_ALE_ma_map_reuse")
+    testdata_cbma.update_path(tmpdir)
+
+    # ALEKernel cannot extract sample_size from a Dataset,
+    # so we need to set it for this kernel and for the later meta-analyses.
+    kern = kernel.ALEKernel(sample_size=20)
+    dset = kern.transform(testdata_cbma, return_type="dataset")
+
+    # The associated column should be in the new Dataset's images DataFrame
+    cols = dset.images.columns.tolist()
+    assert any(["ALEKernel" in col for col in cols])
+
+    # The Dataset without the images will generate them from scratch.
+    meta = ale.ALE(kernel__sample_size=20)
+    with caplog.at_level(logging.DEBUG, logger="nimare.meta.cbma.base"):
+        meta.fit(testdata_cbma)
+    assert "Loading pre-generated MA maps." not in caplog.text
+
+    # The Dataset with the images will re-use them,
+    # as evidenced by the logger message.
+    with caplog.at_level(logging.DEBUG, logger="nimare.meta.cbma.base"):
+        meta.fit(dset)
+    assert "Loading pre-generated MA maps." in caplog.text
 
 
 def test_ALE_analytic_null_unit(testdata_cbma, tmp_path_factory):


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #461.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add a new `inputs_` field called `ma_maps` in which MA maps stored in the Dataset's images attribute are collected, should they exist.
