### PR TITLE
[TST] Reorganize tests for speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
       - store_artifacts:
           path: /tmp/data/lint
 
-  test_py36_and_coverage:
+  test_py36:
     working_directory: /tmp/src/NiMARE
     docker:
       - image: continuumio/miniconda3
@@ -144,15 +144,18 @@ jobs:
       - restore_cache:  # load environment
           key: deps9-{{ checksum "nimare/info.py" }}-{{ checksum "setup.py" }}
       - run:
-          name: Run tests and compile coverage
+          name: Run tests
           command:  |
             apt-get update
             apt-get install -yqq make
             apt-get install -yqq curl
             source activate py36_env
             make unittest
-      - codecov/upload:
-          file: /tmp/src/NiMARE/coverage.xml
+            mv /tmp/src/NiMARE/.coverage /tmp/src/coverage/.coverage.py36
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+              - src/coverage/.coverage.py36
 
   test_performance:
     working_directory: /tmp/src/NiMARE
@@ -171,8 +174,11 @@ jobs:
             apt-get install -yqq make
             source activate py36_env
             make performancetest
-      - codecov/upload:
-          file: /tmp/src/NiMARE/coverage.xml
+            mv /tmp/src/NiMARE/.coverage /tmp/src/coverage/.coverage.performance
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+              - src/coverage/.coverage.performance
 
   test_performance_smoke:
     working_directory: /tmp/src/NiMARE
@@ -191,15 +197,42 @@ jobs:
             apt-get install -yqq make
             source activate py36_env
             make performancesmoketest
+            mv /tmp/src/NiMARE/.coverage /tmp/src/coverage/.coverage.performance_smoke
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+              - src/coverage/.coverage.performance_smoke
+
+  merge_coverage:
+    working_directory: /tmp/src/NiMARE
+    docker:
+      - image: continuumio/miniconda3
+    steps:
+      - attach_workspace:
+          at: /tmp
+      - checkout
+      - restore_cache:
+          key: deps9-{{ checksum "nimare/info.py" }}-{{ checksum "setup.py" }}
+      - run:
+          name: Merge coverage files
+          command: |
+            apt-get update
+            apt-get install -yqq curl
+            source activate py36_env
+            cd /tmp/src/coverage/
+            coverage combine
+            coverage xml
+      - store_artifacts:
+          path: /tmp/src/coverage
       - codecov/upload:
-          file: /tmp/src/NiMARE/coverage.xml
+          file: /tmp/src/coverage/coverage.xml
 
 workflows:
   version: 2.1
   run_tests:
     jobs:
       - make_py36_env
-      - test_py36_and_coverage:
+      - test_py36:
           requires:
             - make_py36_env
       - test_performance:
@@ -216,3 +249,8 @@ workflows:
       - style_check:
           requires:
             - make_py36_env
+      - merge_coverage:
+          requires:
+            - test_py36
+            - test_performance
+            - test_performance_smoke

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,7 @@ jobs:
             apt-get install -yqq curl
             source activate py36_env
             make unittest
+            mkdir /tmp/src/coverage
             mv /tmp/src/NiMARE/.coverage /tmp/src/coverage/.coverage.py36
       - persist_to_workspace:
           root: /tmp
@@ -174,6 +175,7 @@ jobs:
             apt-get install -yqq make
             source activate py36_env
             make performancetest
+            mkdir /tmp/src/coverage
             mv /tmp/src/NiMARE/.coverage /tmp/src/coverage/.coverage.performance
       - persist_to_workspace:
           root: /tmp
@@ -197,6 +199,7 @@ jobs:
             apt-get install -yqq make
             source activate py36_env
             make performancesmoketest
+            mkdir /tmp/src/coverage
             mv /tmp/src/NiMARE/.coverage /tmp/src/coverage/.coverage.performance_smoke
       - persist_to_workspace:
           root: /tmp

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,6 +174,26 @@ jobs:
       - codecov/upload:
           file: /tmp/src/NiMARE/coverage.xml
 
+  test_performance_smoke:
+    working_directory: /tmp/src/NiMARE
+    docker:
+      - image: continuumio/miniconda3
+    steps:
+      - attach_workspace:  # get NiMARE
+          at: /tmp
+      - restore_cache:  # load environment
+          key: deps9-{{ checksum "nimare/info.py" }}-{{ checksum "setup.py" }}
+      - run:
+          name: Test reasonable output for combinations of estimators/kernels/correctors
+          no_output_timeout: 30m
+          command:  |
+            apt-get update
+            apt-get install -yqq make
+            source activate py36_env
+            make performancesmoketest
+      - codecov/upload:
+          file: /tmp/src/NiMARE/coverage.xml
+
 workflows:
   version: 2.1
   run_tests:
