### PR TITLE
[ENH] Incorporate information about valid masking approaches into IBMA Estimators

### DIFF
--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -5,8 +5,8 @@ import logging
 
 import numpy as np
 import pymare
-from nilearn.mass_univariate import permuted_ols
 from nilearn.input_data import NiftiMasker
+from nilearn.mass_univariate import permuted_ols
 
 from ..base import MetaEstimator
 from ..transforms import p_to_z, t_to_z
@@ -27,6 +27,9 @@ class Fishers(MetaEstimator):
     Warning
     -------
     This method does not currently calculate p-values correctly. Do not use.
+
+    Masking approaches which average across voxels (e.g., NiftiLabelsMaskers)
+    will result in invalid results. It cannot be used with these types of maskers.
 
     All image-based meta-analysis estimators adopt an aggressive masking
     strategy, in which any voxels with a value of zero in any of the input maps
@@ -85,6 +88,9 @@ class Stouffers(MetaEstimator):
     Warning
     -------
     This method does not currently calculate p-values correctly. Do not use.
+
+    Masking approaches which average across voxels (e.g., NiftiLabelsMaskers)
+    will result in invalid results. It cannot be used with these types of maskers.
 
     All image-based meta-analysis estimators adopt an aggressive masking
     strategy, in which any voxels with a value of zero in any of the input maps
@@ -162,6 +168,10 @@ class WeightedLeastSquares(MetaEstimator):
 
     Warning
     -------
+    Masking approaches which average across voxels (e.g., NiftiLabelsMaskers)
+    will likely result in biased results. The extent of this bias is currently
+    unknown.
+
     All image-based meta-analysis estimators adopt an aggressive masking
     strategy, in which any voxels with a value of zero in any of the input maps
     will be removed from the analysis.
@@ -217,6 +227,10 @@ class DerSimonianLaird(MetaEstimator):
 
     Warning
     -------
+    Masking approaches which average across voxels (e.g., NiftiLabelsMaskers)
+    will likely result in biased results. The extent of this bias is currently
+    unknown.
+
     All image-based meta-analysis estimators adopt an aggressive masking
     strategy, in which any voxels with a value of zero in any of the input maps
     will be removed from the analysis.
@@ -272,6 +286,10 @@ class Hedges(MetaEstimator):
 
     Warning
     -------
+    Masking approaches which average across voxels (e.g., NiftiLabelsMaskers)
+    will likely result in biased results. The extent of this bias is currently
+    unknown.
+
     All image-based meta-analysis estimators adopt an aggressive masking
     strategy, in which any voxels with a value of zero in any of the input maps
     will be removed from the analysis.
@@ -400,6 +418,10 @@ class VarianceBasedLikelihood(MetaEstimator):
     Likelihood-based estimators are not parallelized across voxels, so this
     method should not be used on full brains, unless you can submit your code
     to a job scheduler.
