### PR TITLE
Stop storing MetaResults as attributes of fitted Estimators

### DIFF
--- a/examples/02_meta-analyses/06_plot_compare_ibma_and_cbma.py
+++ b/examples/02_meta-analyses/06_plot_compare_ibma_and_cbma.py
@@ -47,9 +47,12 @@ dset = coord_gen.transform(dset)
 # ALE (CBMA)
 # -----------------------------------------------------------------------------
 meta_cbma = ALE()
-meta_cbma.fit(dset)
+cbma_results = meta_cbma.fit(dset)
 plot_stat_map(
-    meta_cbma.results.get_map("z"), cut_coords=[0, 0, -8], draw_cross=False, cmap="RdBu_r"
+    cbma_results.get_map("z"),
+    cut_coords=[0, 0, -8],
+    draw_cross=False,
+    cmap="RdBu_r",
 )
 
 ###############################################################################
@@ -57,9 +60,12 @@ plot_stat_map(
 # -----------------------------------------------------------------------------
 # We must resample the image data to the same MNI template as the Dataset.
 meta_ibma = DerSimonianLaird(resample=True)
-meta_ibma.fit(dset)
+ibma_results = meta_ibma.fit(dset)
 plot_stat_map(
-    meta_ibma.results.get_map("z"), cut_coords=[0, 0, -8], draw_cross=False, cmap="RdBu_r"
+    ibma_results.get_map("z"),
+    cut_coords=[0, 0, -8],
+    draw_cross=False,
+    cmap="RdBu_r",
 )
 
 ###############################################################################
@@ -67,8 +73,8 @@ plot_stat_map(
 # -----------------------------------------------------------------------------
 stat_df = pd.DataFrame(
     {
-        "CBMA": meta_cbma.results.get_map("z", return_type="array"),
-        "IBMA": meta_ibma.results.get_map("z", return_type="array"),
+        "CBMA": cbma_results.get_map("z", return_type="array"),
+        "IBMA": ibma_results.get_map("z", return_type="array"),
     }
 )
 print(stat_df.corr())

--- a/examples/02_meta-analyses/07_macm.py
+++ b/examples/02_meta-analyses/07_macm.py
@@ -60,10 +60,10 @@ print(f"{len(no_roi_ids)}/{len(dset.ids)} studies report zero coordinates in the
 # MKDA Chi2 with FWE correction
 # --------------------------------------------------
 mkda = MKDAChi2(kernel__r=10)
-mkda.fit(dset_sel, dset_unsel)
+results = mkda.fit(dset_sel, dset_unsel)
 
 corr = FWECorrector(method="montecarlo", n_iters=10000)
-cres = corr.transform(mkda.results)
+cres = corr.transform(results)
 
 # We want the "specificity" map (2-way chi-square between sel and unsel)
 plotting.plot_stat_map(
@@ -84,5 +84,5 @@ plotting.plot_stat_map(
 # We will use the coordinates in Neurosynth
 xyz = dset.coordinates[["x", "y", "z"]].values
 scale = SCALE(xyz=xyz, n_iters=10000, n_cores=1, kernel__n=20)
-scale.fit(dset_sel)
-plotting.plot_stat_map(scale.results.get_map("z_vthresh"), draw_cross=False, cmap="RdBu_r")
+results = scale.fit(dset_sel)
+plotting.plot_stat_map(results.get_map("z"), draw_cross=False, cmap="RdBu_r")

--- a/examples/02_meta-analyses/09_plot_simulated_data.py
+++ b/examples/02_meta-analyses/09_plot_simulated_data.py
@@ -23,12 +23,12 @@ from nimare.meta import ALE
 
 def analyze_and_plot(dset, ground_truth_foci=None, correct=True, return_cres=False):
     meta = ALE(kernel__fwhm=10)
-    meta.fit(dset)
+    results = meta.fit(dset)
     if correct:
         corr = FDRCorrector()
-        cres = corr.transform(meta.results)
+        cres = corr.transform(results)
     else:
-        cres = meta.results
+        cres = results
 
     # get the z coordinates
     if ground_truth_foci:

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -318,8 +318,7 @@ class Estimator(NiMAREBase):
         else:
             masker = dataset.masker
 
-        results = MetaResult(self, masker, maps)
-        return results
+        return MetaResult(self, masker, maps)
 
     @abstractmethod
     def _fit(self, dataset):

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -318,8 +318,8 @@ class Estimator(NiMAREBase):
         else:
             masker = dataset.masker
 
-        self.results = MetaResult(self, masker, maps)
-        return self.results
+        results = MetaResult(self, masker, maps)
+        return results
 
     @abstractmethod
     def _fit(self, dataset):

--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -203,11 +203,11 @@ class CorrelationDecoder(Decoder):
             if "dataset2" in inspect.getfullargspec(self.meta_estimator.fit).args:
                 nonfeature_ids = sorted(list(set(self.inputs_["id"]) - set(feature_ids)))
                 nonfeature_dset = dataset.slice(nonfeature_ids)
-                self.meta_estimator.fit(feature_dset, nonfeature_dset)
+                meta_results = self.meta_estimator.fit(feature_dset, nonfeature_dset)
             else:
-                self.meta_estimator.fit(feature_dset)
+                meta_results = self.meta_estimator.fit(feature_dset)
 
-            feature_data = self.meta_estimator.results.get_map(
+            feature_data = meta_results.get_map(
                 self.target_image,
                 return_type="array",
             )

--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -166,7 +166,6 @@ class CorrelationDecoder(Decoder):
         self.frequency_threshold = frequency_threshold
         self.meta_estimator = meta_estimator
         self.target_image = target_image
-        self.results = None
 
     def _fit(self, dataset):
         """Generate feature-specific meta-analytic maps for dataset.
@@ -236,7 +235,6 @@ class CorrelationDecoder(Decoder):
         corrs = pearson(img_vec, self.images_)
         out_df = pd.DataFrame(index=self.features_, columns=["r"], data=corrs)
         out_df.index.name = "feature"
-        self.results = out_df
         return out_df
 
 
@@ -277,7 +275,6 @@ class CorrelationDistributionDecoder(Decoder):
         self.features = features
         self.frequency_threshold = frequency_threshold
         self.memory_limit = memory_limit
-        self.results = None
         self._required_inputs["images"] = ("image", target_image)
 
     def _fit(self, dataset):
@@ -349,5 +346,5 @@ class CorrelationDistributionDecoder(Decoder):
             corrs_z = np.arctanh(corrs)
             out_df.loc[feature, "mean"] = np.mean(corrs_z)
             out_df.loc[feature, "std"] = np.std(corrs_z)
-        self.results = out_df
+
         return out_df

--- a/nimare/decode/discrete.py
+++ b/nimare/decode/discrete.py
@@ -179,7 +179,6 @@ class BrainMapDecoder(Decoder):
         self.frequency_threshold = frequency_threshold
         self.u = u
         self.correction = correction
-        self.results = None
 
     def _fit(self, dataset):
         pass
@@ -215,7 +214,7 @@ class BrainMapDecoder(Decoder):
             u=self.u,
             correction=self.correction,
         )
-        self.results = results
+
         return results
 
 
@@ -469,7 +468,6 @@ class NeurosynthDecoder(Decoder):
         self.prior = prior
         self.u = u
         self.correction = correction
-        self.results = None
 
     def _fit(self, dataset):
         pass
@@ -506,7 +504,6 @@ class NeurosynthDecoder(Decoder):
             u=self.u,
             correction=self.correction,
         )
-        self.results = results
         return results
 
 
@@ -746,7 +743,6 @@ class ROIAssociationDecoder(Decoder):
         self.feature_group = feature_group
         self.features = features
         self.frequency_threshold = 0
-        self.results = None
 
     def _fit(self, dataset):
         roi_values = self.kernel_transformer.transform(
@@ -769,5 +765,4 @@ class ROIAssociationDecoder(Decoder):
         corrs = pearson(self.roi_values_, feature_values.T)
         out_df = pd.DataFrame(index=self.features_, columns=["r"], data=corrs)
         out_df.index.name = "feature"
-        self.results = out_df
         return out_df

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -153,7 +153,6 @@ class ALE(CBMAEstimator):
         self.n_iters = n_iters
         self.n_cores = self._check_ncores(n_cores)
         self.dataset = None
-        self.results = None
 
     def _compute_summarystat_est(self, ma_values):
         stat_values = 1.0 - np.prod(1.0 - ma_values, axis=0)
@@ -340,7 +339,6 @@ class ALESubtraction(PairwiseCBMAEstimator):
 
         self.dataset1 = None
         self.dataset2 = None
-        self.results = None
         self.n_iters = n_iters
         self.n_cores = self._check_ncores(n_cores)
         # memory_limit needs to exist to trigger use_memmap decorator, but it will also be used if

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -848,5 +848,5 @@ class PairwiseCBMAEstimator(CBMAEstimator):
             masker = self.masker
         else:
             masker = dataset1.masker
-        self.results = MetaResult(self, masker, maps)
-        return self.results
+
+        return MetaResult(self, masker, maps)

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -137,7 +137,6 @@ class MKDADensity(CBMAEstimator):
         self.n_iters = n_iters
         self.n_cores = self._check_ncores(n_cores)
         self.dataset = None
-        self.results = None
 
     def _compute_weights(self, ma_values):
         """Determine experiment-wise weights per the conventional MKDA approach."""
@@ -1042,7 +1041,6 @@ class KDA(CBMAEstimator):
         self.n_iters = n_iters
         self.n_cores = self._check_ncores(n_cores)
         self.dataset = None
-        self.results = None
 
     def _compute_summarystat_est(self, ma_values):
         """Compute OF scores from data.

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -115,7 +115,7 @@ def test_ALE_approximate_null_unit(testdata_cbma, tmp_path_factory):
     # Test MCC methods
     # Monte Carlo FWE
     corr = FWECorrector(method="montecarlo", voxel_thresh=0.001, n_iters=5, n_cores=-1)
-    cres = corr.transform(meta.results)
+    cres = corr.transform(res)
     assert isinstance(cres, nimare.results.MetaResult)
     assert "z_desc-size_level-cluster_corr-FWE_method-montecarlo" in cres.maps.keys()
     assert "z_desc-mass_level-cluster_corr-FWE_method-montecarlo" in cres.maps.keys()
@@ -153,7 +153,7 @@ def test_ALE_approximate_null_unit(testdata_cbma, tmp_path_factory):
 
     # FDR
     corr = FDRCorrector(method="indep", alpha=0.05)
-    cres = corr.transform(meta.results)
+    cres = corr.transform(res)
     assert isinstance(cres, nimare.results.MetaResult)
     assert isinstance(
         cres.get_map("z_corr-FDR_method-indep", return_type="image"), nib.Nifti1Image
@@ -199,7 +199,7 @@ def test_ALE_montecarlo_null_unit(testdata_cbma, tmp_path_factory):
     # Test MCC methods
     # Monte Carlo FWE
     corr = FWECorrector(method="montecarlo", voxel_thresh=0.001, n_iters=5, n_cores=-1)
-    cres = corr.transform(meta.results)
+    cres = corr.transform(res)
     assert isinstance(cres, nimare.results.MetaResult)
     assert "z_desc-size_level-cluster_corr-FWE_method-montecarlo" in cres.maps.keys()
     assert "z_desc-mass_level-cluster_corr-FWE_method-montecarlo" in cres.maps.keys()
@@ -239,10 +239,6 @@ def test_ALE_montecarlo_null_unit(testdata_cbma, tmp_path_factory):
         "values_desc-mass_level-cluster_corr-fwe_method-montecarlo"
         not in res.estimator.null_distributions_.keys()
     )
-    assert (
-        "values_desc-mass_level-cluster_corr-fwe_method-montecarlo"
-        not in meta.results.estimator.null_distributions_.keys()
-    )
 
     # Bonferroni FWE
     corr = FWECorrector(method="bonferroni")
@@ -257,7 +253,7 @@ def test_ALE_montecarlo_null_unit(testdata_cbma, tmp_path_factory):
 
     # FDR
     corr = FDRCorrector(method="indep", alpha=0.05)
-    cres = corr.transform(meta.results)
+    cres = corr.transform(res)
     assert isinstance(cres, nimare.results.MetaResult)
     assert isinstance(
         cres.get_map("z_corr-FDR_method-indep", return_type="image"), nib.Nifti1Image

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -273,9 +273,7 @@ def test_ALESubtraction_smoke(testdata_cbma, tmp_path_factory):
     assert isinstance(
         results.get_map("z_desc-group1MinusGroup2", return_type="image"), nib.Nifti1Image
     )
-    assert isinstance(
-        results.get_map("z_desc-group1MinusGroup2", return_type="array"), np.ndarray
-    )
+    assert isinstance(results.get_map("z_desc-group1MinusGroup2", return_type="array"), np.ndarray)
 
     sub_meta.save(out_file)
     assert os.path.isfile(out_file)

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -267,14 +267,14 @@ def test_ALESubtraction_smoke(testdata_cbma, tmp_path_factory):
     out_file = os.path.join(tmpdir, "file.pkl.gz")
 
     sub_meta = ale.ALESubtraction(n_iters=10, n_cores=2)
-    sub_meta.fit(testdata_cbma, testdata_cbma)
-    assert isinstance(sub_meta.results, nimare.results.MetaResult)
-    assert "z_desc-group1MinusGroup2" in sub_meta.results.maps.keys()
+    results = sub_meta.fit(testdata_cbma, testdata_cbma)
+    assert isinstance(results, nimare.results.MetaResult)
+    assert "z_desc-group1MinusGroup2" in results.maps.keys()
     assert isinstance(
-        sub_meta.results.get_map("z_desc-group1MinusGroup2", return_type="image"), nib.Nifti1Image
+        results.get_map("z_desc-group1MinusGroup2", return_type="image"), nib.Nifti1Image
     )
     assert isinstance(
-        sub_meta.results.get_map("z_desc-group1MinusGroup2", return_type="array"), np.ndarray
+        results.get_map("z_desc-group1MinusGroup2", return_type="array"), np.ndarray
     )
 
     sub_meta.save(out_file)

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -101,7 +101,6 @@ def test_ibma_smoke(testdata_ibma, meta, meta_kwargs, corrector, corrector_kwarg
     meta = meta(**meta_kwargs)
     res = meta.fit(testdata_ibma)
     z_img = res.get_map("z")
-    assert isinstance(meta.results, nimare.results.MetaResult)
     assert isinstance(res, nimare.results.MetaResult)
     assert res.get_map("z", return_type="array").ndim == 1
     assert z_img.ndim == 3
@@ -145,23 +144,23 @@ def test_ibma_with_custom_masker(testdata_ibma, caplog, estimator, expectation, 
             meta.fit(dset)
     elif expectation == "warning":
         with caplog.at_level(logging.WARNING, logger="nimare.meta.ibma"):
-            meta.fit(dset)
+            res = meta.fit(dset)
             assert "will likely produce biased results" in caplog.text
         caplog.clear()
     else:
         with caplog.at_level(logging.WARNING, logger="nimare.meta.ibma"):
-            meta.fit(dset)
+            res = meta.fit(dset)
             assert "will likely produce biased results" not in caplog.text
         caplog.clear()
 
     # Only fit the estimator if it doesn't raise a ValueError
     if expectation != "error":
-        assert isinstance(meta.results, nimare.results.MetaResult)
+        assert isinstance(res, nimare.results.MetaResult)
         # There are five "labels", but one of them has no good data,
         # so the outputs should be 4 long.
-        assert meta.results.maps["z"].shape == (5,)
-        assert np.isnan(meta.results.maps["z"][0])
-        assert meta.results.get_map("z").shape == (10, 10, 10)
+        assert res.maps["z"].shape == (5,)
+        assert np.isnan(res.maps["z"][0])
+        assert res.get_map("z").shape == (10, 10, 10)
 
 
 @pytest.mark.parametrize(
@@ -181,6 +180,7 @@ def test_ibma_resampling(testdata_ibma_resample, resample, resample_kwargs, expe
     """Test image-based resampling performance."""
     meta = ibma.Fishers(resample=resample, **resample_kwargs)
     with expectation:
-        meta.fit(testdata_ibma_resample)
+        res = meta.fit(testdata_ibma_resample)
+
     if isinstance(expectation, does_not_raise):
-        assert isinstance(meta.results, nimare.results.MetaResult)
+        assert isinstance(res, nimare.results.MetaResult)

--- a/nimare/workflows/scale.py
+++ b/nimare/workflows/scale.py
@@ -69,7 +69,7 @@ rates. NeuroImage, 99, 559-570.
         xyz = np.loadtxt(baseline)
 
     estimator = SCALE(xyz=xyz, n_iters=n_iters, n_cores=n_cores)
-    estimator.fit(dset)
+    results = estimator.fit(dset)
 
     if output_dir is None:
         output_dir = os.path.dirname(dataset_file)
@@ -83,7 +83,7 @@ rates. NeuroImage, 99, 559-570.
     elif not prefix.endswith("_"):
         prefix = prefix + "_"
 
-    estimator.results.save_maps(output_dir=output_dir, prefix=prefix)
+    results.save_maps(output_dir=output_dir, prefix=prefix)
     copyfile(dataset_file, os.path.join(output_dir, prefix + "input_coordinates.txt"))
 
     LGR.info("Workflow completed.")


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #634.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Return `results` from `Estimator.fit`, but do not store the object as an attribute of the `Estimator`.
- Ditto for `Decoder`s.
- Update tests and examples accordingly.