@@ -183,6 +203,9 @@ workflows:
           requires:
             - make_py36_env
       - test_performance:
+          requires:
+            - make_py36_env
+      - test_performance_smoke:
           requires:
             - make_py36_env
       - test_py37

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
           paths:
               - src/coverage/.coverage.py36
 
-  test_performance:
+  test_performance_estimators:
     working_directory: /tmp/src/NiMARE
     docker:
       - image: continuumio/miniconda3
@@ -174,13 +174,37 @@ jobs:
             apt-get update
             apt-get install -yqq make
             source activate py36_env
-            make performancetest
+            make test_performance_estimators
             mkdir /tmp/src/coverage
-            mv /tmp/src/NiMARE/.coverage /tmp/src/coverage/.coverage.performance
+            mv /tmp/src/NiMARE/.coverage /tmp/src/coverage/.coverage.performance_estimators
       - persist_to_workspace:
           root: /tmp
           paths:
-              - src/coverage/.coverage.performance
+              - src/coverage/.coverage.performance_estimators
+
+  test_performance_correctors:
+    working_directory: /tmp/src/NiMARE
+    docker:
+      - image: continuumio/miniconda3
+    steps:
+      - attach_workspace:  # get NiMARE
+          at: /tmp
+      - restore_cache:  # load environment
+          key: deps9-{{ checksum "nimare/info.py" }}-{{ checksum "setup.py" }}
+      - run:
+          name: Test reasonable output for combinations of estimators/kernels/correctors
+          no_output_timeout: 30m
+          command:  |
+            apt-get update
+            apt-get install -yqq make
+            source activate py36_env
+            make test_performance_correctors
+            mkdir /tmp/src/coverage
+            mv /tmp/src/NiMARE/.coverage /tmp/src/coverage/.coverage.performance_correctors
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+              - src/coverage/.coverage.performance_correctors
 
   test_performance_smoke:
     working_directory: /tmp/src/NiMARE
@@ -198,7 +222,7 @@ jobs:
             apt-get update
             apt-get install -yqq make
             source activate py36_env
-            make performancesmoketest
+            make test_performance_smoke
             mkdir /tmp/src/coverage
             mv /tmp/src/NiMARE/.coverage /tmp/src/coverage/.coverage.performance_smoke
       - persist_to_workspace:
@@ -238,7 +262,10 @@ workflows:
       - test_py36:
           requires:
             - make_py36_env
-      - test_performance:
+      - test_performance_estimators:
+          requires:
+            - make_py36_env
+      - test_performance_correctors:
           requires:
             - make_py36_env
       - test_performance_smoke:
@@ -255,5 +282,6 @@ workflows:
       - merge_coverage:
           requires:
             - test_py36
-            - test_performance
+            - test_performance_estimators
+            - test_performance_correctors
             - test_performance_smoke

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ lint:
 	@flake8 nimare
 
 unittest:
-	@py.test -m "not performance" --cov-append --cov-report xml --cov-report term-missing --cov=nimare nimare
+	@py.test -m "not performance and not performance_smoke" --cov-append --cov-report xml --cov-report term-missing --cov=nimare nimare
 
 performancetest:
 	@py.test -m "performance" --cov-append --cov-report xml --cov-report term-missing --cov=nimare nimare
+
+performancesmoketest:
+	@py.test -m "performance_smoke" --cov-append --cov-report xml --cov-report term-missing --cov=nimare nimare

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ lint:
 	@flake8 nimare
 
 unittest:
-	@py.test -m "not performance and not performance_smoke" --cov-append --cov-report xml --cov-report term-missing --cov=nimare nimare
+	@py.test -m "not performance and not performance_smoke" --cov-append --cov-report term-missing --cov=nimare nimare
 
 performancetest:
-	@py.test -m "performance" --cov-append --cov-report xml --cov-report term-missing --cov=nimare nimare
+	@py.test -m "performance" --cov-append --cov-report term-missing --cov=nimare nimare
 
 performancesmoketest:
-	@py.test -m "performance_smoke" --cov-append --cov-report xml --cov-report term-missing --cov=nimare nimare
+	@py.test -m "performance_smoke" --cov-append --cov-report term-missing --cov=nimare nimare

