### PR TITLE
[FIX] Set Dataset.basepath using absolute path

### DIFF
--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -2,6 +2,7 @@
 import copy
 import json
 import logging
+import os.path as op
 
 import nibabel as nib
 import numpy as np
@@ -256,14 +257,14 @@ class Dataset(NiMAREBase):
         new_path : :obj:`str`
             Path to prepend to relative paths of files in Dataset.images.
         """
-        self.basepath = new_path
+        self.basepath = op.abspath(new_path)
         df = self.images
         relative_path_cols = [c for c in df if c.endswith("__relative")]
         for col in relative_path_cols:
             abs_col = col.replace("__relative", "")
             if abs_col in df.columns:
                 LGR.info("Overwriting images column {}".format(abs_col))
-            df[abs_col] = df[col].apply(try_prepend, prefix=new_path)
+            df[abs_col] = df[col].apply(try_prepend, prefix=self.basepath)
         self.images = df
 
     def copy(self):


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #473.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Within `Dataset.update_path()`, replace the assigned path with the absolute path.
