### PR TITLE
[DOC] Change napoleon settings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,8 +27,9 @@ from m2r import MdInclude
 sys.path.insert(0, os.path.abspath(os.path.pardir))
 sys.path.insert(0, os.path.abspath("sphinxext"))
 
-import nimare
 from github_link import make_linkcode_resolve
+
+import nimare
 
 # -- General configuration ------------------------------------------------
 
@@ -105,11 +106,11 @@ pygments_style = "sphinx"
 # -----------------------------------------------------------------------------
 # Napoleon settings
 # -----------------------------------------------------------------------------
-napoleon_google_docstring = True
+napoleon_google_docstring = False
 napoleon_numpy_docstring = True
-napoleon_include_init_with_doc = False
+napoleon_include_init_with_doc = True
 napoleon_include_private_with_doc = False
-napoleon_include_special_with_doc = True
+napoleon_include_special_with_doc = False
 napoleon_use_admonition_for_examples = False
 napoleon_use_admonition_for_notes = False
 napoleon_use_admonition_for_references = False


### PR DESCRIPTION
I don't want to see `__repr__` listed under each class's methods.