--- a/Makefile
+++ b/Makefile
@@ -4,18 +4,23 @@ all_tests: lint unittest performancetest
 
 help:
 	@echo "Please use 'make <target>' where <target> is one of:"
-	@echo "  lint			to run flake8 on all Python files"
-	@echo "  unittest		to run unit tests on nimare"
-	@echo "  performancetest		to run performance tests"
+	@echo "  lint							to run flake8 on all Python files"
+	@echo "  unittest						to run unit tests on nimare"
+	@echo "  test_performance_estimators	to run performance tests on meta estimators"
+	@echo "  test_performance_correctors	to run performance tests on correctors"
+	@echo "  test_performance_smoke			to run performance smoke tests"
 
 lint:
 	@flake8 nimare
 
 unittest:
-	@py.test -m "not performance and not performance_smoke" --cov-append --cov-report term-missing --cov=nimare nimare
+	@py.test -m "not performance_estimators and not performance_correctors and not performance_smoke" --cov-append --cov-report term-missing --cov=nimare nimare
 
-performancetest:
-	@py.test -m "performance" --cov-append --cov-report term-missing --cov=nimare nimare
+test_performance_estimators:
+	@py.test -m "performance_estimators" --cov-append --cov-report term-missing --cov=nimare nimare
 
-performancesmoketest:
+test_performance_correctors:
+	@py.test -m "performance_correctors" --cov-append --cov-report term-missing --cov=nimare nimare
+
+test_performance_smoke:
 	@py.test -m "performance_smoke" --cov-append --cov-report term-missing --cov=nimare nimare

--- a/nimare/tests/test_estimator_performance.py
+++ b/nimare/tests/test_estimator_performance.py
@@ -225,7 +225,7 @@ def test_meta_fit_smoke(meta_res):
     assert isinstance(meta_res, MetaResult)
 
 
-@pytest.mark.performance
+@pytest.mark.performance_estimators
 def test_meta_fit_performance(meta_res, signal_masks, simulatedata_cbma):
     """Test meta-analytic estimator fit performance."""
     _, (ground_truth_foci, _) = simulatedata_cbma
@@ -297,7 +297,7 @@ def test_corr_transform_smoke(meta_cres_small):
     assert isinstance(meta_cres_small, MetaResult)
 
 
-@pytest.mark.performance
+@pytest.mark.performance_correctors
 def test_corr_transform_performance(meta_cres, corr, signal_masks, simulatedata_cbma):
     """Test corrector transform performance."""
     _, (ground_truth_foci, _) = simulatedata_cbma

--- a/nimare/tests/test_estimator_performance.py
+++ b/nimare/tests/test_estimator_performance.py
@@ -220,6 +220,7 @@ def meta_cres_small(meta, meta_res, corr_small, random):
 # --------------
 
 
+@pytest.mark.performance_smoke
 def test_meta_fit_smoke(meta_res):
     """Smoke test for meta-analytic estimator fit."""
     assert isinstance(meta_res, MetaResult)
@@ -291,6 +292,7 @@ def test_meta_fit_performance(meta_res, signal_masks, simulatedata_cbma):
     )
 
 
+@pytest.mark.performance_smoke
 def test_corr_transform_smoke(meta_cres_small):
     """Smoke test for corrector transform."""
     assert isinstance(meta_cres_small, MetaResult)

--- a/nimare/tests/test_estimator_performance.py
+++ b/nimare/tests/test_estimator_performance.py
@@ -2,16 +2,15 @@
 import os
 from contextlib import ExitStack as does_not_raise
 
-import nibabel as nib
 import numpy as np
 import pytest
 
 from ..correct import FDRCorrector, FWECorrector
 from ..generate import create_coordinate_dataset
 from ..meta import ale, kernel, mkda
-from ..meta.utils import compute_kda_ma
 from ..results import MetaResult
 from ..utils import mm2vox
+from .utils import _check_p_values, _create_signal_mask, _transform_res
 
 # set significance levels used for testing.
 ALPHA = 0.05
@@ -382,110 +381,3 @@ def test_corr_transform_performance(meta_cres, corr, signal_masks, simulatedata_
         good_sensitivity=good_sensitivity,
         good_specificity=good_specificity,
     )
