### PR TITLE
[FIX] Add pytest to docs dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,6 @@ RUN export PATH="/opt/miniconda-latest/bin:$PATH" \
            'jupyter' \
            'jupyterlab' \
            'jupyter_contrib_nbextensions' \
-           'seaborn' \
            'pytest' \
            'pytest-cov' \
            'codecov' \
@@ -132,8 +131,7 @@ RUN echo '{ \
     \n          "python=3.6", \
     \n          "jupyter", \
     \n          "jupyterlab", \
-    \n          "jupyter_contrib_nbextensions", \
-    \n          "seaborn" \
+    \n          "jupyter_contrib_nbextensions" \
     \n        ], \
     \n        "pip_install": [ \
     \n          "/src/NiMARE/" \

--- a/nimare/info.py
+++ b/nimare/info.py
@@ -81,7 +81,7 @@ EXTRA_REQUIRES = {
         "m2r",
         "pillow",
         "recommonmark",
-        "seaborn",
+        "pytest",  # For get_test_data_path. May fix later.
         "sphinx>=3.1.1",
         "sphinx-argparse",
         "sphinx-copybutton",


### PR DESCRIPTION
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add pytest to docs dependencies.
    - This is necessary to use `get_test_data_path`, but I will probably move the 21 pain dataset to resources in the future (in which case we'd use `nimare.utils.get_resources_path` instead). 
- Also remove seaborn from any dependencies.