+
+    Masking approaches which average across voxels (e.g., NiftiLabelsMaskers)
+    will likely result in biased results. The extent of this bias is currently
+    unknown.
 
     All image-based meta-analysis estimators adopt an aggressive masking
     strategy, in which any voxels with a value of zero in any of the input maps

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -51,14 +51,17 @@ class Fishers(MetaEstimator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not isinstance(self.masker, NiftiMasker):
+
+    def _fit(self, dataset):
+        masker = self.masker or dataset.masker
+        if not isinstance(masker, NiftiMasker):
             raise ValueError(
+                f"A {type(masker)} mask has been detected. "
                 "Only NiftiMaskers are allowed for this Estimator. "
                 "This is because aggregation, such as averaging values across ROIs, "
                 "will produce invalid results."
             )
 
-    def _fit(self, dataset):
         pymare_dset = pymare.Dataset(y=self.inputs_["z_maps"])
         est = pymare.estimators.FisherCombinationTest()
         est.fit_dataset(pymare_dset)
@@ -117,18 +120,20 @@ class Stouffers(MetaEstimator):
 
     def __init__(self, use_sample_size=False, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not isinstance(self.masker, NiftiMasker):
-            raise ValueError(
-                "Only NiftiMaskers are allowed for this Estimator. "
-                "This is because aggregation, such as averaging values across ROIs, "
-                "will produce invalid results."
-            )
-
         self.use_sample_size = use_sample_size
         if self.use_sample_size:
             self._required_inputs["sample_sizes"] = ("metadata", "sample_sizes")
 
     def _fit(self, dataset):
+        masker = self.masker or dataset.masker
+        if not isinstance(masker, NiftiMasker):
+            raise ValueError(
+                f"A {type(masker)} mask has been detected. "
+                "Only NiftiMaskers are allowed for this Estimator. "
+                "This is because aggregation, such as averaging values across ROIs, "
+                "will produce invalid results."
+            )
+
         est = pymare.estimators.StoufferCombinationTest()
 
         if self.use_sample_size:
@@ -192,16 +197,17 @@ class WeightedLeastSquares(MetaEstimator):
 
     def __init__(self, tau2=0, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not isinstance(self.masker, NiftiMasker):
+        self.tau2 = tau2
+
+    def _fit(self, dataset):
+        masker = self.masker or dataset.masker
+        if not isinstance(masker, NiftiMasker):
             LGR.warning(
-                f"A {type(self.masker)} mask has been detected. "
+                f"A {type(masker)} mask has been detected. "
                 "Masks which average across voxels will likely produce biased results when used "
                 "with this Estimator."
             )
 
-        self.tau2 = tau2
-
-    def _fit(self, dataset):
         pymare_dset = pymare.Dataset(y=self.inputs_["beta_maps"], v=self.inputs_["varcope_maps"])
         est = pymare.estimators.WeightedLeastSquares(tau2=self.tau2)
         est.fit_dataset(pymare_dset)
@@ -253,14 +259,16 @@ class DerSimonianLaird(MetaEstimator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not isinstance(self.masker, NiftiMasker):
+
+    def _fit(self, dataset):
+        masker = self.masker or dataset.masker
+        if not isinstance(masker, NiftiMasker):
             LGR.warning(
-                f"A {type(self.masker)} mask has been detected. "
+                f"A {type(masker)} mask has been detected. "
                 "Masks which average across voxels will likely produce biased results when used "
                 "with this Estimator."
             )
 
-    def _fit(self, dataset):
         est = pymare.estimators.DerSimonianLaird()
         pymare_dset = pymare.Dataset(y=self.inputs_["beta_maps"], v=self.inputs_["varcope_maps"])
         est.fit_dataset(pymare_dset)
@@ -308,14 +316,16 @@ class Hedges(MetaEstimator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not isinstance(self.masker, NiftiMasker):
+
+    def _fit(self, dataset):
+        masker = self.masker or dataset.masker
+        if not isinstance(masker, NiftiMasker):
             LGR.warning(
-                f"A {type(self.masker)} mask has been detected. "
+                f"A {type(masker)} mask has been detected. "
                 "Masks which average across voxels will likely produce biased results when used "
                 "with this Estimator."
             )
 
-    def _fit(self, dataset):
         est = pymare.estimators.Hedges()
         pymare_dset = pymare.Dataset(y=self.inputs_["beta_maps"], v=self.inputs_["varcope_maps"])
         est.fit_dataset(pymare_dset)
@@ -445,16 +455,17 @@ class VarianceBasedLikelihood(MetaEstimator):
 
     def __init__(self, method="ml", *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not isinstance(self.masker, NiftiMasker):
+        self.method = method
+
+    def _fit(self, dataset):
+        masker = self.masker or dataset.masker
+        if not isinstance(masker, NiftiMasker):
             LGR.warning(
-                f"A {type(self.masker)} mask has been detected. "
+                f"A {type(masker)} mask has been detected. "
                 "Masks which average across voxels will likely produce biased results when used "
                 "with this Estimator."
             )
 
-        self.method = method
-
-    def _fit(self, dataset):
         est = pymare.estimators.VarianceBasedLikelihoodEstimator(method=self.method)
 
         pymare_dset = pymare.Dataset(y=self.inputs_["beta_maps"], v=self.inputs_["varcope_maps"])

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -6,6 +6,7 @@ import logging
 import numpy as np
 import pymare
 from nilearn.mass_univariate import permuted_ols
+from nilearn.input_data import NiftiMasker
 
 from ..base import MetaEstimator
 from ..transforms import p_to_z, t_to_z
@@ -47,6 +48,12 @@ class Fishers(MetaEstimator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if not isinstance(self.masker, NiftiMasker):
+            raise ValueError(
+                "Only NiftiMaskers are allowed for this Estimator. "
+                "This is because aggregation, such as averaging values across ROIs, "
+                "will produce invalid results."
+            )
 
     def _fit(self, dataset):
         pymare_dset = pymare.Dataset(y=self.inputs_["z_maps"])
@@ -104,6 +111,13 @@ class Stouffers(MetaEstimator):
 
     def __init__(self, use_sample_size=False, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if not isinstance(self.masker, NiftiMasker):
+            raise ValueError(
+                "Only NiftiMaskers are allowed for this Estimator. "
+                "This is because aggregation, such as averaging values across ROIs, "
+                "will produce invalid results."
+            )
+
         self.use_sample_size = use_sample_size
         if self.use_sample_size:
             self._required_inputs["sample_sizes"] = ("metadata", "sample_sizes")
@@ -168,6 +182,13 @@ class WeightedLeastSquares(MetaEstimator):
 
     def __init__(self, tau2=0, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if not isinstance(self.masker, NiftiMasker):
+            LGR.warning(
+                f"A {type(self.masker)} mask has been detected. "
+                "Masks which average across voxels will likely produce biased results when used "
+                "with this Estimator."
+            )
+
         self.tau2 = tau2
 
     def _fit(self, dataset):
@@ -218,6 +239,12 @@ class DerSimonianLaird(MetaEstimator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if not isinstance(self.masker, NiftiMasker):
+            LGR.warning(
+                f"A {type(self.masker)} mask has been detected. "
+                "Masks which average across voxels will likely produce biased results when used "
+                "with this Estimator."
+            )
 
     def _fit(self, dataset):
         est = pymare.estimators.DerSimonianLaird()
@@ -263,6 +290,12 @@ class Hedges(MetaEstimator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if not isinstance(self.masker, NiftiMasker):
+            LGR.warning(
+                f"A {type(self.masker)} mask has been detected. "
+                "Masks which average across voxels will likely produce biased results when used "
+                "with this Estimator."
+            )
 
     def _fit(self, dataset):
         est = pymare.estimators.Hedges()
@@ -390,6 +423,13 @@ class VarianceBasedLikelihood(MetaEstimator):
 
     def __init__(self, method="ml", *args, **kwargs):
         super().__init__(*args, **kwargs)
+        if not isinstance(self.masker, NiftiMasker):
+            LGR.warning(
+                f"A {type(self.masker)} mask has been detected. "
+                "Masks which average across voxels will likely produce biased results when used "
+                "with this Estimator."
+            )
+
         self.method = method
 
     def _fit(self, dataset):

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -1,4 +1,5 @@
 """Test nimare.meta.ibma (image-based meta-analytic estimators)."""
+import logging
 import os.path as op
 from contextlib import ExitStack as does_not_raise
 
@@ -111,15 +112,44 @@ def test_ibma_smoke(testdata_ibma, meta, meta_kwargs, corrector, corrector_kwarg
         assert cres.get_map("z").ndim == 3
 
 
-def test_ibma_with_custom_masker(testdata_ibma):
-    """Ensure voxel-to-ROI reduction works."""
+@pytest.mark.parametrize(
+    "estimator,expectation",
+    [
+        (ibma.Fishers, "error"),
+        (ibma.Stouffers, "error"),
+        (ibma.WeightedLeastSquares, "warning"),
+        (ibma.DerSimonianLaird, "warning"),
+        (ibma.Hedges, "warning"),
+        (ibma.SampleSizeBasedLikelihood, "no warning"),
+        (ibma.VarianceBasedLikelihood, "warning"),
+        (ibma.PermutedOLS, "no warning"),
+    ],
+)
+def test_ibma_with_custom_masker(testdata_ibma, caplog, estimator, expectation):
+    """Ensure voxel-to-ROI reduction works, but only for Estimators that allow it."""
     atlas = op.join(get_test_data_path(), "test_pain_dataset", "atlas.nii.gz")
     masker = NiftiLabelsMasker(atlas)
-    meta = ibma.Fishers(mask=masker)
-    meta.fit(testdata_ibma)
-    assert isinstance(meta.results, nimare.results.MetaResult)
-    assert meta.results.maps["z"].shape == (5,)
-    assert meta.results.get_map("z").shape == (10, 10, 10)
+
+    if expectation == "error":
+        with pytest.raises(ValueError):
+            meta = estimator(mask=masker)
+    elif expectation == "warning":
+        with caplog.at_level(logging.WARNING, logger="nimare.meta.ibma"):
+            meta = estimator(mask=masker)
+            assert "will likely produce biased results" in caplog.text
+        caplog.clear()
+    else:
+        with caplog.at_level(logging.WARNING, logger="nimare.meta.ibma"):
+            meta = estimator(mask=masker)
+            assert "will likely produce biased results" not in caplog.text
+        caplog.clear()
+
+    # Only fit the estimator if it doesn't raise a ValueError
+    if expectation != "error":
+        meta.fit(testdata_ibma)
+        assert isinstance(meta.results, nimare.results.MetaResult)
+        assert meta.results.maps["z"].shape == (5,)
+        assert meta.results.get_map("z").shape == (10, 10, 10)
 
 
 @pytest.mark.parametrize(

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -113,40 +113,48 @@ def test_ibma_smoke(testdata_ibma, meta, meta_kwargs, corrector, corrector_kwarg
 
 
 @pytest.mark.parametrize(
-    "estimator,expectation",
+    "estimator,expectation,masker_source",
     [
-        (ibma.Fishers, "error"),
-        (ibma.Stouffers, "error"),
-        (ibma.WeightedLeastSquares, "warning"),
-        (ibma.DerSimonianLaird, "warning"),
-        (ibma.Hedges, "warning"),
-        (ibma.SampleSizeBasedLikelihood, "no warning"),
-        (ibma.VarianceBasedLikelihood, "warning"),
-        (ibma.PermutedOLS, "no warning"),
+        (ibma.Fishers, "error", "estimator"),
+        (ibma.Stouffers, "error", "estimator"),
+        (ibma.WeightedLeastSquares, "warning", "estimator"),
+        (ibma.DerSimonianLaird, "warning", "estimator"),
+        (ibma.Hedges, "warning", "estimator"),
+        (ibma.SampleSizeBasedLikelihood, "no warning", "estimator"),
+        (ibma.VarianceBasedLikelihood, "warning", "estimator"),
+        (ibma.PermutedOLS, "no warning", "estimator"),
     ],
 )
-def test_ibma_with_custom_masker(testdata_ibma, caplog, estimator, expectation):
-    """Ensure voxel-to-ROI reduction works, but only for Estimators that allow it."""
+def test_ibma_with_custom_masker(testdata_ibma, caplog, estimator, expectation, masker_source):
+    """Ensure voxel-to-ROI reduction works, but only for Estimators that allow it.
+
+    Notes
+    -----
+    Currently masker_source is not used, but ultimately we will want to test cases where the
+    Dataset uses a NiftiLabelsMasker.
+    """
     atlas = op.join(get_test_data_path(), "test_pain_dataset", "atlas.nii.gz")
     masker = NiftiLabelsMasker(atlas)
 
+    dset = testdata_ibma
+    meta = estimator(mask=masker)
+
     if expectation == "error":
         with pytest.raises(ValueError):
-            meta = estimator(mask=masker)
+            meta.fit(dset)
     elif expectation == "warning":
         with caplog.at_level(logging.WARNING, logger="nimare.meta.ibma"):
-            meta = estimator(mask=masker)
+            meta.fit(dset)
             assert "will likely produce biased results" in caplog.text
         caplog.clear()
     else:
         with caplog.at_level(logging.WARNING, logger="nimare.meta.ibma"):
-            meta = estimator(mask=masker)
+            meta.fit(dset)
             assert "will likely produce biased results" not in caplog.text
         caplog.clear()
 
     # Only fit the estimator if it doesn't raise a ValueError
     if expectation != "error":
-        meta.fit(testdata_ibma)
         assert isinstance(meta.results, nimare.results.MetaResult)
         assert meta.results.maps["z"].shape == (5,)
         assert meta.results.get_map("z").shape == (10, 10, 10)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #466. The actual investigation into the effect of aggregation on IBMA results can continue in #475.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Raise ValueError at `fit()` of Fishers and Stouffers Estimators if the masker is not a NiftiMasker.
- Log warning at `fit()` of WeightedLeastSquares, DerSimonianLaird, Hedges, and VarianceBasedLikelihood Estimators if the masker is not a NiftiMasker.
- Add test that checks for expected behavior of each Estimator when supplied a NiftiLabelsMasker.
- Add information about valid masking approaches to docstrings of affected Estimators.