-
-
-# -----------------
-# UTILITY FUNCTIONS
-# -----------------
-
-
-def _create_signal_mask(ground_truth_foci_ijks, mask):
-    """Create complementary binary images to identify areas of likely significance and nonsignificance.
-
-    Parameters
-    ----------
-    ground_truth_foci_ijks : array_like
-        Ground truth ijk coordinates of foci.
-    mask : :obj:`nibabel.Nifti1Image`
-        Input mask to define shape and size of output binary masks
-
-    Returns
-    -------
-    sig_map : :obj:`nibabel.Nifti1Image`
-        Binary image representing regions around the
-        ground truth foci expected to be significant.
-    nonsig_map : :obj:`nibabel.Nifti1Image`
-        Binary image representing regions not expected
-        to be significant within the brain.
-    """
-    dims = mask.shape
-    vox_dims = mask.header.get_zooms()
-
-    # area where I'm reasonably certain there are significant results
-    sig_prob_map = compute_kda_ma(
-        dims, vox_dims, ground_truth_foci_ijks, r=2, value=1, sum_overlap=False
-    )
-
-    # area where I'm reasonably certain there are not significant results
-    nonsig_prob_map = compute_kda_ma(
-        dims, vox_dims, ground_truth_foci_ijks, r=14, value=1, sum_overlap=False
-    )
-    sig_map = nib.Nifti1Image((sig_prob_map == 1).astype(int), affine=mask.affine)
-    nonsig_map = nib.Nifti1Image((nonsig_prob_map == 0).astype(int), affine=mask.affine)
-    return sig_map, nonsig_map
-
-
-def _check_p_values(
-    p_array,
-    masker,
-    sig_idx,
-    nonsig_idx,
-    alpha,
-    ground_truth_foci_ijks,
-    n_iters=None,
-    good_sensitivity=True,
-    good_specificity=True,
-):
-    """Check if p-values are within the correct range."""
-    ################################################
-    # CHECK IF P-VALUES ARE WITHIN THE CORRECT RANGE
-    ################################################
-    if n_iters:
-        assert p_array.min() >= (1.0 / n_iters)
-        assert p_array.max() <= 1.0 - (1.0 / n_iters)
-    else:
-        assert (p_array >= 0).all() and (p_array <= 1).all()
-
-    p_map = masker.inverse_transform(p_array).get_fdata()
-
-    # reformat coordinate indices to index p_map
-    gtf_idx = [
-        [ground_truth_foci_ijks[i][j] for i in range(len(ground_truth_foci_ijks))]
-        for j in range(3)
-    ]
-
-    best_chance_p_values = p_map[gtf_idx]
-    assert all(best_chance_p_values < ALPHA) == good_sensitivity
-
-    p_array_sig = p_array[sig_idx]
-    p_array_nonsig = p_array[nonsig_idx]
-
-    # assert that at least 50% of voxels surrounding the foci
-    # are significant at alpha = .05
-    observed_sig = p_array_sig < alpha
-    observed_sig_perc = observed_sig.sum() / len(observed_sig)
-    assert (observed_sig_perc >= 0.5) == good_sensitivity
-
-    # assert that more than 95% of voxels farther away
-    # from foci are nonsignificant at alpha = 0.05
-    observed_nonsig = p_array_nonsig > alpha
-    observed_nonsig_perc = observed_nonsig.sum() / len(observed_nonsig)
-    assert np.isclose(observed_nonsig_perc, (1 - alpha), atol=0.05) == good_specificity
-
-
-def _transform_res(meta, meta_res, corr):
-    """Evaluate whether meta estimator and corrector work together."""
-    #######################################
-    # CHECK IF META/CORRECTOR WORK TOGETHER
-    #######################################
-    # all combinations of meta-analysis estimators and multiple comparison correctors
-    # that do not work together
-    corr_expectation = does_not_raise()
-
-    with corr_expectation:
-        cres = corr.transform(meta_res)
-
-    # if multiple correction failed (expected) do not continue
-    if isinstance(corr_expectation, type(pytest.raises(ValueError))):
-        pytest.xfail("this meta-analysis & corrector combo fails")
-    return cres

--- a/nimare/tests/utils.py
+++ b/nimare/tests/utils.py
@@ -1,5 +1,16 @@
 """Utility functions for testing nimare."""
 import os.path as op
+from contextlib import ExitStack as does_not_raise
+
+import nibabel as nib
+import numpy as np
+import pytest
+
+from ..meta.utils import compute_kda_ma
+
+# set significance levels used for testing.
+# duplicated in test_estimator_performance
+ALPHA = 0.05
 
 
 def get_test_data_path():
