### PR TITLE
[FIX] Separate IJK calculation from coordinate space conversion

### DIFF
--- a/examples/02_meta-analyses/macm.py
+++ b/examples/02_meta-analyses/macm.py
@@ -78,8 +78,8 @@ plotting.plot_stat_map(
 # multiple-comparisons correction.
 
 # First, we must define our null model of reported coordinates in the literature.
-# We will use the IJK coordinates in Neurosynth
-ijk = dset.coordinates[["i", "j", "k"]].values
-scale = nimare.meta.SCALE(ijk=ijk, n_iters=10000, kernel__n=20)
+# We will use the coordinates in Neurosynth
+xyz = dset.coordinates[["x", "y", "z"]].values
+scale = nimare.meta.SCALE(xyz=xyz, n_iters=10000, kernel__n=20)
 scale.fit(dset_sel)
 plotting.plot_stat_map(scale.results.get_map("z_vthresh"), draw_cross=False, cmap="RdBu_r")

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -14,7 +14,7 @@ from nilearn._utils.niimg_conversions import _check_same_fov
 from nilearn.image import concat_imgs, resample_to_img
 
 from .results import MetaResult
-from .utils import get_masker
+from .utils import get_masker, mm2vox
 
 LGR = logging.getLogger(__name__)
 
@@ -404,6 +404,13 @@ class MetaEstimator(Estimator):
                         )
                         if all(f is not None for f in files):
                             self.inputs_["ma_maps"] = files
+
+                # Calculate IJK matrix indices for target mask
+                # Mask space is assumed to be the same as the Dataset's space
+                # These indices are used directly by any KernelTransformer
+                xyz = self.inputs_["coordinates"][["x", "y", "z"]].values
+                ijk = mm2vox(xyz, mask_img.affine)
+                self.inputs_["coordinates"][["i", "j", "k"]] = ijk
 
         # Further reduce image-based inputs to remove "bad" voxels
         # (voxels with zeros or NaNs in any studies)

--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -648,7 +648,7 @@ class Dataset(NiMAREBase):
         mask_ijk = np.vstack(np.where(mask.get_fdata())).T
         distances = cdist(mask_ijk, dset_ijk)
         distances = np.any(distances == 0, axis=0)
-        found_ids = list(self.coordinates.iloc[distances]["id"].unique())
+        found_ids = list(self.coordinates.loc[distances, "id"].unique())
         return found_ids
 
     def get_studies_by_coordinate(self, xyz, r=20):
@@ -673,5 +673,5 @@ class Dataset(NiMAREBase):
         assert xyz.shape[1] == 3 and xyz.ndim == 2
         distances = cdist(xyz, self.coordinates[["x", "y", "z"]].values)
         distances = np.any(distances <= r, axis=0)
-        found_ids = list(self.coordinates.iloc[distances]["id"].unique())
+        found_ids = list(self.coordinates.loc[distances, "id"].unique())
         return found_ids

--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -184,14 +184,10 @@ class Dataset(NiMAREBase):
         if hasattr(self, "masker") and not np.array_equal(
             self.masker.mask_img.affine, mask.mask_img.affine
         ):
-            LGR.info(
-                "New masker does not match old masker. "
-                "Space is assumed to be the same, but coordinates will "
-                "be transformed to new matrix."
-            )
-            coords = self.coordinates
-            coords[["i", "j", "k"]] = mm2vox(coords[["x", "y", "z"]], mask.mask_img.affine)
-            self.coordinates = coords
+            # This message does not have an associated effect,
+            # since matrix indices are calculated as necessary
+            LGR.warning("New masker does not match old masker. Space is assumed to be the same.")
+
         self.__masker = mask
 
     @property

