### PR TITLE
[FIX] Assume non-symmetric null distribution in ALESubtraction

### DIFF
--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -338,7 +338,10 @@ class ALESubtraction(PairwiseCBMAEstimator):
 
         z_arr = p_to_z(p_arr, tail="two") * diff_signs
 
-        images = {"z_desc-group1MinusGroup2": z_arr}
+        images = {
+            "z_desc-group1MinusGroup2": z_arr,
+            "p_desc-group1MinusGroup2": p_arr,
+        }
         return images
 
 

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -327,6 +327,9 @@ class ALESubtraction(PairwiseCBMAEstimator):
                 iter_diff_values.flush()
 
         # Determine p-values based on voxel-wise null distributions
+        # In cases with differently-sized groups,
+        # the ALE-difference values will be biased and skewed,
+        # but the null distributions will be too, so symmetric should be False.
         p_arr = np.ones(n_voxels)
         for voxel in range(n_voxels):
             p_arr[voxel] = null_to_p(

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -330,7 +330,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
         p_arr = np.ones(n_voxels)
         for voxel in range(n_voxels):
             p_arr[voxel] = null_to_p(
-                diff_ale_values[voxel], iter_diff_values[:, voxel], tail="two", symmetric=True
+                diff_ale_values[voxel], iter_diff_values[:, voxel], tail="two", symmetric=False
             )
         diff_signs = np.sign(diff_ale_values - np.median(iter_diff_values, axis=0))
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None, but addresses an issue reported by @mriedel56 offline.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Change `symmetric=True` to `symmetric=False`.
- Add comment about use of `symmetric=False` to code.
- Output p-value map for ALESubtraction in addition to z-value map.
