### PR TITLE
[FIX] Find common stem in find_stem instead of largest common substring

### DIFF
--- a/nimare/tests/test_utils.py
+++ b/nimare/tests/test_utils.py
@@ -9,6 +9,49 @@ import pytest
 from nimare import utils
 
 
+def test_find_stem():
+    """Test nimare.utils.find_stem."""
+    test_array = [
+        "/home/data/dataset/file1.nii.gz",
+        "/home/data/dataset/file2.nii.gz",
+        "/home/data/dataset/file3.nii.gz",
+        "/home/data/dataset/file4.nii.gz",
+        "/home/data/dataset/file5.nii.gz",
+    ]
+    stem = utils.find_stem(test_array)
+    assert stem == "/home/data/dataset/file"
+
+    test_array = [
+        "/home/data/dataset/subfolder1/file1.nii.gz",
+        "/home/data/dataset/subfolder1/file2.nii.gz",
+        "/home/data/dataset/subfolder2/file3.nii.gz",
+        "/home/data/dataset/subfolder2/file4.nii.gz",
+        "/home/data/dataset/subfolder3/file5.nii.gz",
+    ]
+    stem = utils.find_stem(test_array)
+    assert stem == "/home/data/dataset/subfolder"
+
+    test_array = [
+        "/home/data/file1_test-filename_test.nii.gz",
+        "/home/data/file2_test-filename_test.nii.gz",
+        "/home/data/file3_test-filename_test.nii.gz",
+        "/home/data/file4_test-filename_test.nii.gz",
+        "/home/data/file5_test-filename_test.nii.gz",
+    ]
+    stem = utils.find_stem(test_array)
+    assert stem == "/home/data/file"
+
+    test_array = [
+        "souse",
+        "youse",
+        "house",
+        "mouse",
+        "louse",
+    ]
+    stem = utils.find_stem(test_array)
+    assert stem == ""
+
+
 def test_get_template():
     """Test nimare.utils.get_template."""
     img = utils.get_template(space="mni152_1mm", mask=None)

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -356,6 +356,7 @@ def find_stem(arr):
         # Generate all starting substrings of our reference string
         stem = reference_string[:i_char]
 
+        j_item = 1  # Retained in case of an array with only one item
         for j_item in range(1, n_items_in_array):
             # Check if the generated stem is common to to all words
             if not arr[j_item].startswith(stem):

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -170,6 +170,8 @@ def validate_images_df(image_df):
         DataFrame with updated paths and columns.
     """
     valid_suffixes = [".brik", ".head", ".nii", ".img", ".hed"]
+
+    # Find columns in the DataFrame with images
     file_cols = []
     for col in image_df.columns:
         vals = [v for v in image_df[col].values if isinstance(v, str)]
@@ -177,7 +179,7 @@ def validate_images_df(image_df):
         if fc:
             file_cols.append(col)
 
-    # Clean up image_df
+    # Clean up DataFrame
     # Find out which columns have full paths and which have relative paths
     abs_cols = []
     for col in file_cols:
@@ -191,7 +193,7 @@ def validate_images_df(image_df):
         else:
             raise ValueError(
                 "Mix of absolute and relative paths detected "
-                'for images in column "{}"'.format(col)
+                "for images in column '{}'".format(col)
             )
 
     # Set relative paths from absolute ones
@@ -202,7 +204,7 @@ def validate_images_df(image_df):
         # Get parent *directory* if shared path includes common prefix.
         if not shared_path.endswith(op.sep):
             shared_path = op.dirname(shared_path) + op.sep
-        LGR.info('Shared path detected: "{0}"'.format(shared_path))
+        LGR.info("Shared path detected: '{0}'".format(shared_path))
         for abs_col in abs_cols:
             image_df[abs_col + "__relative"] = image_df[abs_col].apply(
                 lambda x: x.split(shared_path)[1] if isinstance(x, str) else x
@@ -343,28 +345,26 @@ def find_stem(arr):
     From https://www.geeksforgeeks.org/longest-common-substring-array-strings/
     """
     # Determine size of the array
-    n = len(arr)
+    n_items_in_array = len(arr)
 
-    # Take first word from array
-    # as reference
-    s = arr[0]
-    ll = len(s)
+    # Take first word from array as reference
+    reference_string = arr[0]
+    n_chars_in_first_item = len(reference_string)
 
     res = ""
-    for i in range(ll):
-        for j in range(i + 1, ll + 1):
-            # generating all possible substrings of our ref string arr[0] i.e s
-            stem = s[i:j]
-            k = 1
-            for k in range(1, n):
-                # Check if the generated stem is common to to all words
-                if stem not in arr[k]:
-                    break
+    for i_char in range(n_chars_in_first_item):
+        # Generate all starting substrings of our reference string
+        stem = reference_string[:i_char]
 
-            # If current substring is present in all strings and its length is
-            # greater than current result
-            if k + 1 == n and len(res) < len(stem):
-                res = stem
+        for j_item in range(1, n_items_in_array):
+            # Check if the generated stem is common to to all words
+            if not arr[j_item].startswith(stem):
+                break
+
+        # If current substring is present in all strings and its length is
+        # greater than current result
+        if (j_item + 1 == n_items_in_array) and (len(res) < len(stem)):
+            res = stem
 
     return res
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #471. While we should still revisit how images are validated and paths to images are stored, this at least should fix the immediate issue.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Refactor and clean up find_stem, so that it finds the common _stem_ (or beginning substring) instead of the largest common substring in any part of the set of strings.
- Add test for find_stem.
