### PR TITLE
[FIX] Reference selected features instead of initial features in CorrelationDecoder

### DIFF
--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -191,7 +191,7 @@ class CorrelationDecoder(Decoder):
             feature_ids = sorted(list(set(feature_ids).intersection(self.inputs_["id"])))
 
             LGR.info(
-                f"Decoding {feature} ({i}/{len(self.features)}): {len(feature_ids)}/"
+                f"Decoding {feature} ({i}/{len(self.features_)}): {len(feature_ids)}/"
                 f"{len(dataset.ids)} studies"
             )
             feature_dset = dataset.slice(feature_ids)


### PR DESCRIPTION
Closes #559.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- When referencing the list of features used in the decoder, use `self.features_` (the final set) instead of `self.features` (the initial set, which may be `None`).
