### PR TITLE
Retain updated Estimator in Corrector-generated MetaResults

### DIFF
--- a/nimare/correct.py
+++ b/nimare/correct.py
@@ -136,6 +136,10 @@ class Corrector(metaclass=ABCMeta):
         # Update corrected map names and add them to maps dict
         corr_maps = {(k + self._name_suffix): v for k, v in corr_maps.items()}
         result.maps.update(corr_maps)
+
+        # Update the estimator as well, in order to retain updated null distributions
+        result.estimator = est
+
         return result
 
     @abstractmethod

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -216,6 +216,22 @@ def test_ALE_montecarlo_null_unit(testdata_cbma, tmp_path_factory):
         np.ndarray,
     )
 
+    # Check that the updated null distribution is in the corrected MetaResult's Estimator,
+    # but not the original one.
+    assert (
+        "values_desc-mass_level-cluster_corr-fwe_method-montecarlo"
+        in cres.estimator.null_distributions_.keys()
+    )
+    assert (
+        "values_desc-mass_level-cluster_corr-fwe_method-montecarlo"
+        not in meta.null_distributions_.keys()
+    )
+    # For some reason this doesn't work...
+    # assert (
+    #     "values_desc-mass_level-cluster_corr-fwe_method-montecarlo"
+    #     not in meta.results.estimator.null_distributions_.keys()
+    # )
+
     # Bonferroni FWE
     corr = FWECorrector(method="bonferroni")
     cres = corr.transform(res)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Copy an updated version of the Estimator into the updated MetaResult object returned by Correctors, so that the updated MetaResult will have access to any new null distributions or other updated attributes that may be present in the Estimator after its been run through multiple comparisons correction.
