### PR TITLE
[REF] Reduce memory in CBMA Estimators

### DIFF
--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -379,6 +379,8 @@ class CBMAEstimator(MetaEstimator):
         )
         iter_ss_map = self.compute_summarystat(iter_ma_maps)
 
+        del iter_ma_maps
+
         # Get bin edges for histogram
         bin_centers = self.null_distributions_["histogram_bins"]
         step_size = bin_centers[1] - bin_centers[0]
@@ -475,11 +477,17 @@ class CBMAEstimator(MetaEstimator):
             iter_df, masker=self.masker, return_type="array"
         )
         iter_ss_map = self.compute_summarystat(iter_ma_maps)
+
+        del iter_ma_maps
+
         iter_max_value = np.max(iter_ss_map)
         iter_ss_map = self.masker.inverse_transform(iter_ss_map).get_fdata().copy()
         iter_ss_map[iter_ss_map <= voxel_thresh] = 0
 
         labeled_matrix = ndimage.measurements.label(iter_ss_map, conn)[0]
+
+        del iter_ss_map
+
         _, clust_sizes = np.unique(labeled_matrix, return_counts=True)
         clust_sizes = clust_sizes[1:]  # First cluster is zeros in matrix
         if clust_sizes.size:

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -404,7 +404,13 @@ class MKDAChi2(PairwiseCBMAEstimator):
         else:
             with mp.Pool(n_cores) as p:
                 perm_results = list(tqdm(p.imap(self._run_fwe_permutation, params), total=n_iters))
+
+        del iter_df1, iter_df2, iter_dfs1, iter_dfs2, rand_idx1, rand_ijk1, iter_ijks1,
+        del rand_idx2, rand_ijk2, iter_ijks2, params
+
         pAgF_null_chi2_dist, pFgA_null_chi2_dist = zip(*perm_results)
+
+        del perm_results
 
         # pAgF_FWE
         pAgF_null_chi2_dist = np.squeeze(pAgF_null_chi2_dist)

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -297,14 +297,18 @@ class MKDAChi2(PairwiseCBMAEstimator):
         temp_ma_maps1 = self.kernel_transformer.transform(
             iter_df1, self.masker, return_type="array"
         )
+        n_selected = temp_ma_maps1.shape[0]
+        n_selected_active_voxels = np.sum(temp_ma_maps1, axis=0)
+
+        del temp_ma_maps1
+
         temp_ma_maps2 = self.kernel_transformer.transform(
             iter_df2, self.masker, return_type="array"
         )
-
-        n_selected = temp_ma_maps1.shape[0]
         n_unselected = temp_ma_maps2.shape[0]
-        n_selected_active_voxels = np.sum(temp_ma_maps1, axis=0)
         n_unselected_active_voxels = np.sum(temp_ma_maps2, axis=0)
+
+        del temp_ma_maps2
 
         # Currently unused conditional probabilities
         # pAgF = n_selected_active_voxels / n_selected
@@ -407,6 +411,9 @@ class MKDAChi2(PairwiseCBMAEstimator):
         pAgF_p_FWE = np.empty_like(pAgF_chi2_vals).astype(float)
         for voxel in range(pFgA_chi2_vals.shape[0]):
             pAgF_p_FWE[voxel] = null_to_p(pAgF_chi2_vals[voxel], pAgF_null_chi2_dist, tail="upper")
+
+        del pAgF_null_chi2_dist
+
         # Crop p-values of 0 or 1 to nearest values that won't evaluate to
         # 0 or 1. Prevents inf z-values.
         pAgF_p_FWE[pAgF_p_FWE < eps] = eps
@@ -418,6 +425,9 @@ class MKDAChi2(PairwiseCBMAEstimator):
         pFgA_p_FWE = np.empty_like(pFgA_chi2_vals).astype(float)
         for voxel in range(pFgA_chi2_vals.shape[0]):
             pFgA_p_FWE[voxel] = null_to_p(pFgA_chi2_vals[voxel], pFgA_null_chi2_dist, tail="upper")
+
+        del pFgA_null_chi2_dist
+
         # Crop p-values of 0 or 1 to nearest values that won't evaluate to
         # 0 or 1. Prevents inf z-values.
         pFgA_p_FWE[pFgA_p_FWE < eps] = eps

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -405,8 +405,8 @@ class MKDAChi2(PairwiseCBMAEstimator):
             with mp.Pool(n_cores) as p:
                 perm_results = list(tqdm(p.imap(self._run_fwe_permutation, params), total=n_iters))
 
-        del iter_df1, iter_df2, iter_dfs1, iter_dfs2, rand_idx1, rand_ijk1, iter_ijks1
-        del rand_idx2, rand_ijk2, iter_ijks2, params
+        del iter_df1, iter_df2, iter_dfs1, iter_dfs2, rand_idx1, rand_xyz1, iter_xyzs1
+        del rand_idx2, rand_xyz2, iter_xyzs2, params
 
         pAgF_null_chi2_dist, pFgA_null_chi2_dist = zip(*perm_results)
 

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -405,7 +405,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
             with mp.Pool(n_cores) as p:
                 perm_results = list(tqdm(p.imap(self._run_fwe_permutation, params), total=n_iters))
 
-        del iter_df1, iter_df2, iter_dfs1, iter_dfs2, rand_idx1, rand_ijk1, iter_ijks1,
+        del iter_df1, iter_df2, iter_dfs1, iter_dfs2, rand_idx1, rand_ijk1, iter_ijks1
         del rand_idx2, rand_ijk2, iter_ijks2, params
 
         pAgF_null_chi2_dist, pFgA_null_chi2_dist = zip(*perm_results)


### PR DESCRIPTION
Closes None, but I'm trying to find a solution for Jennifer Barredo's memory issues, as reported in https://neurostars.org/t/nimare-allocating-resources-to-avoid-memory-crashes/20251

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Delete variables as they become unnecessary within CBMA (especially MKDAChi2) Estimators' FWE correction methods. I don't think this will make a huge difference, but it could help.
