### PR TITLE
[ENH] Do not apply IBMA methods to voxels with zeros or NaNs

### DIFF
--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -156,7 +156,9 @@ def test_ibma_with_custom_masker(testdata_ibma, caplog, estimator, expectation, 
     # Only fit the estimator if it doesn't raise a ValueError
     if expectation != "error":
         assert isinstance(meta.results, nimare.results.MetaResult)
-        assert meta.results.maps["z"].shape == (5,)
+        # There are five "labels", but one of them has no good data,
+        # so the outputs should be 4 long.
+        assert meta.results.maps["z"].shape == (4,)
         assert meta.results.get_map("z").shape == (10, 10, 10)
 
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Related to #542 and #274. The issue at hand is that PyMARE raises warnings when provided with arrays that are all zeros, while NiMARE's aggressive masking replaces any voxels with a zero in one or more studies with zeros across all studies. Our current goal is to eliminate that warning by only feeding PyMARE voxels with valid data. 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-
