### PR TITLE
Disable MA map pre-generation in CorrelationDecoder

### DIFF
--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -184,10 +184,6 @@ class CorrelationDecoder(Decoder):
         """
         self.masker = dataset.masker
 
-        # Pre-generate MA maps to speed things up
-        kernel_transformer = self.meta_estimator.kernel_transformer
-        dataset = kernel_transformer.transform(dataset, return_type="dataset")
-
         for i, feature in enumerate(self.features_):
             feature_ids = dataset.get_studies_by_label(
                 labels=[feature], label_threshold=self.frequency_threshold
@@ -199,8 +195,9 @@ class CorrelationDecoder(Decoder):
                 f"{len(dataset.ids)} studies"
             )
             feature_dset = dataset.slice(feature_ids)
-            # This seems like a somewhat inelegant solution
+
             # Check if the meta method is a pairwise estimator
+            # This seems like a somewhat inelegant solution
             if "dataset2" in inspect.getfullargspec(self.meta_estimator.fit).args:
                 nonfeature_ids = sorted(list(set(self.inputs_["id"]) - set(feature_ids)))
                 nonfeature_dset = dataset.slice(nonfeature_ids)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/master/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None, but should help many users. Per #629 and #630, storing the MA maps as files and loading them as needed actually slows things down and increases memory usage.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Do not pre-generate MA maps for the CorrelationDecoder.
