### PR TITLE
Add markers in pyproject.toml to fix pytest warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,9 @@ exclude = '''
 
 [tool.pytest.ini_options]
 markers = [
-    "performance: mark tests that measure performance (deselect with '-m \"not performance\"')",
+    "performance_smoke: mark smoke tests that measure performance",
+    "performance_estimators: mark tests that measure estimator performance",
+    "performance_correctors: mark tests that measure corrector performance",
 ]
 
 [tool.isort]


### PR DESCRIPTION
Closes None.

Here's the kind of warning I'm seeing:

```
=============================== warnings summary ===============================
[33](https://github.com/neurostuff/NiMARE/runs/5398359515?check_suite_focus=true#step:5:33)
nimare/tests/test_estimator_performance.py:222
[34](https://github.com/neurostuff/NiMARE/runs/5398359515?check_suite_focus=true#step:5:34)
  /home/runner/work/NiMARE/NiMARE/nimare/tests/test_estimator_performance.py:222: PytestUnknownMarkWarning: Unknown pytest.mark.performance_smoke - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
[35](https://github.com/neurostuff/NiMARE/runs/5398359515?check_suite_focus=true#step:5:35)
    @pytest.mark.performance_smoke
```

Changes proposed:

- Add pytest markers to the pyproject.toml file.