### PR TITLE
[FIX] Extract relevant metadata in kernel transformers for Dataset-based transform calls

### DIFF
--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -139,7 +139,20 @@ class KernelTransformer(Transformer):
                     elif return_type == "dataset":
                         return dataset.copy()
 
-        # Otherwise, generate the MA maps
+            # Add any metadata the Transformer might need to the coordinates DataFrame
+            # This approach is probably inferior to one which uses a _required_inputs attribute
+            # (like the MetaEstimators), but it should work just fine as long as individual
+            # requirements are written in here.
+            if hasattr(self, "sample_size") and self.sample_size is None:
+                coordinates = add_metadata_to_dataframe(
+                    dataset,
+                    coordinates,
+                    metadata_field="sample_sizes",
+                    target_column="sample_size",
+                    filter_func=np.mean,
+                )
+
+        # Generate the MA maps if they weren't already available as images
         if return_type == "array":
             mask_data = mask.get_fdata().astype(np.bool)
         elif return_type == "image":

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -145,7 +145,11 @@ class KernelTransformer(Transformer):
             # This approach is probably inferior to one which uses a _required_inputs attribute
             # (like the MetaEstimators), but it should work just fine as long as individual
             # requirements are written in here.
-            if hasattr(self, "sample_size") and self.sample_size is None:
+            if (
+                hasattr(self, "sample_size")
+                and (self.sample_size is None)
+                and ("sample_size" not in coordinates.columns)
+            ):
                 coordinates = add_metadata_to_dataframe(
                     dataset,
                     coordinates,

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -83,13 +83,7 @@ def test_ALEKernel_inputdataset_returnimages(testdata_cbma):
 
     Test on Dataset object.
     """
-    # Manually override dataset coordinates file sample sizes
-    # This column would be extracted from metadata and added to coordinates
-    # automatically by the Estimator
-    testdata_cbma = testdata_cbma.copy()
     coordinates = testdata_cbma.coordinates.copy()
-    coordinates["sample_size"] = 20
-    testdata_cbma.coordinates = coordinates
 
     id_ = "pain_03.nidm-1"
     kern = kernel.ALEKernel()


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #547.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Extract sample size information from Dataset metadata and add to coordinates DataFrame within `KernelTransformer.transform()`.
    - I've included a check to ensure that this won't be run if the column already exists in the DataFrame.
    - This fix should only affect `ALEKernel` when run on a `Dataset` instead of a `pandas.DataFrame`, which should only happen when you're called it directly. The CBMAEstimators feed in `pandas.DataFrame`s.
- Test this new behavior.
- Miscellaneous cleanup for kernel module.
