### PR TITLE
Do not inherit IBMAEstimator's aggressive_mask from previous Datasets

### DIFF
--- a/nimare/base.py
+++ b/nimare/base.py
@@ -368,6 +368,10 @@ class MetaEstimator(Estimator):
         # Ensure that protected values are not included among _required_inputs
         assert "aggressive_mask" not in self._required_inputs.keys(), "This is a protected name."
 
+        if "aggressive_mask" in self.inputs_.keys():
+            LGR.warning("Removing existing 'aggressive_mask' from Estimator.")
+            self.inputs_.pop("aggressive_mask")
+
         # A dictionary to collect masked image data, to be further reduced by the aggressive mask.
         temp_image_inputs = {}
 

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -440,8 +440,9 @@ class MetaEstimator(Estimator):
                     f"Masking out {n_bad_voxels} additional voxels. "
                     "The updated masker is available in the Estimator.masker attribute."
                 )
-        for name, raw_masked_data in temp_image_inputs.items():
-            self.inputs_[name] = raw_masked_data[:, self.inputs_["aggressive_mask"]]
+
+            for name, raw_masked_data in temp_image_inputs.items():
+                self.inputs_[name] = raw_masked_data[:, self.inputs_["aggressive_mask"]]
 
 
 class Transformer(NiMAREBase):


### PR DESCRIPTION
Closes #651.

Changes proposed in this pull request:

- Remove the `aggressive_mask` key at the beginning of `MetaEstimator._preprocess_inputs()` if it's defined. Basically, this redefines `aggressive_mask` from scratch any time `fit` is called.
- Mask data with the aggressive mask only if that aggressive mask is defined. 
    - At first glance, this should be a bug that's come up already, and yet it hasn't. I assume there's a reason why CBMAEstimators loading `ma_maps` haven't failed due to a missing `aggressive_mask` key in `inputs_`, but I don't know what it is at the moment.