--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -17,7 +17,7 @@ from .utils import (
     get_template,
     listify,
     mm2vox,
-    transform_coordinates_to_ijk,
+    transform_coordinates_to_space,
     try_prepend,
     validate_df,
     validate_images_df,
@@ -331,7 +331,7 @@ class Dataset(NiMAREBase):
             new_df = new_df.where(~new_df.isna(), None)
             setattr(new_dset, attribute, new_df)
 
-        new_dset.coordinates = transform_coordinates_to_ijk(
+        new_dset.coordinates = transform_coordinates_to_space(
             new_dset.coordinates,
             self.masker,
             self.space,

--- a/nimare/info.py
+++ b/nimare/info.py
@@ -51,7 +51,7 @@ REQUIRES = [
     "fuzzywuzzy",
     "indexed_gzip>=1.4.0",
     "nibabel>=3.0.0",
-    "nilearn>=0.7.1",
+    "nilearn>=0.7.1,<0.8.0",
     "numpy",
     "pandas",
     "pymare>=0.0.2",

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -369,9 +369,9 @@ class SCALE(CBMAEstimator):
     n_cores : int, optional
         Number of processes to use for meta-analysis. If -1, use all
         available cores. Default: -1
-    ijk : :obj:`str` or (N x 3) array_like
-        Tab-delimited file of coordinates from database or numpy array with ijk
-        coordinates. Voxels are rows and i, j, k (meaning matrix-space) values
+    xyz : :obj:`str` or (N x 3) array_like
+        Tab-delimited file of coordinates from database or numpy array with XYZ
+        coordinates. Voxels are rows and x, y, z (meaning coordinates) values
         are the three columnns.
     kernel_transformer : :obj:`nimare.meta.kernel.KernelTransformer`, optional
         Kernel with which to convolve coordinates from dataset. Default is
@@ -397,7 +397,7 @@ class SCALE(CBMAEstimator):
         voxel_thresh=0.001,
         n_iters=10000,
         n_cores=-1,
-        ijk=None,
+        xyz=None,
         kernel_transformer=ALEKernel,
         memory_limit=None,
         **kwargs,
@@ -413,7 +413,7 @@ class SCALE(CBMAEstimator):
         super().__init__(kernel_transformer=kernel_transformer, **kwargs)
 
         self.voxel_thresh = voxel_thresh
-        self.ijk = ijk
+        self.xyz = xyz
         self.n_iters = n_iters
         self.n_cores = self._check_ncores(n_cores)
         self.memory_limit = memory_limit
@@ -447,13 +447,13 @@ class SCALE(CBMAEstimator):
         stat_values = self._compute_summarystat(ma_values)
 
         iter_df = self.inputs_["coordinates"].copy()
-        rand_idx = np.random.choice(self.ijk.shape[0], size=(iter_df.shape[0], self.n_iters))
-        rand_ijk = self.ijk[rand_idx, :]
-        iter_ijks = np.split(rand_ijk, rand_ijk.shape[1], axis=1)
+        rand_idx = np.random.choice(self.xyz.shape[0], size=(iter_df.shape[0], self.n_iters))
+        rand_xyz = self.xyz[rand_idx, :]
+        iter_xyzs = np.split(rand_xyz, rand_xyz.shape[1], axis=1)
 
         # Define parameters
         iter_dfs = [iter_df] * self.n_iters
-        params = zip(iter_dfs, iter_ijks)
+        params = zip(iter_dfs, iter_xyzs)
 
         if self.n_cores == 1:
             if self.memory_limit:
@@ -564,8 +564,8 @@ class SCALE(CBMAEstimator):
 
     def _run_permutation(self, params):
         """Run a single random SCALE permutation of a dataset."""
-        iter_df, iter_ijk = params
-        iter_ijk = np.squeeze(iter_ijk)
-        iter_df[["i", "j", "k"]] = iter_ijk
+        iter_df, iter_xyz = params
+        iter_xyz = np.squeeze(iter_xyz)
+        iter_df[["x", "y", "z"]] = iter_xyz
         stat_values = self._compute_summarystat(iter_df)
         return stat_values

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -360,6 +360,10 @@ class ALESubtraction(PairwiseCBMAEstimator):
 class SCALE(CBMAEstimator):
     r"""Specific coactivation likelihood estimation.
 
+    .. versionchanged:: 0.0.10
+
+        Replace ``ijk`` with ``xyz``. This should be easier for users to collect.
+
     Parameters
     ----------
     voxel_thresh : float, optional

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -176,7 +176,7 @@ class KernelTransformer(Transformer):
 
         # Generate the MA maps if they weren't already available as images
         if return_type == "array":
-            mask_data = mask.get_fdata().astype(np.bool)
+            mask_data = mask.get_fdata().astype(bool)
         elif return_type == "image":
             dtype = type(self.value) if hasattr(self, "value") else float
             mask_data = mask.get_fdata().astype(dtype)

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -153,7 +153,9 @@ class KernelTransformer(Transformer):
 
             # Calculate IJK
             if not np.array_equal(mask.affine, dataset.masker.mask_img.affine):
-                coordinates[["i", "j", "k"]] = mm2vox(coordinates[["x", "y", "z"]], mask.affine)
+                LGR.warning("Mask affine does not match Dataset affine. Assuming same space.")
+
+            coordinates[["i", "j", "k"]] = mm2vox(coordinates[["x", "y", "z"]], mask.affine)
 
             # Add any metadata the Transformer might need to the coordinates DataFrame
             # This approach is probably inferior to one which uses a _required_inputs attribute

--- a/nimare/tests/test_dataset.py
+++ b/nimare/tests/test_dataset.py
@@ -3,6 +3,7 @@ import os.path as op
 
 import nibabel as nib
 import numpy as np
+import pytest
 
 import nimare
 from nimare import dataset
@@ -20,10 +21,16 @@ def test_dataset_smoke():
         assert isinstance(method(), list)
         assert isinstance(method(ids=dset.ids[:5]), list)
         assert isinstance(method(ids=dset.ids[0]), list)
+
     assert isinstance(dset.get_images(imtype="beta"), list)
     assert isinstance(dset.get_metadata(field="sample_sizes"), list)
     assert isinstance(dset.get_studies_by_label("cogat_cognitive_control"), list)
     assert isinstance(dset.get_studies_by_coordinate(np.array([[20, 20, 20]])), list)
+
+    # If label is not available, raise ValueError
+    with pytest.raises(ValueError):
+        dset.get_studies_by_label("dog")
+
     mask_data = np.zeros(dset.masker.mask_img.shape, int)
     mask_data[40, 40, 40] = 1
     mask_img = nib.Nifti1Image(mask_data, dset.masker.mask_img.affine)

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -10,6 +10,7 @@ import pytest
 import nimare
 from nimare.correct import FDRCorrector, FWECorrector
 from nimare.meta import ale
+from nimare.utils import vox2mm
 
 
 def test_ALE_ma_map_reuse(testdata_cbma, tmp_path_factory, caplog):
@@ -257,9 +258,12 @@ def test_ALESubtraction_smoke_lowmem(testdata_cbma, tmp_path_factory):
 def test_SCALE_smoke(testdata_cbma):
     """Smoke test for SCALE."""
     dset = testdata_cbma.slice(testdata_cbma.ids[:3])
-    ijk = np.vstack(np.where(testdata_cbma.masker.mask_img.get_fdata())).T
-    ijk = ijk[:, :20]
-    meta = ale.SCALE(n_iters=5, n_cores=1, ijk=ijk)
+    xyz = vox2mm(
+        np.vstack(np.where(testdata_cbma.masker.mask_img.get_fdata())).T,
+        testdata_cbma.masker.mask_img.affine,
+    )
+    xyz = xyz[:, :20]
+    meta = ale.SCALE(n_iters=5, n_cores=1, xyz=xyz)
     res = meta.fit(dset)
     assert isinstance(res, nimare.results.MetaResult)
     assert "z" in res.maps.keys()
@@ -270,9 +274,12 @@ def test_SCALE_smoke(testdata_cbma):
 def test_SCALE_smoke_lowmem(testdata_cbma):
     """Smoke test for SCALE with low memory settings."""
     dset = testdata_cbma.slice(testdata_cbma.ids[:3])
-    ijk = np.vstack(np.where(testdata_cbma.masker.mask_img.get_fdata())).T
-    ijk = ijk[:, :20]
-    meta = ale.SCALE(n_iters=5, n_cores=1, ijk=ijk, memory_limit="1gb")
+    xyz = vox2mm(
+        np.vstack(np.where(testdata_cbma.masker.mask_img.get_fdata())).T,
+        testdata_cbma.masker.mask_img.affine,
+    )
+    xyz = xyz[:, :20]
+    meta = ale.SCALE(n_iters=5, n_cores=1, xyz=xyz, memory_limit="1gb")
     res = meta.fit(dset)
     assert isinstance(res, nimare.results.MetaResult)
     assert "z" in res.maps.keys()

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -1,100 +1,157 @@
 """Test nimare.meta.kernel (CBMA kernel estimators)."""
 import shutil
 
+import nibabel as nib
 import numpy as np
 import pytest
+from nilearn.datasets import load_mni152_brain_mask
 from scipy.ndimage.measurements import center_of_mass
 
 import nimare
 from nimare import extract
 from nimare.dataset import Dataset
 from nimare.meta import MKDADensity, kernel
+from nimare.utils import get_masker, mm2vox
 
 
-def test_ALEKernel_smoke(testdata_cbma):
-    """Smoke test for nimare.meta.kernel.ALEKernel."""
-    # Manually override dataset coordinates file sample sizes
-    # This column would be extracted from metadata and added to coordinates
-    # automatically by the Estimator
+@pytest.mark.parametrize(
+    "kern, res, param, return_type, kwargs",
+    [
+        (kernel.ALEKernel, 1, "dataset", "dataset", {"sample_size": 20}),
+        (kernel.ALEKernel, 2, "dataset", "dataset", {"sample_size": 20}),
+        (kernel.ALEKernel, 1, "dataset", "image", {"sample_size": 20}),
+        (kernel.ALEKernel, 2, "dataset", "image", {"sample_size": 20}),
+        (kernel.ALEKernel, 1, "dataframe", "image", {"sample_size": 20}),
+        (kernel.ALEKernel, 2, "dataframe", "image", {"sample_size": 20}),
+        (kernel.ALEKernel, 1, "dataset", "array", {"sample_size": 20}),
+        (kernel.ALEKernel, 2, "dataset", "array", {"sample_size": 20}),
+        (kernel.ALEKernel, 1, "dataframe", "array", {"sample_size": 20}),
+        (kernel.ALEKernel, 2, "dataframe", "array", {"sample_size": 20}),
+        (kernel.MKDAKernel, 1, "dataset", "image", {"r": 4, "value": 1}),
+        (kernel.MKDAKernel, 2, "dataset", "image", {"r": 4, "value": 1}),
+        (kernel.MKDAKernel, 1, "dataframe", "image", {"r": 4, "value": 1}),
+        (kernel.MKDAKernel, 2, "dataframe", "image", {"r": 4, "value": 1}),
+        (kernel.KDAKernel, 1, "dataset", "image", {"r": 4, "value": 1}),
+        (kernel.KDAKernel, 2, "dataset", "image", {"r": 4, "value": 1}),
+        (kernel.KDAKernel, 1, "dataframe", "image", {"r": 4, "value": 1}),
+        (kernel.KDAKernel, 2, "dataframe", "image", {"r": 4, "value": 1}),
+    ],
+)
+def test_kernel_peaks(testdata_cbma, tmp_path_factory, kern, res, param, return_type, kwargs):
+    """Peak/COMs of kernel maps should match the foci fed in (assuming focus isn't masked out).
+
+    Notes
+    -----
+    Remember that dataframe --> dataset won't work.
+    Only testing dataset --> dataset with ALEKernel because it takes a while.
+    Test on multiple template resolutions.
+    """
+    tmpdir = tmp_path_factory.mktemp("test_kernel_peaks")
+    testdata_cbma.update_path(tmpdir)
+
+    id_ = "pain_03.nidm-1"
+    template = load_mni152_brain_mask(resolution=res)
+    masker = get_masker(template)
+
+    xyz = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["x", "y", "z"]]
+    ijk = mm2vox(xyz, masker.mask_img.affine)
+    ijk = np.squeeze(ijk.astype(int))
+
+    if param == "dataframe":
+        input_ = testdata_cbma.coordinates.copy()
+    elif param == "dataset":
+        input_ = testdata_cbma.copy()
+
+    kern_instance = kern(**kwargs)
+    output = kern_instance.transform(input_, masker, return_type=return_type)
+
+    if return_type == "image":
+        kern_data = output[0].get_fdata()
+    elif return_type == "array":
+        kern_data = np.squeeze(masker.inverse_transform(output[:1, :]).get_fdata())
+    else:
+        f = output.images.loc[output.images["id"] == id_, kern_instance.image_type].values[0]
+        kern_data = nib.load(f).get_fdata()
+
+    if isinstance(kern_instance, kernel.ALEKernel):
+        loc_idx = np.array(np.where(kern_data == np.max(kern_data))).T
+    elif isinstance(kern_instance, (kernel.MKDAKernel, kernel.KDAKernel)):
+        loc_idx = np.array(center_of_mass(kern_data)).astype(int).T
+    else:
+        raise Exception(f"A {type(kern_instance)}? Why?")
+
+    loc_ijk = np.squeeze(loc_idx)
+
+    assert np.array_equal(ijk, loc_ijk)
+
+
+@pytest.mark.parametrize(
+    "kern, kwargs",
+    [
+        (kernel.ALEKernel, {"sample_size": 20}),
+        (kernel.MKDAKernel, {"r": 4, "value": 1}),
+        (kernel.KDAKernel, {"r": 4, "value": 1}),
+    ],
+)
+def test_kernel_transform_attributes(testdata_cbma, kern, kwargs):
+    """Check that attributes are added at transform."""
+    kern_instance = kern(**kwargs)
+    assert not hasattr(kern_instance, "filename_pattern")
+    assert not hasattr(kern_instance, "image_type")
+    _ = kern_instance.transform(testdata_cbma, return_type="image")
+    assert hasattr(kern_instance, "filename_pattern")
+    assert hasattr(kern_instance, "image_type")
+
+
+@pytest.mark.parametrize(
+    "kern, kwargs, set_kwargs",
+    [
+        (kernel.ALEKernel, {"sample_size": 20}, {"sample_size": None, "fwhm": 10}),
+        (kernel.MKDAKernel, {"r": 4, "value": 1}, {"r": 10, "value": 3}),
+        (kernel.KDAKernel, {"r": 4, "value": 1}, {"r": 10, "value": 3}),
+    ],
+)
+def test_kernel_smoke(testdata_cbma, kern, kwargs, set_kwargs):
+    """Smoke test for different kernel transformers and check that you can reset params."""
     coordinates = testdata_cbma.coordinates.copy()
-    coordinates["sample_size"] = 20
 
-    kern = kernel.ALEKernel()
-    ma_maps = kern.transform(coordinates, testdata_cbma.masker, return_type="image")
+    kern_instance = kern(**kwargs)
+    ma_maps = kern_instance.transform(coordinates, testdata_cbma.masker, return_type="image")
     assert len(ma_maps) == len(testdata_cbma.ids) - 2
-    ma_maps = kern.transform(coordinates, testdata_cbma.masker, return_type="array")
+    ma_maps = kern_instance.transform(coordinates, testdata_cbma.masker, return_type="array")
     assert ma_maps.shape[0] == len(testdata_cbma.ids) - 2
+
     # Test set_params
-    kern.set_params(fwhm=10, sample_size=None)
-    kern2 = kernel.ALEKernel(fwhm=10)
-    ma_maps1 = kern.transform(coordinates, testdata_cbma.masker, return_type="array")
-    ma_maps2 = kern2.transform(coordinates, testdata_cbma.masker, return_type="array")
+    kern_instance.set_params(**set_kwargs)
+    kern_instance2 = kern(**set_kwargs)
+    ma_maps1 = kern_instance.transform(coordinates, testdata_cbma.masker, return_type="array")
+    ma_maps2 = kern_instance2.transform(coordinates, testdata_cbma.masker, return_type="array")
     assert ma_maps1.shape[0] == ma_maps2.shape[0] == len(testdata_cbma.ids) - 2
     assert np.array_equal(ma_maps1, ma_maps2)
 
 
-def test_ALEKernel_1mm(testdata_cbma):
-    """Peaks of ALE kernel maps should match the foci fed in (assuming focus isn't masked out).
-
-    Test on 1mm template.
-    """
-    # Manually override dataset coordinates file sample sizes
-    # This column would be extracted from metadata and added to coordinates
-    # automatically by the Estimator
-    coordinates = testdata_cbma.coordinates.copy()
-    coordinates["sample_size"] = 20
-
-    id_ = "pain_03.nidm-1"
-    kern = kernel.ALEKernel()
-    ma_maps = kern.transform(coordinates, testdata_cbma.masker, return_type="image")
-    ijk = coordinates.loc[coordinates["id"] == id_, ["i", "j", "k"]]
-    ijk = ijk.values.astype(int)
-    kern_data = ma_maps[0].get_fdata()
-    max_idx = np.where(kern_data == np.max(kern_data))
-    max_ijk = np.array(max_idx).T
-    assert np.array_equal(ijk, max_ijk)
-
-
-def test_ALEKernel_2mm(testdata_cbma):
-    """Peaks of ALE kernel maps should match the foci fed in (assuming focus isn't masked out).
-
-    Test on 2mm template.
-    """
-    # Manually override dataset coordinates file sample sizes
-    # This column would be extracted from metadata and added to coordinates
-    # automatically by the Estimator
-    coordinates = testdata_cbma.coordinates.copy()
-    coordinates["sample_size"] = 20
-
-    id_ = "pain_03.nidm-1"
-    kern = kernel.ALEKernel()
-    ma_maps = kern.transform(coordinates, masker=testdata_cbma.masker, return_type="image")
-
-    ijk = coordinates.loc[coordinates["id"] == id_, ["i", "j", "k"]]
-    ijk = np.squeeze(ijk.values.astype(int))
-    kern_data = ma_maps[0].get_fdata()
-    max_idx = np.array(np.where(kern_data == np.max(kern_data))).T
-    max_ijk = np.squeeze(max_idx)
-    assert np.array_equal(ijk, max_ijk)
-
-
-def test_ALEKernel_inputdataset_returnimages(testdata_cbma):
-    """Peaks of ALE kernel maps should match the foci fed in (assuming focus isn't masked out).
-
-    Test on Dataset object.
-    """
-    coordinates = testdata_cbma.coordinates.copy()
-
-    id_ = "pain_03.nidm-1"
-    kern = kernel.ALEKernel()
-    ma_maps = kern.transform(testdata_cbma, return_type="image")
-
-    ijk = coordinates.loc[coordinates["id"] == id_, ["i", "j", "k"]]
-    ijk = np.squeeze(ijk.values.astype(int))
-    kern_data = ma_maps[0].get_fdata()
-    max_idx = np.array(np.where(kern_data == np.max(kern_data))).T
-    max_ijk = np.squeeze(max_idx)
-    assert np.array_equal(ijk, max_ijk)
+@pytest.mark.parametrize(
+    "kern, kwargs",
+    [
+        (kernel.ALEKernel, {"sample_size": 20}),
+        (kernel.KDAKernel, {}),
+        (kernel.MKDAKernel, {}),
+    ],
+)
+def test_kernel_low_high_memory(testdata_cbma, tmp_path_factory, kern, kwargs):
+    """Compare kernel results when memory_limit is used vs. not."""
+    kern_low_mem = kern(memory_limit="1gb", **kwargs)
+    kern_spec_mem = kern(memory_limit="2gb", **kwargs)
+    kern_high_mem = kern(memory_limit=None, **kwargs)
+    trans_kwargs = {"dataset": testdata_cbma, "return_type": "array"}
+    assert np.array_equal(
+        kern_low_mem.transform(**trans_kwargs),
+        kern_high_mem.transform(**trans_kwargs),
+    )
+    assert np.array_equal(
+        kern_low_mem.transform(**trans_kwargs),
+        kern_spec_mem.transform(**trans_kwargs),
+    )
 
 
 def test_ALEKernel_fwhm(testdata_cbma):
@@ -108,8 +165,10 @@ def test_ALEKernel_fwhm(testdata_cbma):
     kern = kernel.ALEKernel(fwhm=10)
     ma_maps = kern.transform(coordinates, masker=testdata_cbma.masker, return_type="image")
 
-    ijk = coordinates.loc[coordinates["id"] == id_, ["i", "j", "k"]]
-    ijk = np.squeeze(ijk.values.astype(int))
+    xyz = coordinates.loc[coordinates["id"] == id_, ["x", "y", "z"]]
+    ijk = mm2vox(xyz, testdata_cbma.masker.mask_img.affine)
+    ijk = np.squeeze(ijk.astype(int))
+
     kern_data = ma_maps[0].get_fdata()
     max_idx = np.array(np.where(kern_data == np.max(kern_data))).T
     max_ijk = np.squeeze(max_idx)
@@ -127,198 +186,14 @@ def test_ALEKernel_sample_size(testdata_cbma):
     kern = kernel.ALEKernel(sample_size=20)
     ma_maps = kern.transform(coordinates, masker=testdata_cbma.masker, return_type="image")
 
-    ijk = coordinates.loc[coordinates["id"] == id_, ["i", "j", "k"]]
-    ijk = np.squeeze(ijk.values.astype(int))
+    xyz = coordinates.loc[coordinates["id"] == id_, ["x", "y", "z"]]
+    ijk = mm2vox(xyz, testdata_cbma.masker.mask_img.affine)
+    ijk = np.squeeze(ijk.astype(int))
+
     kern_data = ma_maps[0].get_fdata()
     max_idx = np.array(np.where(kern_data == np.max(kern_data))).T
     max_ijk = np.squeeze(max_idx)
     assert np.array_equal(ijk, max_ijk)
-
-
-def test_ALEKernel_inputdataset_returndataset(testdata_cbma, tmp_path_factory):
-    """Check that all return types produce equivalent results (minus the masking element)."""
-    tmpdir = tmp_path_factory.mktemp("test_ALEKernel_inputdataset_returndataset")
-    testdata_cbma.update_path(tmpdir)
-    kern = kernel.ALEKernel(sample_size=20, memory_limit="1gb")
-    ma_maps = kern.transform(testdata_cbma, return_type="image")
-    ma_arr = kern.transform(testdata_cbma, return_type="array")
-    dset = kern.transform(testdata_cbma, return_type="dataset")
-    ma_maps_from_dset = kern.transform(dset, return_type="image")
-    ma_arr_from_dset = kern.transform(dset, return_type="array")
-    ma_maps_arr = testdata_cbma.masker.transform(ma_maps)
-    ma_maps_from_dset_arr = dset.masker.transform(ma_maps_from_dset)
-    dset_from_dset = kern.transform(dset, return_type="dataset")
-    ids = dset.coordinates["id"].unique()
-    ma_maps_dset = testdata_cbma.masker.transform(dset.get_images(ids=ids, imtype=kern.image_type))
-    assert isinstance(dset_from_dset, Dataset)
-    assert np.array_equal(ma_arr, ma_maps_arr)
-    assert np.array_equal(ma_arr, ma_maps_dset)
-    assert np.array_equal(ma_arr, ma_maps_from_dset_arr)
-    assert np.array_equal(ma_arr, ma_arr_from_dset)
-
-
-def test_MKDAKernel_smoke(testdata_cbma):
-    """Smoke test for nimare.meta.kernel.MKDAKernel, using Dataset object."""
-    kern = kernel.MKDAKernel()
-    ma_maps = kern.transform(testdata_cbma, return_type="image")
-    assert len(ma_maps) == len(testdata_cbma.ids) - 2
-    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="array")
-    assert ma_maps.shape[0] == len(testdata_cbma.ids) - 2
-
-
-def test_MKDAKernel_1mm(testdata_cbma):
-    """Centers of mass of MKDA kernel maps should match the foci fed in.
-
-    This assumes the focus isn't masked out and spheres don't overlap.
-    Test on 1mm template.
-    """
-    id_ = "pain_03.nidm-1"
-    kern = kernel.MKDAKernel(r=4, value=1, memory_limit="1gb")
-    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="image")
-
-    ijk = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["i", "j", "k"]]
-    ijk = np.squeeze(ijk.values.astype(int))
-    kern_data = ma_maps[0].get_fdata()
-    com = np.array(center_of_mass(kern_data)).astype(int).T
-    com = np.squeeze(com)
-    assert np.array_equal(ijk, com)
-
-
-def test_MKDAKernel_2mm(testdata_cbma):
-    """Centers of mass of MKDA kernel maps should match the foci fed in.
-
-    This assumes the focus isn't masked out and spheres don't overlap.
-    Test on 2mm template.
-    """
-    id_ = "pain_03.nidm-1"
-    kern = kernel.MKDAKernel(r=4, value=1)
-    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="image")
-
-    ijk = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["i", "j", "k"]]
-    ijk = np.squeeze(ijk.values.astype(int))
-    kern_data = ma_maps[0].get_fdata()
-    com = np.array(center_of_mass(kern_data)).astype(int).T
-    com = np.squeeze(com)
-    assert np.array_equal(ijk, com)
-
-
-def test_MKDAKernel_inputdataset_returndataset(testdata_cbma, tmp_path_factory):
-    """Check that all return types produce equivalent results (minus the masking element)."""
-    tmpdir = tmp_path_factory.mktemp("test_MKDAKernel_inputdataset_returndataset")
-    testdata_cbma.update_path(tmpdir)
-    kern = kernel.MKDAKernel(r=4, value=1)
-    ma_maps = kern.transform(testdata_cbma, return_type="image")
-    ma_arr = kern.transform(testdata_cbma, return_type="array")
-    dset = kern.transform(testdata_cbma, return_type="dataset")
-    ma_maps_from_dset = kern.transform(dset, return_type="image")
-    ma_arr_from_dset = kern.transform(dset, return_type="array")
-    dset_from_dset = kern.transform(dset, return_type="dataset")
-    ma_maps_arr = testdata_cbma.masker.transform(ma_maps)
-    ma_maps_from_dset_arr = dset.masker.transform(ma_maps_from_dset)
-    ids = dset.coordinates["id"].unique()
-    ma_maps_dset = testdata_cbma.masker.transform(dset.get_images(ids=ids, imtype=kern.image_type))
-    assert isinstance(dset_from_dset, Dataset)
-    assert np.array_equal(ma_arr, ma_maps_arr)
-    assert np.array_equal(ma_arr, ma_maps_dset)
-    assert np.array_equal(ma_arr, ma_maps_from_dset_arr)
-    assert np.array_equal(ma_arr, ma_arr_from_dset)
-
-
-def test_KDAKernel_smoke(testdata_cbma):
-    """Smoke test for nimare.meta.kernel.KDAKernel."""
-    kern = kernel.KDAKernel()
-    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="image")
-    assert len(ma_maps) == len(testdata_cbma.ids) - 2
-    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="array")
-    assert ma_maps.shape[0] == len(testdata_cbma.ids) - 2
-
-
-def test_KDAKernel_1mm(testdata_cbma):
-    """Centers of mass of KDA kernel maps should match the foci fed in.
-
-    This assumes focus isn't masked out and spheres don't overlap.
-    Test on 1mm template.
-    """
-    id_ = "pain_03.nidm-1"
-    kern = kernel.KDAKernel(r=4, value=1)
-    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="image")
-
-    ijk = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["i", "j", "k"]]
-    ijk = np.squeeze(ijk.values.astype(int))
-    kern_data = ma_maps[0].get_fdata()
-    com = np.array(center_of_mass(kern_data)).astype(int).T
-    com = np.squeeze(com)
-    assert np.array_equal(ijk, com)
-
-
-def test_KDAKernel_2mm(testdata_cbma):
-    """Centers of mass of KDA kernel maps should match the foci fed in.
-
-    This assumes focus isn't masked out and spheres don't overlap.
-    Test on 2mm template.
-    """
-    id_ = "pain_03.nidm-1"
-    kern = kernel.KDAKernel(r=4, value=1)
-    ma_maps = kern.transform(testdata_cbma.coordinates, testdata_cbma.masker, return_type="image")
-
-    ijk = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["i", "j", "k"]]
-    ijk = np.squeeze(ijk.values.astype(int))
-    kern_data = ma_maps[0].get_fdata()
-    com = np.array(center_of_mass(kern_data)).astype(int).T
-    com = np.squeeze(com)
-    assert np.array_equal(ijk, com)
-
-
-def test_KDAKernel_inputdataset_returnimages(testdata_cbma):
-    """Centers of mass of KDA kernel maps should match the foci fed in.
-
-    This assumes focus isn't masked out and spheres don't overlap.
-    Test on Dataset object.
-    """
-    id_ = "pain_03.nidm-1"
-    kern = kernel.KDAKernel(r=4, value=1)
-    ma_maps = kern.transform(testdata_cbma, return_type="image")
-
-    ijk = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["i", "j", "k"]]
-    ijk = np.squeeze(ijk.values.astype(int))
-    kern_data = ma_maps[0].get_fdata()
-    com = np.array(center_of_mass(kern_data)).astype(int).T
-    com = np.squeeze(com)
-    assert np.array_equal(ijk, com)
-
-
-def test_KDAKernel_inputdataset_returndataset(testdata_cbma, tmp_path_factory):
-    """Check that the different return types produce equivalent results (minus masking)."""
-    tmpdir = tmp_path_factory.mktemp("test_KDAKernel_inputdataset_returndataset")
-    testdata_cbma.update_path(tmpdir)
-    kern = kernel.KDAKernel(r=4, value=1)
-    # MA map generation from transformer
-    ma_maps = kern.transform(testdata_cbma, return_type="image")
-    ma_arr = kern.transform(testdata_cbma, return_type="array")
-    dset = kern.transform(testdata_cbma, return_type="dataset")
-    # Load generated MA maps
-    ma_maps_from_dset = kern.transform(dset, return_type="image")
-    ma_arr_from_dset = kern.transform(dset, return_type="array")
-    dset_from_dset = kern.transform(dset, return_type="dataset")
-    ma_maps_arr = testdata_cbma.masker.transform(ma_maps)
-    ma_maps_from_dset_arr = dset.masker.transform(ma_maps_from_dset)
-    ids = dset.coordinates["id"].unique()
-    ma_maps_dset = testdata_cbma.masker.transform(dset.get_images(ids=ids, imtype=kern.image_type))
-    assert isinstance(dset_from_dset, Dataset)
-    assert np.array_equal(ma_arr, ma_maps_arr)
-    assert np.array_equal(ma_arr, ma_maps_dset)
-    assert np.array_equal(ma_arr, ma_maps_from_dset_arr)
-    assert np.array_equal(ma_arr, ma_arr_from_dset)
-
-
-def test_KDAKernel_transform_attributes(testdata_cbma):
-    """Check that attributes are added at transform."""
-    kern = kernel.KDAKernel(r=4, value=1)
-    assert not hasattr(kern, "filename_pattern")
-    assert not hasattr(kern, "image_type")
-    _ = kern.transform(testdata_cbma, return_type="image")
-    assert hasattr(kern, "filename_pattern")
-    assert hasattr(kern, "image_type")
 
 
 def test_Peaks2MapsKernel(testdata_cbma, tmp_path_factory):
@@ -362,27 +237,3 @@ def test_Peaks2MapsKernel_MKDADensity(testdata_cbma, tmp_path_factory):
     res = est.fit(testdata_cbma)
     assert isinstance(res, nimare.results.MetaResult)
     assert res.get_map("p", return_type="array").dtype == np.float64
-
-
-@pytest.mark.parametrize(
-    "kern, kwargs",
-    [
-        (kernel.ALEKernel, {"sample_size": 20}),
-        (kernel.KDAKernel, {}),
-        (kernel.MKDAKernel, {}),
-    ],
-)
-def test_kernel_low_high_memory(testdata_cbma, tmp_path_factory, kern, kwargs):
-    """Compare kernel results when memory_limit is used vs. not."""
-    kern_low_mem = kern(memory_limit="1gb", **kwargs)
-    kern_spec_mem = kern(memory_limit="2gb", **kwargs)
-    kern_high_mem = kern(memory_limit=None, **kwargs)
-    trans_kwargs = {"dataset": testdata_cbma, "return_type": "array"}
-    assert np.array_equal(
-        kern_low_mem.transform(**trans_kwargs),
-        kern_high_mem.transform(**trans_kwargs),
-    )
-    assert np.array_equal(
-        kern_low_mem.transform(**trans_kwargs),
-        kern_spec_mem.transform(**trans_kwargs),
-    )

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -50,7 +50,10 @@ def test_kernel_peaks(testdata_cbma, tmp_path_factory, kern, res, param, return_
     testdata_cbma.update_path(tmpdir)
 
     id_ = "pain_03.nidm-1"
-    template = load_mni152_brain_mask(resolution=res)
+
+    # Ignoring resolution until we support 0.8.1
+    # template = load_mni152_brain_mask(resolution=res)
+    template = load_mni152_brain_mask()
     masker = get_masker(template)
 
     xyz = testdata_cbma.coordinates.loc[testdata_cbma.coordinates["id"] == id_, ["x", "y", "z"]]

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -123,11 +123,11 @@ def dict_to_coordinates(data, masker, space):
     # replace nan with none
     df = df.where(pd.notnull(df), None)
     df[["x", "y", "z"]] = df[["x", "y", "z"]].astype(float)
-    df = transform_coordinates_to_ijk(df, masker, space)
+    df = transform_coordinates_to_space(df, masker, space)
     return df
 
 
-def transform_coordinates_to_ijk(df, masker, space):
+def transform_coordinates_to_space(df, masker, space):
     """Convert xyz coordinates in a DataFrame to ijk indices for a given target space.
 
     Parameters
@@ -164,9 +164,6 @@ def transform_coordinates_to_ijk(df, masker, space):
             df.loc[idx, ["x", "y", "z"]] = alg(df.loc[idx, ["x", "y", "z"]].values)
         df.loc[idx, "space"] = space
 
-    xyz = df[["x", "y", "z"]].values
-    ijk = mm2vox(xyz, masker.mask_img.affine)
-    df[["i", "j", "k"]] = ijk
     return df
 
 

--- a/nimare/workflows/scale.py
+++ b/nimare/workflows/scale.py
@@ -9,6 +9,7 @@ import numpy as np
 from ..dataset import Dataset
 from ..io import convert_sleuth_to_dataset
 from ..meta import SCALE
+from ..utils import vox2mm
 
 LGR = logging.getLogger(__name__)
 
@@ -60,11 +61,14 @@ rates. NeuroImage, 99, 559-570.
     # indices matching the dataset template, where the base rate for a given
     # voxel is reflected by the number of times that voxel appears in the array
     if not baseline:
-        ijk = np.vstack(np.where(dset.masker.mask_img.get_fdata())).T
+        xyz = vox2mm(
+            np.vstack(np.where(dset.masker.mask_img.get_fdata())).T,
+            dset.masker.mask_img.affine,
+        )
     else:
-        ijk = np.loadtxt(baseline)
+        xyz = np.loadtxt(baseline)
 
-    estimator = SCALE(ijk=ijk, n_iters=n_iters, n_cores=n_cores)
+    estimator = SCALE(xyz=xyz, n_iters=n_iters, n_cores=n_cores)
     estimator.fit(dset)
 
     if output_dir is None:


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #555, though this may not be our permanent solution.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Replace `np.bool` with `bool`, because it's being deprecated.
- Calculate IJK as needed within `KernelTransformer`, `Dataset.get_studies_by_mask`, and `MetaEstimator`.
- Fix bug in `Dataset.get_studies_by_label` in which, when the provided label was missing from the `Dataset.annotations` DataFrame, all Dataset IDs would be returned without so much as a warning.
- Replace basically every use of IJK with XYZ... hopefully I caught it all!
- Restructure the kernel tests to loop through parameters rather than having separate tests that are mostly duplicates of one another.
- Pin nilearn version to less than 0.8.0, to avoid the changes to the MNI152 template.