@@ -9,3 +20,105 @@ def get_test_data_path():
     Based on function by Yaroslav Halchenko used in Neurosynth Python package.
     """
     return op.abspath(op.join(op.dirname(__file__), "data") + op.sep)
+
+
+def _create_signal_mask(ground_truth_foci_ijks, mask):
+    """Create complementary binary images to identify areas of likely significance and nonsignificance.
+
+    Parameters
+    ----------
+    ground_truth_foci_ijks : array_like
+        Ground truth ijk coordinates of foci.
+    mask : :obj:`nibabel.Nifti1Image`
+        Input mask to define shape and size of output binary masks
+
+    Returns
+    -------
+    sig_map : :obj:`nibabel.Nifti1Image`
+        Binary image representing regions around the
+        ground truth foci expected to be significant.
+    nonsig_map : :obj:`nibabel.Nifti1Image`
+        Binary image representing regions not expected
+        to be significant within the brain.
+    """
+    dims = mask.shape
+    vox_dims = mask.header.get_zooms()
+
+    # area where I'm reasonably certain there are significant results
+    sig_prob_map = compute_kda_ma(
+        dims, vox_dims, ground_truth_foci_ijks, r=2, value=1, sum_overlap=False
+    )
+
+    # area where I'm reasonably certain there are not significant results
+    nonsig_prob_map = compute_kda_ma(
+        dims, vox_dims, ground_truth_foci_ijks, r=14, value=1, sum_overlap=False
+    )
+    sig_map = nib.Nifti1Image((sig_prob_map == 1).astype(int), affine=mask.affine)
+    nonsig_map = nib.Nifti1Image((nonsig_prob_map == 0).astype(int), affine=mask.affine)
+    return sig_map, nonsig_map
+
+
+def _check_p_values(
+    p_array,
+    masker,
+    sig_idx,
+    nonsig_idx,
+    alpha,
+    ground_truth_foci_ijks,
+    n_iters=None,
+    good_sensitivity=True,
+    good_specificity=True,
+):
+    """Check if p-values are within the correct range."""
+    ################################################
+    # CHECK IF P-VALUES ARE WITHIN THE CORRECT RANGE
+    ################################################
+    if n_iters:
+        assert p_array.min() >= (1.0 / n_iters)
+        assert p_array.max() <= 1.0 - (1.0 / n_iters)
+    else:
+        assert (p_array >= 0).all() and (p_array <= 1).all()
+
+    p_map = masker.inverse_transform(p_array).get_fdata()
+
+    # reformat coordinate indices to index p_map
+    gtf_idx = [
+        [ground_truth_foci_ijks[i][j] for i in range(len(ground_truth_foci_ijks))]
+        for j in range(3)
+    ]
+
+    best_chance_p_values = p_map[gtf_idx]
+    assert all(best_chance_p_values < ALPHA) == good_sensitivity
+
+    p_array_sig = p_array[sig_idx]
+    p_array_nonsig = p_array[nonsig_idx]
+
+    # assert that at least 50% of voxels surrounding the foci
+    # are significant at alpha = .05
+    observed_sig = p_array_sig < alpha
+    observed_sig_perc = observed_sig.sum() / len(observed_sig)
+    assert (observed_sig_perc >= 0.5) == good_sensitivity
+
+    # assert that more than 95% of voxels farther away
+    # from foci are nonsignificant at alpha = 0.05
+    observed_nonsig = p_array_nonsig > alpha
+    observed_nonsig_perc = observed_nonsig.sum() / len(observed_nonsig)
+    assert np.isclose(observed_nonsig_perc, (1 - alpha), atol=0.05) == good_specificity
+
+
+def _transform_res(meta, meta_res, corr):
+    """Evaluate whether meta estimator and corrector work together."""
+    #######################################
+    # CHECK IF META/CORRECTOR WORK TOGETHER
+    #######################################
+    # all combinations of meta-analysis estimators and multiple comparison correctors
+    # that do not work together
+    corr_expectation = does_not_raise()
+
+    with corr_expectation:
+        cres = corr.transform(meta_res)
+
+    # if multiple correction failed (expected) do not continue
+    if isinstance(corr_expectation, type(pytest.raises(ValueError))):
+        pytest.xfail("this meta-analysis & corrector combo fails")
+    return cres


### PR DESCRIPTION
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Move the smoke tests in `test_estimator_performance` into a new job only run on Python 3.6.
- Move utility functions in `test_estimator_performance` into `tests.utils`.
- Take coverage reports from unit tests, performance tests, and performance smoke tests, and merge them before uploading.
