### PR TITLE
Use BibTeX citations in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,7 @@ extensions = [
     "sphinx_copybutton",  # for copying code snippets
     "sphinx_gallery.gen_gallery",  # example gallery
     "sphinxarg.ext",  # argparse
+    "sphinxcontrib.bibtex",  # for foot-citations
     "recommonmark",  # markdown parser
 ]
 
@@ -202,6 +203,14 @@ sphinx_gallery_conf = {
 
 # Generate the plots for the gallery
 plot_gallery = True
+
+# -----------------------------------------------------------------------------
+# sphinxcontrib-bibtex
+# -----------------------------------------------------------------------------
+bibtex_bibfiles = ["./references.bib"]
+bibtex_style = "unsrt"
+bibtex_reference_style = "author_year"
+bibtex_footbibliography_header = ""
 
 
 def setup(app):

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,3 +1,14 @@
+@article{blei2003latent,
+  title={Latent dirichlet allocation},
+  author={Blei, David M and Ng, Andrew Y and Jordan, Michael I},
+  journal={Journal of machine Learning research},
+  volume={3},
+  number={Jan},
+  pages={993--1022},
+  year={2003},
+  url={https://dl.acm.org/doi/10.5555/944919.944937}
+}
+
 @article{brockwell2001comparison,
   title={A comparison of statistical methods for meta-analysis},
   author={Brockwell, Sarah E and Gordon, Ian R},
@@ -123,6 +134,50 @@
   publisher={Elsevier},
   url={https://doi.org/10.1016/j.neuroimage.2014.06.007},
   doi={10.1016/j.neuroimage.2014.06.007}
+}
+
+@article{newman2009distributed,
+  title={Distributed algorithms for topic models.},
+  author={Newman, David and Asuncion, Arthur and Smyth, Padhraic and Welling, Max},
+  journal={Journal of Machine Learning Research},
+  volume={10},
+  number={8},
+  year={2009},
+  url={http://jmlr.org/papers/v10/newman09a.html}
+}
+
+@article{poldrack2011cognitive,
+  title={The cognitive atlas: toward a knowledge foundation for cognitive neuroscience},
+  author={Poldrack, Russell A and Kittur, Aniket and Kalar, Donald and Miller, Eric and Seppa, Christian and Gil, Yolanda and Parker, D Stott and Sabb, Fred W and Bilder, Robert M},
+  journal={Frontiers in neuroinformatics},
+  volume={5},
+  pages={17},
+  year={2011},
+  publisher={Frontiers},
+  url={https://doi.org/10.3389/fninf.2011.00017},
+  doi={10.3389/fninf.2011.00017}
+}
+
+@article{poldrack2012discovering,
+  title={Discovering relations between mind, brain, and mental disorders using topic mapping},
+  author={Poldrack, Russell A and Mumford, Jeanette A and Schonberg, Tom and Kalar, Donald and Barman, Bishal and Yarkoni, Tal},
+  year={2012},
+  publisher={Public Library of Science San Francisco, USA},
+  url={https://doi.org/10.1371/journal.pcbi.1002707},
+  doi={10.1371/journal.pcbi.1002707}
+}
+
+@article{rubin2017decoding,
+  title={Decoding brain activity using a large-scale probabilistic functional-anatomical atlas of human cognition},
+  author={Rubin, Timothy N and Koyejo, Oluwasanmi and Gorgolewski, Krzysztof J and Jones, Michael N and Poldrack, Russell A and Yarkoni, Tal},
+  journal={PLoS computational biology},
+  volume={13},
+  number={10},
+  pages={e1005649},
+  year={2017},
+  publisher={Public Library of Science San Francisco, CA USA},
+  url={https://doi.org/10.1371/journal.pcbi.1005649},
+  doi={10.1371/journal.pcbi.1005649}
 }
 
 @article{stouffer1949american,

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,3 +1,16 @@
+@article{amft2015definition,
+  title={Definition and characterization of an extended social-affective default network},
+  author={Amft, Maren and Bzdok, Danilo and Laird, Angela R and Fox, Peter T and Schilbach, Leonhard and Eickhoff, Simon B},
+  journal={Brain Structure and Function},
+  volume={220},
+  number={2},
+  pages={1031--1049},
+  year={2015},
+  publisher={Springer},
+  url={https://doi.org/10.1007/s00429-013-0698-0},
+  doi={10.1007/s00429-013-0698-0}
+}
+
 @article{blei2003latent,
   title={Latent dirichlet allocation},
   author={Blei, David M and Ng, Andrew Y and Jordan, Michael I},
@@ -251,6 +264,19 @@
   publisher={Oxford University Press},
   url={https://doi.org/10.1093/scan/nsm015},
   doi={10.1093/scan/nsm015}
+}
+
+@article{yarkoni2011large,
+  title={Large-scale automated synthesis of human functional neuroimaging data},
+  author={Yarkoni, Tal and Poldrack, Russell A and Nichols, Thomas E and Van Essen, David C and Wager, Tor D},
+  journal={Nature methods},
+  volume={8},
+  number={8},
+  pages={665--670},
+  year={2011},
+  publisher={Nature Publishing Group},
+  url={https://doi.org/10.1038/nmeth.1635},
+  doi={10.1038/nmeth.1635}
 }
 
 @article{zaykin2011optimally,

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -230,7 +230,7 @@
   doi={10.1371/journal.pcbi.1005649}
 }
 
-@software{sochat2015ttoz,
+@misc{sochat2015ttoz,
   author = {Sochat, Vanessa},
   title = {TtoZ Original Release},
   month = oct,

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,3 +1,16 @@
+@article{brockwell2001comparison,
+  title={A comparison of statistical methods for meta-analysis},
+  author={Brockwell, Sarah E and Gordon, Ian R},
+  journal={Statistics in medicine},
+  volume={20},
+  number={6},
+  pages={825--840},
+  year={2001},
+  publisher={Wiley Online Library},
+  url={https://doi.org/10.1002/sim.650},
+  doi={10.1002/sim.650}
+}
+
 @article{bullmore1999global,
   title={Global, voxel, and cluster tests, by theory and permutation, for a difference between two groups of structural MR images of the brain},
   author={Bullmore, Edward T and Suckling, John and Overmeyer, Stephan and Rabe-Hesketh, Sophia and Taylor, Eric and Brammer, Michael J},
@@ -9,6 +22,17 @@
   publisher={IEEE},
   url={https://doi.org/10.1109/42.750253},
   doi={10.1109/42.750253}
+}
+
+@article{dersimonian1986meta,
+  title={Meta-analysis in clinical trials},
+  author={DerSimonian, Rebecca and Laird, Nan},
+  journal={Controlled clinical trials},
+  volume={7},
+  number={3},
+  pages={177--188},
+  year={1986},
+  publisher={Elsevier}
 }
 
 @article{eickhoff2012activation,
@@ -36,6 +60,46 @@
   doi={10.1016/j.neuroimage.2016.04.072}
 }
 
+@article{fisher1946statistical,
+  title={Statistical methods for research workers.},
+  author={Fisher, Ronald Aylmer and others},
+  journal={Statistical methods for research workers.},
+  number={10th. ed.},
+  year={1946},
+  publisher={Oliver and Boyd}
+}
+
+@article{freedman1983nonstochastic,
+  title={A nonstochastic interpretation of reported significance levels},
+  author={Freedman, David and Lane, David},
+  journal={Journal of Business \& Economic Statistics},
+  volume={1},
+  number={4},
+  pages={292--298},
+  year={1983},
+  publisher={Taylor \& Francis}
+}
+
+@book{hedges2014statistical,
+  title={Statistical methods for meta-analysis},
+  author={Hedges, Larry V and Olkin, Ingram},
+  year={2014},
+  publisher={Academic press}
+}
+
+@article{kosmidis2017improving,
+  title={Improving the accuracy of likelihood-based inference in meta-analysis and meta-regression},
+  author={Kosmidis, Ioannis and Guolo, Annamaria and Varin, Cristiano},
+  journal={Biometrika},
+  volume={104},
+  number={2},
+  pages={489--496},
+  year={2017},
+  publisher={Oxford University Press},
+  url={https://doi.org/10.1093/biomet/asx001},
+  doi={10.1093/biomet/asx001}
+}
+
 @article{laird2005ale,
   title={ALE meta-analysis: Controlling the false discovery rate and performing statistical contrasts},
   author={Laird, Angela R and Fox, P Mickle and Price, Cathy J and Glahn, David C and Uecker, Angela M and Lancaster, Jack L and Turkeltaub, Peter E and Kochunov, Peter and Fox, Peter T},
@@ -59,6 +123,14 @@
   publisher={Elsevier},
   url={https://doi.org/10.1016/j.neuroimage.2014.06.007},
   doi={10.1016/j.neuroimage.2014.06.007}
+}
+
+@article{stouffer1949american,
+  title={The american soldier: Adjustment during army life.(studies in social psychology in world war ii), vol. 1},
+  author={Stouffer, Samuel A and Suchman, Edward A and DeVinney, Leland C and Star, Shirley A and Williams Jr, Robin M},
+  journal={Studies in social psychology in World War II},
+  year={1949},
+  publisher={Princeton Univ. Press}
 }
 
 @article{turkeltaub2002meta,
@@ -124,6 +196,19 @@
   publisher={Oxford University Press},
   url={https://doi.org/10.1093/scan/nsm015},
   doi={10.1093/scan/nsm015}
+}
+
+@article{zaykin2011optimally,
+  title={Optimally weighted Z-test is a powerful method for combining probabilities in meta-analysis},
+  author={Zaykin, Dmitri V},
+  journal={Journal of evolutionary biology},
+  volume={24},
+  number={8},
+  pages={1836--1841},
+  year={2011},
+  publisher={Wiley Online Library},
+  url={https://doi.org/10.1111/j.1420-9101.2011.02297.x},
+  doi={10.1111/j.1420-9101.2011.02297.x}
 }
 
 @article{zhang2009cluster,

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1,0 +1,140 @@
+@article{bullmore1999global,
+  title={Global, voxel, and cluster tests, by theory and permutation, for a difference between two groups of structural MR images of the brain},
+  author={Bullmore, Edward T and Suckling, John and Overmeyer, Stephan and Rabe-Hesketh, Sophia and Taylor, Eric and Brammer, Michael J},
+  journal={IEEE transactions on medical imaging},
+  volume={18},
+  number={1},
+  pages={32--42},
+  year={1999},
+  publisher={IEEE},
+  url={https://doi.org/10.1109/42.750253},
+  doi={10.1109/42.750253}
+}
+
+@article{eickhoff2012activation,
+  title={Activation likelihood estimation meta-analysis revisited},
+  author={Eickhoff, Simon B and Bzdok, Danilo and Laird, Angela R and Kurth, Florian and Fox, Peter T},
+  journal={Neuroimage},
+  volume={59},
+  number={3},
+  pages={2349--2361},
+  year={2012},
+  publisher={Elsevier},
+  url={https://doi.org/10.1016/j.neuroimage.2011.09.017},
+  doi={10.1016/j.neuroimage.2011.09.017}
+}
+
+@article{eickhoff2016behavior,
+  title={Behavior, sensitivity, and power of activation likelihood estimation characterized by massive empirical simulation},
+  author={Eickhoff, Simon B and Nichols, Thomas E and Laird, Angela R and Hoffstaedter, Felix and Amunts, Katrin and Fox, Peter T and Bzdok, Danilo and Eickhoff, Claudia R},
+  journal={Neuroimage},
+  volume={137},
+  pages={70--85},
+  year={2016},
+  publisher={Elsevier},
+  url={https://doi.org/10.1016/j.neuroimage.2016.04.072},
+  doi={10.1016/j.neuroimage.2016.04.072}
+}
+
+@article{laird2005ale,
+  title={ALE meta-analysis: Controlling the false discovery rate and performing statistical contrasts},
+  author={Laird, Angela R and Fox, P Mickle and Price, Cathy J and Glahn, David C and Uecker, Angela M and Lancaster, Jack L and Turkeltaub, Peter E and Kochunov, Peter and Fox, Peter T},
+  journal={Human brain mapping},
+  volume={25},
+  number={1},
+  pages={155--164},
+  year={2005},
+  publisher={Wiley Online Library},
+  url={https://doi.org/10.1002/hbm.20136},
+  doi={10.1002/hbm.20136}
+}
+
+@article{langner2014meta,
+  title={Meta-analytic connectivity modeling revisited: controlling for activation base rates},
+  author={Langner, Robert and Rottschy, Claudia and Laird, Angela R and Fox, Peter T and Eickhoff, Simon B},
+  journal={Neuroimage},
+  volume={99},
+  pages={559--570},
+  year={2014},
+  publisher={Elsevier},
+  url={https://doi.org/10.1016/j.neuroimage.2014.06.007},
+  doi={10.1016/j.neuroimage.2014.06.007}
+}
+
+@article{turkeltaub2002meta,
+  title={Meta-analysis of the functional neuroanatomy of single-word reading: method and validation},
+  author={Turkeltaub, Peter E and Eden, Guinevere F and Jones, Karen M and Zeffiro, Thomas A},
+  journal={Neuroimage},
+  volume={16},
+  number={3},
+  pages={765--780},
+  year={2002},
+  publisher={Elsevier},
+  url={https://doi.org/10.1006/nimg.2002.1131},
+  doi={10.1006/nimg.2002.1131}
+}
+
+@article{turkeltaub2012minimizing,
+  title={Minimizing within-experiment and within-group effects in activation likelihood estimation meta-analyses},
+  author={Turkeltaub, Peter E and Eickhoff, Simon B and Laird, Angela R and Fox, Mick and Wiener, Martin and Fox, Peter},
+  journal={Human brain mapping},
+  volume={33},
+  number={1},
+  pages={1--13},
+  year={2012},
+  publisher={Wiley Online Library},
+  url={https://doi.org/10.1002/hbm.21186},
+  doi={10.1002/hbm.21186}
+}
+
+@article{wager2003valence,
+  title={Valence, gender, and lateralization of functional brain anatomy in emotion: a meta-analysis of findings from neuroimaging},
+  author={Wager, Tor D and Phan, K Luan and Liberzon, Israel and Taylor, Stephan F},
+  journal={Neuroimage},
+  volume={19},
+  number={3},
+  pages={513--531},
+  year={2003},
+  publisher={Elsevier},
+  url={https://doi.org/10.1016/S1053-8119(03)00078-8},
+  doi={10.1016/S1053-8119(03)00078-8}
+}
+
+@article{wager2004neuroimaging,
+  title={Neuroimaging studies of shifting attention: a meta-analysis},
+  author={Wager, Tor D and Jonides, John and Reading, Susan},
+  journal={Neuroimage},
+  volume={22},
+  number={4},
+  pages={1679--1693},
+  year={2004},
+  publisher={Elsevier},
+  url={https://doi.org/10.1016/j.neuroimage.2004.03.052},
+  doi={10.1016/j.neuroimage.2004.03.052}
+}
+
+@article{wager2007meta,
+  title={Meta-analysis of functional neuroimaging data: current and future directions},
+  author={Wager, Tor D and Lindquist, Martin and Kaplan, Lauren},
+  journal={Social cognitive and affective neuroscience},
+  volume={2},
+  number={2},
+  pages={150--158},
+  year={2007},
+  publisher={Oxford University Press},
+  url={https://doi.org/10.1093/scan/nsm015},
+  doi={10.1093/scan/nsm015}
+}
+
+@article{zhang2009cluster,
+  title={Cluster mass inference via random field theory},
+  author={Zhang, Hui and Nichols, Thomas E and Johnson, Timothy D},
+  journal={Neuroimage},
+  volume={44},
+  number={1},
+  pages={51--61},
+  year={2009},
+  publisher={Elsevier},
+  url={https://doi.org/10.1016/j.neuroimage.2008.08.017},
+  doi={10.1016/j.neuroimage.2008.08.017}
+}

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -84,6 +84,18 @@
   doi={10.1016/j.neuroimage.2016.04.072}
 }
 
+@article{enge2021meta,
+  title={A meta-analysis of fMRI studies of semantic cognition in children},
+  author={Enge, Alexander and Rahman, Rasha Abdel and Skeide, Michael A},
+  journal={NeuroImage},
+  volume={241},
+  pages={118436},
+  year={2021},
+  publisher={Elsevier},
+  url={https://doi.org/10.1016/j.neuroimage.2021.118436},
+  doi={10.1016/j.neuroimage.2021.118436}
+}
+
 @article{fisher1946statistical,
   title={Statistical methods for research workers.},
   author={Fisher, Ronald Aylmer and others},
@@ -109,6 +121,17 @@
   author={Hedges, Larry V and Olkin, Ingram},
   year={2014},
   publisher={Academic press}
+}
+
+@article{hughett2008accurate,
+  title={Accurate computation of the F-to-z and t-to-z transforms for large arguments},
+  author={Hughett, Paul},
+  journal={Journal of Statistical Software},
+  volume={23},
+  pages={1--5},
+  year={2008},
+  url={https://doi.org/10.18637/jss.v023.c01},
+  doi={10.18637/jss.v023.c01}
 }
 
 @article{kosmidis2017improving,
@@ -159,6 +182,19 @@
   url={http://jmlr.org/papers/v10/newman09a.html}
 }
 
+@article{nichols2005valid,
+  title={Valid conjunction inference with the minimum statistic},
+  author={Nichols, Thomas and Brett, Matthew and Andersson, Jesper and Wager, Tor and Poline, Jean-Baptiste},
+  journal={Neuroimage},
+  volume={25},
+  number={3},
+  pages={653--660},
+  year={2005},
+  publisher={Elsevier},
+  url={https://doi.org/10.1016/j.neuroimage.2004.12.005},
+  doi={10.1016/j.neuroimage.2004.12.005}
+}
+
 @article{poldrack2011cognitive,
   title={The cognitive atlas: toward a knowledge foundation for cognitive neuroscience},
   author={Poldrack, Russell A and Kittur, Aniket and Kalar, Donald and Miller, Eric and Seppa, Christian and Gil, Yolanda and Parker, D Stott and Sabb, Fred W and Bilder, Robert M},
@@ -191,6 +227,16 @@
   publisher={Public Library of Science San Francisco, CA USA},
   url={https://doi.org/10.1371/journal.pcbi.1005649},
   doi={10.1371/journal.pcbi.1005649}
+}
+
+@software{sochat2015ttoz,
+  author = {Sochat, Vanessa},
+  title = {TtoZ Original Release},
+  month = oct,
+  year = 2015,
+  publisher = {Zenodo},
+  doi = {10.5281/zenodo.32508},
+  url = {https://doi.org/10.5281/zenodo.32508}
 }
 
 @article{stouffer1949american,

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -212,6 +212,7 @@
   author={Poldrack, Russell A and Mumford, Jeanette A and Schonberg, Tom and Kalar, Donald and Barman, Bishal and Yarkoni, Tal},
   year={2012},
   publisher={Public Library of Science San Francisco, USA},
+  journal={PLOS Computational Biology},
   url={https://doi.org/10.1371/journal.pcbi.1002707},
   doi={10.1371/journal.pcbi.1002707}
 }

--- a/examples/02_meta-analyses/08_plot_cbma_subtraction_conjunction.py
+++ b/examples/02_meta-analyses/08_plot_cbma_subtraction_conjunction.py
@@ -8,7 +8,7 @@ Two-sample ALE meta-analysis
 
 Meta-analytic projects often involve a number of common steps comparing two or more samples.
 
-In this example, we replicate the ALE-based analyses from [1]_.
+In this example, we replicate the ALE-based analyses from :footcite:t:`enge2021meta`.
 
 A common project workflow with two meta-analytic samples involves the following:
 
@@ -28,11 +28,11 @@ from nilearn.plotting import plot_stat_map
 # Load Sleuth text files into Datasets
 # -----------------------------------------------------------------------------
 # The data for this example are a subset of studies from a meta-analysis on
-# semantic cognition in children. [1]_ A first group of studies probed
-# children's semantic world knowledge (e.g., correctly naming an object after
-# hearing its auditory description) while a second group of studies asked
-# children to decide if two (or more) words were semantically related to one
-# another or not.
+# semantic cognition in children :footcite:p:`enge2021meta`.
+# A first group of studies probed children's semantic world knowledge
+# (e.g., correctly naming an object after hearing its auditory description)
+# while a second group of studies asked children to decide if two (or more)
+# words were semantically related to one another or not.
 from nimare.io import convert_sleuth_to_dataset
 from nimare.utils import get_resource_path
 
@@ -143,9 +143,10 @@ plot_stat_map(
 # To determine the overlap of the meta-analytic results, a conjunction image
 # can be computed by (a) identifying voxels that were statistically significant
 # in *both* individual group maps and (b) selecting, for each of these voxels,
-# the smaller of the two group-specific *z* values. [2]_ Since this is simple
-# arithmetic on images, conjunction is not implemented as a separate method in
-# :code:`NiMARE` but can easily be achieved with :func:`nilearn.image.math_img`.
+# the smaller of the two group-specific *z* values :footcite:t:`nichols2005valid`.
+# Since this is simple arithmetic on images, conjunction is not implemented as
+# a separate method in :code:`NiMARE` but can easily be achieved with
+# :func:`nilearn.image.math_img`.
 from nilearn.image import math_img
 
 formula = "np.where(img1 * img2 > 0, np.minimum(img1, img2), 0)"
@@ -164,9 +165,4 @@ plot_stat_map(
 ###############################################################################
 # References
 # -----------------------------------------------------------------------------
-# .. [1] Enge, Alexander, et al. "A meta-analysis of fMRI studies of
-#     semantic cognition in children." Neuroimage 241 (2021): 118436.
-#     https://doi.org/10.1016/j.neuroimage.2021.118436
-# .. [2] Nichols, Thomas, et al. "Valid conjunction inference with the
-#     minimum statistic." Neuroimage 25.3 (2005): 653-660.
-#     https://doi.org/10.1016/j.neuroimage.2004.12.005
+# .. footbibliography::

--- a/nimare/annotate/cogat.py
+++ b/nimare/annotate/cogat.py
@@ -34,14 +34,12 @@ class CogAtLemmatizer(object):
 
     Notes
     -----
-    The Cognitive Atlas [1]_ is an ontology for describing cognitive neuroscience concepts and
-    tasks.
+    The Cognitive Atlas :footcite:p:`poldrack2011cognitive` is an ontology for describing
+    cognitive neuroscience concepts and tasks.
 
     References
     ----------
-    .. [1] Poldrack, Russell A., et al. "The cognitive atlas: toward a knowledge foundation for
-       cognitive neuroscience." Frontiers in neuroinformatics 5 (2011): 17.
-       https://doi.org/10.3389/fninf.2011.00017
+    .. footbibliography::
 
     See Also
     --------
@@ -128,14 +126,12 @@ def extract_cogat(text_df, id_df=None, text_column="abstract"):
 
     Notes
     -----
-    The Cognitive Atlas [1]_ is an ontology for describing cognitive neuroscience concepts and
-    tasks.
+    The Cognitive Atlas :footcite:p:`poldrack2011cognitive` is an ontology for describing
+    cognitive neuroscience concepts and tasks.
 
     References
     ----------
-    .. [1]  Poldrack, Russell A., et al. "The cognitive atlas: toward a
-            knowledge foundation for cognitive neuroscience." Frontiers in
-            neuroinformatics 5 (2011): 17. https://doi.org/10.3389/fninf.2011.00017
+    .. footbibliography::
 
     See Also
     --------

--- a/nimare/annotate/gclda.py
+++ b/nimare/annotate/gclda.py
@@ -20,7 +20,7 @@ LGR = logging.getLogger(__name__)
 class GCLDAModel(NiMAREBase):
     """Generate a generalized correspondence latent Dirichlet allocation (GCLDA) topic model.
 
-    This model was originally described in Rubin et al. (2017) [1]_.
+    This model was originally described in :footcite:t:`rubin2017decoding`.
 
     .. versionchanged:: 0.0.8
 
@@ -80,10 +80,7 @@ class GCLDAModel(NiMAREBase):
 
     References
     ----------
-    .. [1] Rubin, Timothy N., et al. "Decoding brain activity using a large-scale probabilistic
-       functional-anatomical atlas of human cognition."
-       PLoS computational biology 13.10 (2017): e1005649.
-       https://doi.org/10.1371/journal.pcbi.1005649
+    .. footbibliography::
 
     See Also
     --------
@@ -729,7 +726,7 @@ class GCLDAModel(NiMAREBase):
 
         Computes the log-likelihood of data in any model object (either train or test) given the
         posterior predictive distributions over peaks and word-types for the model,
-        using the method described in Newman et al. (2009) [2]_.
+        using the method described in :footcite:t:`newman2009distributed`.
         Note that this is not computing the joint log-likelihood of model parameters and data.
 
         Parameters
@@ -753,9 +750,7 @@ class GCLDAModel(NiMAREBase):
 
         References
         ----------
-        .. [2] Newman, D., Asuncion, A., Smyth, P., & Welling, M. (2009).
-            Distributed algorithms for topic models. Journal of Machine
-            Learning Research, 10(Aug), 1801-1828.
+        .. footbibliography::
         """
         if model is None:
             model = self

--- a/nimare/annotate/lda.py
+++ b/nimare/annotate/lda.py
@@ -27,11 +27,12 @@ class LDAModel(NiMAREBase):
         Maximum number of iterations to use during model fitting. Default = 1000.
     alpha : :obj:`float` or None, optional
         The ``alpha`` value for the model. This corresponds to the model's ``doc_topic_prior``
-        parameter. Default is None, which evaluates to ``1 / n_topics``, as was used in [2]_.
+        parameter. Default is None, which evaluates to ``1 / n_topics``,
+        as was used in :footcite:t:`poldrack2012discovering`.
     beta : :obj:`float` or None, optional
         The ``beta`` value for the model. This corresponds to the model's ``topic_word_prior``
         parameter. If None, it evaluates to ``1 / n_topics``.
-        Default is 0.001, which was used in [2]_.
+        Default is 0.001, which was used in :footcite:t:`poldrack2012discovering`.
     text_column : :obj:`str`, optional
         The source of text to use for the model. This should correspond to an existing column
         in the :py:attr:`~nimare.dataset.Dataset.texts` attribute. Default is "abstract".
@@ -42,16 +43,12 @@ class LDAModel(NiMAREBase):
 
     Notes
     -----
-    Latent Dirichlet allocation was first developed in [1]_, and was first applied to neuroimaging
-    articles in [2]_.
+    Latent Dirichlet allocation was first developed in :footcite:t:`blei2003latent`,
+    and was first applied to neuroimaging articles in :footcite:t:`poldrack2012discovering`.
 
     References
     ----------
-    .. [1] Blei, David M., Andrew Y. Ng, and Michael I. Jordan. "Latent dirichlet allocation."
-       Journal of machine Learning research 3.Jan (2003): 993-1022.
-    .. [2] Poldrack, Russell A., et al. "Discovering relations between mind, brain, and mental
-       disorders using topic mapping." PLoS computational biology 8.10 (2012): e1002707.
-       https://doi.org/10.1371/journal.pcbi.1002707
+    .. footbibliography::
 
     See Also
     --------

--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -24,7 +24,7 @@ LGR = logging.getLogger(__name__)
 def gclda_decode_map(model, image, topic_priors=None, prior_weight=1):
     r"""Perform image-to-text decoding for continuous inputs using method from Rubin et al. (2017).
 
-    The method used in this function was originally described in Rubin et al. (2017) [1]_.
+    The method used in this function was originally described in :footcite:t:`rubin2017decoding`.
 
     Parameters
     ----------
@@ -88,10 +88,7 @@ def gclda_decode_map(model, image, topic_priors=None, prior_weight=1):
 
     References
     ----------
-    .. [1] Rubin, Timothy N., et al. "Decoding brain activity using a large-scale probabilistic
-       functional-anatomical atlas of human cognition."
-       PLoS computational biology 13.10 (2017): e1005649.
-       https://doi.org/10.1371/journal.pcbi.1005649
+    .. footbibliography::
     """
     image = load_niimg(image)
 

--- a/nimare/decode/discrete.py
+++ b/nimare/decode/discrete.py
@@ -20,7 +20,7 @@ from .utils import weight_priors
 def gclda_decode_roi(model, roi, topic_priors=None, prior_weight=1.0):
     r"""Perform image-to-text decoding for discrete inputs using method from Rubin et al. (2017).
 
-    The method used in this function was originally described in Rubin et al. (2017) [1]_.
+    The method used in this function was originally described in :footcite:t:`rubin2017decoding`.
 
     Parameters
     ----------
@@ -80,10 +80,7 @@ def gclda_decode_roi(model, roi, topic_priors=None, prior_weight=1.0):
 
     References
     ----------
-    .. [1] Rubin, Timothy N., et al. "Decoding brain activity using a large-scale probabilistic
-       functional-anatomical atlas of human cognition."
-       PLoS computational biology 13.10 (2017): e1005649.
-       https://doi.org/10.1371/journal.pcbi.1005649
+    .. footbibliography::
     """
     roi = load_niimg(roi)
 
@@ -120,7 +117,7 @@ def gclda_decode_roi(model, roi, topic_priors=None, prior_weight=1.0):
 class BrainMapDecoder(Decoder):
     """Perform image-to-text decoding for discrete inputs according to the BrainMap method.
 
-    This method was described in [1]_.
+    This method was described in :footcite:t:`amft2015definition`.
 
     .. versionadded:: 0.0.3
 
@@ -156,9 +153,7 @@ class BrainMapDecoder(Decoder):
 
     References
     ----------
-    .. [1] Amft, Maren, et al. "Definition and characterization of an extended social-affective
-       default network." Brain Structure and Function 220.2 (2015): 1031-1049.
-       https://doi.org/10.1007/s00429-013-0698-0
+    .. footbibliography::
     """
 
     _required_inputs = {
@@ -231,7 +226,7 @@ def brainmap_decode(
 ):
     """Perform image-to-text decoding for discrete inputs according to the BrainMap method.
 
-    This method was described in [1]_.
+    This method was described in :footcite:t:`amft2015definition`.
 
     Parameters
     ----------
@@ -280,9 +275,7 @@ def brainmap_decode(
 
     References
     ----------
-    .. [1] Amft, Maren, et al. "Definition and characterization of an extended social-affective
-       default network." Brain Structure and Function 220.2 (2015): 1031-1049.
-       https://doi.org/10.1007/s00429-013-0698-0
+    .. footbibliography::
     """
     dataset_ids = sorted(list(set(coordinates["id"].values)))
     if ids2 is None:
@@ -398,7 +391,7 @@ def brainmap_decode(
 class NeurosynthDecoder(Decoder):
     """Perform discrete functional decoding according to Neurosynth's meta-analytic method.
 
-    Neurosynth was described in [1]_.
+    Neurosynth was described in :footcite:t:`yarkoni2011large`.
 
     .. versionadded:: 0.0.3
 
@@ -444,8 +437,7 @@ class NeurosynthDecoder(Decoder):
 
     References
     ----------
-    .. [1] Yarkoni, Tal, et al. "Large-scale automated synthesis of human functional neuroimaging
-       data." Nature methods 8.8 (2011): 665. https://doi.org/10.1038/nmeth.1635
+    .. footbibliography::
     """
 
     _required_inputs = {
@@ -528,7 +520,7 @@ def neurosynth_decode(
     (`ids`) are compared to the unselected studies remaining in the database
     (`dataset`).
 
-    Neurosynth was described in [1]_.
+    Neurosynth was described in :footcite:t:`yarkoni2011large`.
 
     Parameters
     ----------
@@ -583,8 +575,7 @@ def neurosynth_decode(
 
     References
     ----------
-    .. [1] Yarkoni, Tal, et al. "Large-scale automated synthesis of human functional neuroimaging
-       data." Nature methods 8.8 (2011): 665. https://doi.org/10.1038/nmeth.1635
+    .. footbibliography::
     """
     dataset_ids = sorted(list(set(coordinates["id"].values)))
     if ids2 is None:
@@ -683,7 +674,7 @@ def neurosynth_decode(
 class ROIAssociationDecoder(Decoder):
     """Perform discrete functional decoding according to Neurosynth's ROI association method.
 
-    Neurosynth was described in [1]_.
+    Neurosynth was described in :footcite:t:`yarkoni2011large`.
 
     Parameters
     ----------
@@ -714,8 +705,7 @@ class ROIAssociationDecoder(Decoder):
 
     References
     ----------
-    .. [1] Yarkoni, Tal, et al. "Large-scale automated synthesis of human functional neuroimaging
-       data." Nature methods 8.8 (2011): 665. https://doi.org/10.1038/nmeth.1635
+    .. footbibliography::
     """
 
     _required_inputs = {

--- a/nimare/decode/encode.py
+++ b/nimare/decode/encode.py
@@ -12,7 +12,7 @@ from .utils import weight_priors
 def gclda_encode(model, text, out_file=None, topic_priors=None, prior_weight=1.0):
     r"""Perform text-to-image encoding according to the method described in Rubin et al. (2017).
 
-    This method was originally described in Rubin et al. (2017) [1]_.
+    This method was originally described in :footcite:t:`rubin2017decoding`.
 
     Parameters
     ----------
@@ -80,10 +80,7 @@ def gclda_encode(model, text, out_file=None, topic_priors=None, prior_weight=1.0
 
     References
     ----------
-    .. [1] Rubin, Timothy N., et al. "Decoding brain activity using a large-scale probabilistic
-       functional-anatomical atlas of human cognition."
-       PLoS computational biology 13.10 (2017): e1005649.
-       https://doi.org/10.1371/journal.pcbi.1005649
+    .. footbibliography::
     """
     if isinstance(text, list):
         text = " ".join(text)

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -31,7 +31,7 @@ LGR = logging.getLogger(__name__)
     "distribution for significance testing.",
 )
 class ALE(CBMAEstimator):
-    r"""Activation likelihood estimation.
+    """Activation likelihood estimation.
 
     Parameters
     ----------
@@ -56,7 +56,7 @@ class ALE(CBMAEstimator):
                                 This method is must slower, and is only slightly more accurate.
         ======================= =================================================================
 
-    n_iters : int, optional
+    n_iters : :obj:`int`, optional
         Number of iterations to use to define the null distribution.
         This is only used if ``null_method=="montecarlo"``.
         Default is 10000.
@@ -67,7 +67,7 @@ class ALE(CBMAEstimator):
         Default is 1.
     **kwargs
         Keyword arguments. Arguments for the kernel_transformer can be assigned here,
-        with the prefix '\kernel__' in the variable name.
+        with the prefix ``kernel__`` in the variable name.
         Another optional argument is ``mask``.
 
     Attributes
@@ -113,7 +113,7 @@ class ALE(CBMAEstimator):
 
     Notes
     -----
-    The ALE algorithm was originally developed in :footcite:t:`turkeltaub2002meta`_,
+    The ALE algorithm was originally developed in :footcite:t:`turkeltaub2002meta`,
     then updated in :footcite:t:`turkeltaub2012minimizing` and
     :footcite:t:`eickhoff2012activation`.
 

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -113,7 +113,9 @@ class ALE(CBMAEstimator):
 
     Notes
     -----
-    The ALE algorithm was originally developed in [1]_, then updated in [2]_ and [3]_.
+    The ALE algorithm was originally developed in :footcite:t:`turkeltaub2002meta`_,
+    then updated in :footcite:t:`turkeltaub2012minimizing` and
+    :footcite:t:`eickhoff2012activation`.
 
     The ALE algorithm is also implemented as part of the GingerALE app provided by the BrainMap
     organization (https://www.brainmap.org/ale/).
@@ -122,14 +124,7 @@ class ALE(CBMAEstimator):
 
     References
     ----------
-    .. [1] Turkeltaub, Peter E., et al. "Meta-analysis of the functional
-        neuroanatomy of single-word reading: method and validation."
-        Neuroimage 16.3 (2002): 765-780.
-    .. [2] Turkeltaub, Peter E., et al. "Minimizing within-experiment and
-        within-group effects in activation likelihood estimation
-        meta-analyses." Human brain mapping 33.1 (2012): 1-13.
-    .. [3] Eickhoff, Simon B., et al. "Activation likelihood estimation
-        meta-analysis revisited." Neuroimage 59.3 (2012): 2349-2361.
+    .. footbibliography::
     """
 
     def __init__(
@@ -298,7 +293,8 @@ class ALESubtraction(PairwiseCBMAEstimator):
 
     Notes
     -----
-    This method was originally developed in [1]_ and refined in [2]_.
+    This method was originally developed in :footcite:t:`laird2005ale` and refined in
+    :footcite:t:`eickhoff2012activation`.
 
     The ALE subtraction algorithm is also implemented as part of the GingerALE app provided by the
     BrainMap organization (https://www.brainmap.org/ale/).
@@ -319,11 +315,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
 
     References
     ----------
-    .. [1] Laird, Angela R., et al. "ALE meta-analysis: Controlling the false discovery rate and
-       performing statistical contrasts." Human brain mapping 25.1 (2005): 155-164.
-       https://doi.org/10.1002/hbm.20136
-    .. [2] Eickhoff, Simon B., et al. "Activation likelihood estimation meta-analysis revisited."
-       Neuroimage 59.3 (2012): 2349-2361. https://doi.org/10.1016/j.neuroimage.2011.09.017
+    .. footbibliography::
     """
 
     def __init__(self, kernel_transformer=ALEKernel, n_iters=10000, n_cores=1, **kwargs):
@@ -488,6 +480,8 @@ class ALESubtraction(PairwiseCBMAEstimator):
 class SCALE(CBMAEstimator):
     r"""Specific coactivation likelihood estimation.
 
+    This method was originally introduced in :footcite:t:`langner2014meta`.
+
     .. versionchanged:: 0.0.12
 
         - Remove unused parameters ``voxel_thresh`` and ``memory_limit``.
@@ -542,9 +536,7 @@ class SCALE(CBMAEstimator):
 
     References
     ----------
-    * Langner, Robert, et al. "Meta-analytic connectivity modeling
-      revisited: controlling for activation base rates." NeuroImage 99
-      (2014): 559-570. https://doi.org/10.1016/j.neuroimage.2014.06.007
+    .. footbibliography::
     """
 
     def __init__(

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -562,13 +562,14 @@ class CBMAEstimator(MetaEstimator):
                 based on cluster size. This was previously simply called "logp_level-cluster".
                 This array is **not** generated if ``vfwe_only`` is ``True``.
             -   ``logp_desc-mass_level-cluster``: Cluster-level FWE-corrected ``-log10(p)`` map
-                based on cluster mass. According to [4]_ and [5]_, cluster mass-based inference is
-                more powerful than cluster size.
+                based on cluster mass. According to :footcite:t:`bullmore1999global` and
+                :footcite:t:`zhang2009cluster`, cluster mass-based inference is more powerful than
+                cluster size.
                 This array is **not** generated if ``vfwe_only`` is ``True``.
             -   ``logp_level-voxel``: Voxel-level FWE-corrected ``-log10(p)`` map.
                 Voxel-level correction is generally more conservative than cluster-level
                 correction, so it is only recommended for very large meta-analyses
-                (i.e., hundreds of studies), per [6]_.
+                (i.e., hundreds of studies), per :footcite:t:`eickhoff2016behavior`.
 
         Notes
         -----
@@ -588,18 +589,7 @@ class CBMAEstimator(MetaEstimator):
 
         References
         ----------
-        .. [4] Bullmore, E. T., Suckling, J., Overmeyer, S., Rabe-Hesketh, S., Taylor, E., &
-               Brammer, M. J. (1999). Global, voxel, and cluster tests, by theory and permutation,
-               for a difference between two groups of structural MR images of the brain.
-               IEEE transactions on medical imaging, 18(1), 32-42. doi: 10.1109/42.750253
-        .. [5] Zhang, H., Nichols, T. E., & Johnson, T. D. (2009).
-               Cluster mass inference via random field theory. Neuroimage, 44(1), 51-61.
-               doi: 10.1016/j.neuroimage.2008.08.017
-        .. [6] Eickhoff, S. B., Nichols, T. E., Laird, A. R., Hoffstaedter, F., Amunts, K.,
-               Fox, P. T., ... & Eickhoff, C. R. (2016).
-               Behavior, sensitivity, and power of activation likelihood estimation characterized
-               by massive empirical simulation. Neuroimage, 137, 70-85.
-               doi: 10.1016/j.neuroimage.2016.04.072
+        .. footbibliography::
 
         Examples
         --------

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -25,6 +25,8 @@ LGR = logging.getLogger(__name__)
 class MKDADensity(CBMAEstimator):
     r"""Multilevel kernel density analysis- Density analysis.
 
+    The MKDA density method was originally introduced in :footcite:t:`wager2007meta`.
+
     Parameters
     ----------
     kernel_transformer : :obj:`~nimare.meta.kernel.KernelTransformer`, optional
@@ -111,10 +113,7 @@ class MKDADensity(CBMAEstimator):
 
     References
     ----------
-    * Wager, Tor D., Martin Lindquist, and Lauren Kaplan. "Meta-analysis
-      of functional neuroimaging data: current and future directions." Social
-      cognitive and affective neuroscience 2.2 (2007): 150-158.
-      https://doi.org/10.1093/scan/nsm015
+    .. footbibliography::
     """
 
     def __init__(
@@ -228,6 +227,8 @@ class MKDADensity(CBMAEstimator):
 class MKDAChi2(PairwiseCBMAEstimator):
     r"""Multilevel kernel density analysis- Chi-square analysis.
 
+    The MKDA chi-square method was originally introduced in :footcite:t:`wager2007meta`.
+
     .. versionchanged:: 0.0.8
 
         * [REF] Use saved MA maps, when available.
@@ -292,10 +293,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
 
     References
     ----------
-    * Wager, Tor D., Martin Lindquist, and Lauren Kaplan. "Meta-analysis
-      of functional neuroimaging data: current and future directions." Social
-      cognitive and affective neuroscience 2.2 (2007): 150-158.
-      https://doi.org/10.1093/scan/nsm015
+    .. footbibliography::
     """
 
     def __init__(self, kernel_transformer=MKDAKernel, prior=0.5, **kwargs):
@@ -988,7 +986,8 @@ class KDA(CBMAEstimator):
 
     Notes
     -----
-    Kernel density analysis was first introduced in [1]_ and [2]_.
+    Kernel density analysis was first introduced in :footcite:t:`wager2003valence` and
+    :footcite:t:`wager2004neuroimaging`.
 
     Available correction methods: :func:`KDA.correct_fwe_montecarlo`
 
@@ -1000,13 +999,7 @@ class KDA(CBMAEstimator):
 
     References
     ----------
-    .. [1] Wager, Tor D., et al. "Valence, gender, and lateralization of
-        functional brain anatomy in emotion: a meta-analysis of findings from
-        neuroimaging." Neuroimage 19.3 (2003): 513-531.
-        https://doi.org/10.1016/S1053-8119(03)00078-8
-    .. [2] Wager, Tor D., John Jonides, and Susan Reading. "Neuroimaging
-        studies of shifting attention: a meta-analysis." Neuroimage 22.4
-        (2004): 1679-1693. https://doi.org/10.1016/j.neuroimage.2004.03.052
+    .. footbibliography::
     """
 
     def __init__(

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -20,6 +20,8 @@ class Fishers(MetaEstimator):
 
     Requires z-statistic images, but will be extended to work with t-statistic images as well.
 
+    This method is described in :footcite:t:`fisher1946statistical`.
+
     Notes
     -----
     Requires ``z`` images.
@@ -35,9 +37,7 @@ class Fishers(MetaEstimator):
 
     References
     ----------
-    * Fisher, R. A. (1934). Statistical methods for research workers.
-      Statistical methods for research workers., (5th Ed).
-      https://www.cabdirect.org/cabdirect/abstract/19351601205
+    .. footbibliography::
 
     See Also
     --------
@@ -77,10 +77,13 @@ class Stouffers(MetaEstimator):
 
     Requires z-statistic images.
 
+    This method is described in :footcite:t:`stouffer1949american`.
+
     Parameters
     ----------
     use_sample_size : :obj:`bool`, optional
-        Whether to use sample sizes for weights (i.e., "weighted Stouffer's") or not.
+        Whether to use sample sizes for weights (i.e., "weighted Stouffer's") or not,
+        as described in :footcite:t:`zaykin2011optimally`.
         Default is False.
 
     Notes
@@ -98,14 +101,7 @@ class Stouffers(MetaEstimator):
 
     References
     ----------
-    * Stouffer, S. A., Suchman, E. A., DeVinney, L. C., Star, S. A., &
-      Williams Jr, R. M. (1949). The American Soldier: Adjustment during
-      army life. Studies in social psychology in World War II, vol. 1.
-      https://psycnet.apa.org/record/1950-00790-000
-    * Zaykin, D. V. (2011). Optimally weighted Z-test is a powerful method for
-      combining probabilities in meta-analysis. Journal of evolutionary
-      biology, 24(8), 1836-1841.
-      https://doi.org/10.1111/j.1420-9101.2011.02297.x
+    .. footbibliography::
 
     See Also
     --------
@@ -166,6 +162,8 @@ class WeightedLeastSquares(MetaEstimator):
     When tau^2 = 0 (default), the model is the standard inverse-weighted
     fixed-effects meta-regression.
 
+    This method was described in :footcite:t:`brockwell2001comparison`.
+
     Parameters
     ----------
     tau2 : :obj:`float` or 1D :class:`numpy.ndarray`, optional
@@ -187,9 +185,7 @@ class WeightedLeastSquares(MetaEstimator):
 
     References
     ----------
-    * Brockwell, S. E., & Gordon, I. R. (2001). A comparison of statistical
-      methods for meta-analysis. Statistics in Medicine, 20(6), 825–840.
-      https://doi.org/10.1002/sim.650
+    .. footbibliography::
 
     See Also
     --------
@@ -241,8 +237,8 @@ class DerSimonianLaird(MetaEstimator):
 
     .. versionadded:: 0.0.4
 
-    Estimates the between-subject variance tau^2 using the DerSimonian-Laird
-    (1986) method-of-moments approach.
+    Estimates the between-subject variance tau^2 using the :footcite:t:`dersimonian1986meta`
+    method-of-moments approach :footcite:p:`dersimonian1986meta,kosmidis2017improving`.
 
     Notes
     -----
@@ -260,11 +256,7 @@ class DerSimonianLaird(MetaEstimator):
 
     References
     ----------
-    * DerSimonian, R., & Laird, N. (1986). Meta-analysis in clinical trials.
-      Controlled clinical trials, 7(3), 177-188.
-    * Kosmidis, I., Guolo, A., & Varin, C. (2017). Improving the accuracy of
-      likelihood-based inference in meta-analysis and meta-regression.
-      Biometrika, 104(2), 489–496. https://doi.org/10.1093/biomet/asx001
+    .. footbibliography::
 
     See Also
     --------
@@ -315,7 +307,7 @@ class Hedges(MetaEstimator):
 
     .. versionadded:: 0.0.4
 
-    Estimates the between-subject variance tau^2 using the Hedges & Olkin (1985)
+    Estimates the between-subject variance tau^2 using the :footcite:t:`hedges2014statistical`
     approach.
 
     Notes
@@ -334,7 +326,7 @@ class Hedges(MetaEstimator):
 
     References
     ----------
-    * Hedges LV, Olkin I. 1985. Statistical Methods for Meta-Analysis.
+    .. footbibliography::
 
     See Also
     --------
@@ -467,7 +459,8 @@ class VarianceBasedLikelihood(MetaEstimator):
     .. versionadded:: 0.0.4
 
     Iteratively estimates the between-subject variance tau^2 and fixed effect
-    coefficients using the specified likelihood-based estimator (ML or REML).
+    coefficients using the specified likelihood-based estimator (ML or REML)
+    :footcite:p:`dersimonian1986meta,kosmidis2017improving`.
 
     Parameters
     ----------
@@ -503,11 +496,7 @@ class VarianceBasedLikelihood(MetaEstimator):
 
     References
     ----------
-    * DerSimonian, R., & Laird, N. (1986). Meta-analysis in clinical trials.
-      Controlled clinical trials, 7(3), 177-188.
-    * Kosmidis, I., Guolo, A., & Varin, C. (2017). Improving the accuracy of
-      likelihood-based inference in meta-analysis and meta-regression.
-      Biometrika, 104(2), 489–496. https://doi.org/10.1093/biomet/asx001
+    .. footbibliography::
 
     See Also
     --------
@@ -561,6 +550,8 @@ class PermutedOLS(MetaEstimator):
 
     .. versionadded:: 0.0.4
 
+    This approach is described in :footcite:t:`freedman1983nonstochastic`.
+
     Parameters
     ----------
     two_sided : :obj:`bool`, optional
@@ -583,8 +574,7 @@ class PermutedOLS(MetaEstimator):
 
     References
     ----------
-    * Freedman, D., & Lane, D. (1983). A nonstochastic interpretation of reported significance
-      levels. Journal of Business & Economic Statistics, 1(4), 292-298.
+    .. footbibliography::
 
     See Also
     --------

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -300,7 +300,7 @@ class ALEKernel(KernelTransformer):
 
     By default (if neither ``fwhm`` nor ``sample_size`` is provided), the FWHM of the kernel
     will be determined on a study-wise basis based on the sample sizes available in the input,
-    via the method described in [1]_.
+    via the method described in :footcite:t:`eickhoff2012activation`.
 
     .. versionchanged:: 0.0.8
 
@@ -325,8 +325,7 @@ class ALEKernel(KernelTransformer):
 
     References
     ----------
-    .. [1] Eickhoff, Simon B., et al. "Activation likelihood estimation
-           meta-analysis revisited." Neuroimage 59.3 (2012): 2349-2361.
+    .. footbibliography::
     """
 
     def __init__(self, fwhm=None, sample_size=None, memory_limit=None):

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -691,7 +691,8 @@ def t_to_z(t_values, dof):
 
     .. versionadded:: 0.0.3
 
-    An implementation of [1]_ from Vanessa Sochat's TtoZ package [2]_.
+    An implementation of :footcite:t:`hughett2008accurate` from Vanessa Sochat's TtoZ package
+    :footcite:p:`sochat2015ttoz`.
 
     Parameters
     ----------
@@ -707,11 +708,7 @@ def t_to_z(t_values, dof):
 
     References
     ----------
-    .. [1] Hughett, P. (2007). Accurate Computation of the F-to-z and t-to-z
-           Transforms for Large Arguments. Journal of Statistical Software,
-           23(1), 1-5.
-    .. [2] Sochat, V. (2015, October 21). TtoZ Original Release. Zenodo.
-           http://doi.org/10.5281/zenodo.32508
+    .. footbibliography::
     """
     # Select just the nonzero voxels
     nonzero = t_values[t_values != 0]
@@ -750,8 +747,8 @@ def z_to_t(z_values, dof):
 
     .. versionadded:: 0.0.3
 
-    An inversion of the t_to_z implementation of [1]_ from Vanessa Sochat's
-    TtoZ package [2]_.
+    An inversion of the t_to_z implementation of :footcite:t:`hughett2008accurate` from
+    Vanessa Sochat's TtoZ package :footcite:p:`sochat2015ttoz`.
 
     Parameters
     ----------
@@ -767,11 +764,7 @@ def z_to_t(z_values, dof):
 
     References
     ----------
-    .. [1] Hughett, P. (2007). Accurate Computation of the F-to-z and t-to-z
-           Transforms for Large Arguments. Journal of Statistical Software,
-           23(1), 1-5.
-    .. [2] Sochat, V. (2015, October 21). TtoZ Original Release. Zenodo.
-           http://doi.org/10.5281/zenodo.32508
+    .. footbibliography::
     """
     # Select just the nonzero voxels
     nonzero = z_values[z_values != 0]

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ doc =
     sphinx-copybutton
     sphinx_gallery==0.10.1
     sphinx_rtd_theme
+    sphinxcontrib-bibtex
 tests =
     codecov
     coverage


### PR DESCRIPTION
Closes #665.

Changes proposed:

- Replace references sections with footbibliographies.
- Add `sphinxcontrib-bibtex` to doc dependencies.