### PR TITLE
[FIX] Disable non-NiftiMasker masks

### DIFF
--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -1,15 +1,11 @@
 """Test nimare.meta.ibma (image-based meta-analytic estimators)."""
-import os.path as op
 from contextlib import ExitStack as does_not_raise
 
-from nilearn.input_data import NiftiLabelsMasker
 import pytest
 
 import nimare
 from nimare.correct import FDRCorrector, FWECorrector
 from nimare.meta import ibma
-
-from .utils import get_test_data_path
 
 
 @pytest.mark.parametrize(
@@ -109,17 +105,6 @@ def test_ibma_smoke(testdata_ibma, meta, meta_kwargs, corrector, corrector_kwarg
         cres = corr.transform(res)
         assert cres.get_map("z", return_type="array").ndim == 1
         assert cres.get_map("z").ndim == 3
-
-
-def test_ibma_with_custom_masker(testdata_ibma):
-    """Ensure voxel-to-ROI reduction works."""
-    atlas = op.join(get_test_data_path(), "test_pain_dataset", "atlas.nii.gz")
-    masker = NiftiLabelsMasker(atlas)
-    meta = ibma.Fishers(mask=masker)
-    meta.fit(testdata_ibma)
-    assert isinstance(meta.results, nimare.results.MetaResult)
-    assert meta.results.maps["z"].shape == (5,)
-    assert meta.results.get_map("z").shape == (10, 10, 10)
 
 
 @pytest.mark.parametrize(

--- a/nimare/tests/test_utils.py
+++ b/nimare/tests/test_utils.py
@@ -5,6 +5,7 @@ import os.path as op
 
 import nibabel as nib
 import pytest
+from nilearn import input_data
 
 from nimare import utils
 
@@ -79,3 +80,16 @@ def test_use_memmap(caplog, has_low_memory, low_memory):
         assert not os.path.isfile(my_class.memmap_filename)
         # test when a function is called a new memmap file is created
         assert first_memmap_filename != my_class.memmap_filename
+
+
+def test_get_masker():
+    """Smoke test for get_masker."""
+    img = utils.get_template(space="mni152_2mm", mask="brain")
+    masker = utils.get_masker(img)
+    assert isinstance(masker, input_data.NiftiMasker)
+    masker_ = input_data.NiftiMasker(img)
+    masker = utils.get_masker(masker_)
+    assert isinstance(masker, input_data.NiftiMasker)
+    masker_ = input_data.NiftiLabelsMasker(img)
+    with pytest.raises(ValueError):
+        masker = utils.get_masker(masker_)

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -274,6 +274,12 @@ def get_masker(mask):
     -------
     masker : an initialized, fitted instance of a subclass of
         `nilearn.input_data.base_masker.BaseMasker`
+
+    Notes
+    -----
+    Due to issues with averaging across voxels in image-based meta-analyses,
+    only non-aggregative maskers (i.e., NiftiMaskers) are allowed.
+    See https://github.com/neurostuff/NiMARE/issues/466 for more information.
     """
     if isinstance(mask, str):
         mask = nib.load(mask)
@@ -281,9 +287,9 @@ def get_masker(mask):
     if isinstance(mask, nib.nifti1.Nifti1Image):
         mask = NiftiMasker(mask)
 
-    if not (hasattr(mask, "transform") and hasattr(mask, "inverse_transform")):
+    if not isinstance(mask, NiftiMasker):
         raise ValueError(
-            "mask argument must be a string, a nibabel image," " or a Nilearn Masker instance."
+            "mask argument must be a string, a nibabel image, or a nilearn NiftiMasker instance."
         )
 
     # Fit the masker if needed


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
References #466.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Check masker type in `nimare.utils.get_masker` and only allow `NiftiMasker`s.
- Remove IBMA test with custom masker.
