### PR TITLE
[FIX] Use `resample=True` in IBMA examples

### DIFF
--- a/examples/02_meta-analyses/plot_compare_ibma_and_cbma.py
+++ b/examples/02_meta-analyses/plot_compare_ibma_and_cbma.py
@@ -18,10 +18,10 @@ import pandas as pd
 from nilearn.plotting import plot_stat_map
 
 import nimare
-from nimare.transforms import ImagesToCoordinates, ImageTransformer
-from nimare.meta.ibma import DerSimonianLaird
 from nimare.meta.cbma import ALE
+from nimare.meta.ibma import DerSimonianLaird
 from nimare.tests.utils import get_test_data_path
+from nimare.transforms import ImagesToCoordinates, ImageTransformer
 
 ###############################################################################
 # Download data
@@ -55,7 +55,8 @@ plot_stat_map(
 ###############################################################################
 # DerSimonian-Laird (IBMA)
 # -----------------------------------------------------------------------------
-meta_ibma = DerSimonianLaird()
+# We must resample the image data to the same MNI template as the Dataset.
+meta_ibma = DerSimonianLaird(resample=True)
 meta_ibma.fit(dset)
 plot_stat_map(
     meta_ibma.results.get_map("z"), cut_coords=[0, 0, -8], draw_cross=False, cmap="RdBu_r"

--- a/examples/02_meta-analyses/plot_ibma.py
+++ b/examples/02_meta-analyses/plot_ibma.py
@@ -40,39 +40,40 @@ dset.update_path(dset_dir)
 # Calculate missing images
 xformer = nimare.transforms.ImageTransformer(target=["varcope", "z"])
 dset = xformer.transform(dset)
+raise Exception()
 
 ###############################################################################
 # Stouffer's
 # --------------------------------------------------
-meta = ibma.Stouffers(use_sample_size=False)
+meta = ibma.Stouffers(use_sample_size=False, resample=True)
 meta.fit(dset)
 plot_stat_map(meta.results.get_map("z"), cut_coords=[0, 0, -8], draw_cross=False, cmap="RdBu_r")
 
 ###############################################################################
 # Stouffer's with weighting by sample size
 # -----------------------------------------------------------------------------
-meta = ibma.Stouffers(use_sample_size=True)
+meta = ibma.Stouffers(use_sample_size=True, resample=True)
 meta.fit(dset)
 plot_stat_map(meta.results.get_map("z"), cut_coords=[0, 0, -8], draw_cross=False, cmap="RdBu_r")
 
 ###############################################################################
 # Fisher's
 # -----------------------------------------------------------------------------
-meta = ibma.Fishers()
+meta = ibma.Fishers(resample=True)
 meta.fit(dset)
 plot_stat_map(meta.results.get_map("z"), cut_coords=[0, 0, -8], draw_cross=False, cmap="RdBu_r")
 
 ###############################################################################
 # Permuted OLS
 # -----------------------------------------------------------------------------
-meta = ibma.PermutedOLS(two_sided=True)
+meta = ibma.PermutedOLS(two_sided=True, resample=True)
 meta.fit(dset)
 plot_stat_map(meta.results.get_map("z"), cut_coords=[0, 0, -8], draw_cross=False, cmap="RdBu_r")
 
 ###############################################################################
 # Permuted OLS with FWE Correction
 # -----------------------------------------------------------------------------
-meta = ibma.PermutedOLS(two_sided=True)
+meta = ibma.PermutedOLS(two_sided=True, resample=True)
 meta.fit(dset)
 corrector = FWECorrector(method="montecarlo", n_iters=100, n_cores=1)
 cresult = corrector.transform(meta.results)
@@ -86,20 +87,20 @@ plot_stat_map(
 ###############################################################################
 # Weighted Least Squares
 # -----------------------------------------------------------------------------
-meta = ibma.WeightedLeastSquares(tau2=0)
+meta = ibma.WeightedLeastSquares(tau2=0, resample=True)
 meta.fit(dset)
 plot_stat_map(meta.results.get_map("z"), cut_coords=[0, 0, -8], draw_cross=False, cmap="RdBu_r")
 
 ###############################################################################
 # DerSimonian-Laird
 # -----------------------------------------------------------------------------
-meta = ibma.DerSimonianLaird()
+meta = ibma.DerSimonianLaird(resample=True)
 meta.fit(dset)
 plot_stat_map(meta.results.get_map("z"), cut_coords=[0, 0, -8], draw_cross=False, cmap="RdBu_r")
 
 ###############################################################################
 # Hedges
 # -----------------------------------------------------------------------------
-meta = ibma.Hedges()
+meta = ibma.Hedges(resample=True)
 meta.fit(dset)
 plot_stat_map(meta.results.get_map("z"), cut_coords=[0, 0, -8], draw_cross=False, cmap="RdBu_r")

--- a/examples/02_meta-analyses/plot_ibma.py
+++ b/examples/02_meta-analyses/plot_ibma.py
@@ -40,7 +40,6 @@ dset.update_path(dset_dir)
 # Calculate missing images
 xformer = nimare.transforms.ImageTransformer(target=["varcope", "z"])
 dset = xformer.transform(dset)
-raise Exception()
 
 ###############################################################################
 # Stouffer's


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #543. Basically, this PR uses `resample` when running image-based meta-analyses on the NIDM 21 pain dataset, because that dataset is in MNI space with a 2mm3 resolution and 91x109x91 matrices, but the only MNI brain in `nilearn` from >=0.8.1 has differently-sized matrices.

We still end up with a bunch of warnings because any masking applied to the pain dataset images will now involve resampling, and those images all have NaNs outside their brain coverage, which `nilearn` doesn't like.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Use `resample=True` for all IBMA estimators in examples when running IBMAs on the NIDM 21-pain dataset.

