### PR TITLE
Replace relative imports with absolute ones

### DIFF
--- a/nimare/annotate/cogat.py
+++ b/nimare/annotate/cogat.py
@@ -5,11 +5,11 @@ import re
 import numpy as np
 import pandas as pd
 
-from .. import references
-from ..due import due
-from ..extract import download_cognitive_atlas
-from ..utils import _uk_to_us
-from . import utils
+from nimare import references
+from nimare.annotate import utils
+from nimare.due import due
+from nimare.extract import download_cognitive_atlas
+from nimare.utils import _uk_to_us
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/annotate/gclda.py
+++ b/nimare/annotate/gclda.py
@@ -8,10 +8,10 @@ import pandas as pd
 from nilearn._utils import load_niimg
 from scipy.stats import multivariate_normal
 
-from .. import references
-from ..base import NiMAREBase
-from ..due import due
-from ..utils import get_template
+from nimare import references
+from nimare.base import NiMAREBase
+from nimare.due import due
+from nimare.utils import get_template
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/annotate/text.py
+++ b/nimare/annotate/text.py
@@ -5,7 +5,7 @@ import os.path as op
 import pandas as pd
 from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 
-from ..utils import get_resource_path
+from nimare.utils import get_resource_path
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -13,8 +13,8 @@ import numpy as np
 from nilearn._utils.niimg_conversions import _check_same_fov
 from nilearn.image import concat_imgs, resample_to_img
 
-from .results import MetaResult
-from .utils import get_masker, mm2vox
+from nimare.results import MetaResult
+from nimare.utils import get_masker, mm2vox
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/correct.py
+++ b/nimare/correct.py
@@ -6,8 +6,8 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 import numpy as np
 import statsmodels.stats.multitest as mc
 
-from .results import MetaResult
-from .transforms import p_to_z
+from nimare.results import MetaResult
+from nimare.transforms import p_to_z
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -9,8 +9,8 @@ import numpy as np
 import pandas as pd
 from nilearn._utils import load_niimg
 
-from .base import NiMAREBase
-from .utils import (
+from nimare.base import NiMAREBase
+from nimare.utils import (
     _dict_to_coordinates,
     _dict_to_df,
     _listify,

--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -8,14 +8,14 @@ from nilearn._utils import load_niimg
 from nilearn.masking import apply_mask
 from tqdm.auto import tqdm
 
-from .. import references
-from ..base import Decoder
-from ..due import due
-from ..meta.cbma.base import CBMAEstimator
-from ..meta.cbma.mkda import MKDAChi2
-from ..stats import pearson
-from ..utils import _check_type, _safe_transform
-from .utils import weight_priors
+from nimare import references
+from nimare.base import Decoder
+from nimare.decode.utils import weight_priors
+from nimare.due import due
+from nimare.meta.cbma.base import CBMAEstimator
+from nimare.meta.cbma.mkda import MKDAChi2
+from nimare.stats import pearson
+from nimare.utils import _check_type, _safe_transform
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/decode/discrete.py
+++ b/nimare/decode/discrete.py
@@ -6,14 +6,14 @@ from scipy import special
 from scipy.stats import binom
 from statsmodels.sandbox.stats.multicomp import multipletests
 
-from .. import references
-from ..base import Decoder
-from ..due import due
-from ..meta.kernel import KernelTransformer, MKDAKernel
-from ..stats import one_way, pearson, two_way
-from ..transforms import p_to_z
-from ..utils import _check_type, get_masker
-from .utils import weight_priors
+from nimare import references
+from nimare.base import Decoder
+from nimare.decode.utils import weight_priors
+from nimare.due import due
+from nimare.meta.kernel import KernelTransformer, MKDAKernel
+from nimare.stats import one_way, pearson, two_way
+from nimare.transforms import p_to_z
+from nimare.utils import _check_type, get_masker
 
 
 @due.dcite(references.GCLDA_DECODING, description="Citation for GCLDA decoding.")

--- a/nimare/decode/encode.py
+++ b/nimare/decode/encode.py
@@ -3,9 +3,9 @@ import numpy as np
 from nilearn.masking import unmask
 from sklearn.feature_extraction.text import CountVectorizer
 
-from .. import references
-from ..due import due
-from .utils import weight_priors
+from nimare import references
+from nimare.decode.utils import weight_priors
+from nimare.due import due
 
 
 @due.dcite(references.GCLDA_DECODING, description="Citation for GCLDA encoding.")

--- a/nimare/due.py
+++ b/nimare/due.py
@@ -6,7 +6,7 @@ To use it, place it into your project codebase to be imported, e.g. copy as
 Note that it might be better to avoid naming it duecredit.py to avoid shadowing
 installed duecredit.
 Then use in your code as
-    from .due import due, Doi, BibTeX
+    from nimare.due import due, Doi, BibTeX
 See  https://github.com/duecredit/duecredit/blob/master/README.md for examples.
 Origin:     Originally a part of the duecredit
 Copyright:  2015-2016  DueCredit developers

--- a/nimare/extract/extract.py
+++ b/nimare/extract/extract.py
@@ -18,15 +18,15 @@ import pandas as pd
 import requests
 from tqdm.auto import tqdm
 
-from ..dataset import Dataset
-from ..utils import get_resource_path
-from .utils import (
+from nimare.dataset import Dataset
+from nimare.extract.utils import (
     _download_zipped_file,
     _expand_df,
     _get_concept_reltype,
     _get_dataset_dir,
     _longify,
 )
+from nimare.utils import get_resource_path
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/extract/utils.py
+++ b/nimare/extract/utils.py
@@ -10,7 +10,7 @@ import pandas as pd
 import requests
 from fuzzywuzzy import fuzz
 
-from ..utils import _uk_to_us
+from nimare.utils import _uk_to_us
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/generate.py
+++ b/nimare/generate.py
@@ -3,11 +3,11 @@ from itertools import zip_longest
 
 import numpy as np
 
-from .dataset import Dataset
-from .io import convert_neurovault_to_dataset
-from .meta.utils import compute_ale_ma, get_ale_kernel
-from .transforms import ImageTransformer
-from .utils import get_template, mm2vox, vox2mm
+from nimare.dataset import Dataset
+from nimare.io import convert_neurovault_to_dataset
+from nimare.meta.utils import compute_ale_ma, get_ale_kernel
+from nimare.transforms import ImageTransformer
+from nimare.utils import get_template, mm2vox, vox2mm
 
 # defaults for creating a neurovault dataset
 NEUROVAULT_IDS = (8836, 8838, 8893, 8895, 8892, 8891, 8962, 8894, 8956, 8854, 9000)

--- a/nimare/io.py
+++ b/nimare/io.py
@@ -12,8 +12,8 @@ import pandas as pd
 import requests
 from scipy import sparse
 
-from .dataset import Dataset
-from .extract.utils import _get_dataset_dir
+from nimare.dataset import Dataset
+from nimare.extract.utils import _get_dataset_dir
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -6,13 +6,13 @@ import pandas as pd
 from joblib import Parallel, delayed
 from tqdm.auto import tqdm
 
-from ... import references
-from ...due import due
-from ...stats import null_to_p, nullhist_to_p
-from ...transforms import p_to_z
-from ...utils import tqdm_joblib, use_memmap
-from ..kernel import ALEKernel
-from .base import CBMAEstimator, PairwiseCBMAEstimator
+from nimare import references
+from nimare.due import due
+from nimare.meta.cbma.base import CBMAEstimator, PairwiseCBMAEstimator
+from nimare.meta.kernel import ALEKernel
+from nimare.stats import null_to_p, nullhist_to_p
+from nimare.transforms import p_to_z
+from nimare.utils import tqdm_joblib, use_memmap
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -8,11 +8,13 @@ from joblib import Parallel, delayed
 from scipy import ndimage
 from tqdm.auto import tqdm
 
-from ...base import MetaEstimator
-from ...results import MetaResult
-from ...stats import null_to_p, nullhist_to_p
-from ...transforms import p_to_z
-from ...utils import (
+from nimare.base import MetaEstimator
+from nimare.meta.kernel import KernelTransformer
+from nimare.meta.utils import _calculate_cluster_measures, _get_last_bin
+from nimare.results import MetaResult
+from nimare.stats import null_to_p, nullhist_to_p
+from nimare.transforms import p_to_z
+from nimare.utils import (
     _add_metadata_to_dataframe,
     _check_type,
     _safe_transform,
@@ -20,8 +22,6 @@ from ...utils import (
     use_memmap,
     vox2mm,
 )
-from ..kernel import KernelTransformer
-from ..utils import _calculate_cluster_measures, _get_last_bin
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -9,14 +9,14 @@ from scipy.stats import chi2
 from statsmodels.sandbox.stats.multicomp import multipletests
 from tqdm.auto import tqdm
 
-from ... import references
-from ...due import due
-from ...stats import null_to_p, one_way, two_way
-from ...transforms import p_to_z
-from ...utils import tqdm_joblib, use_memmap, vox2mm
-from ..kernel import KDAKernel, MKDAKernel
-from ..utils import _calculate_cluster_measures
-from .base import CBMAEstimator, PairwiseCBMAEstimator
+from nimare import references
+from nimare.due import due
+from nimare.meta.cbma.base import CBMAEstimator, PairwiseCBMAEstimator
+from nimare.meta.kernel import KDAKernel, MKDAKernel
+from nimare.meta.utils import _calculate_cluster_measures
+from nimare.stats import null_to_p, one_way, two_way
+from nimare.transforms import p_to_z
+from nimare.utils import tqdm_joblib, use_memmap, vox2mm
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -8,9 +8,9 @@ import pymare
 from nilearn.input_data import NiftiMasker
 from nilearn.mass_univariate import permuted_ols
 
-from ..base import MetaEstimator
-from ..transforms import p_to_z, t_to_z
-from ..utils import _boolean_unmask
+from nimare.base import MetaEstimator
+from nimare.transforms import p_to_z, t_to_z
+from nimare.utils import _boolean_unmask
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -16,17 +16,22 @@ import numpy as np
 import pandas as pd
 from nilearn import image
 
-from .. import references
-from ..base import Transformer
-from ..due import due
-from ..utils import (
+from nimare import references
+from nimare.base import Transformer
+from nimare.due import due
+from nimare.meta.utils import (
+    compute_ale_ma,
+    compute_kda_ma,
+    compute_p2m_ma,
+    get_ale_kernel,
+)
+from nimare.utils import (
     _add_metadata_to_dataframe,
     _safe_transform,
     mm2vox,
     use_memmap,
     vox2mm,
 )
-from .utils import compute_ale_ma, compute_kda_ma, compute_p2m_ma, get_ale_kernel
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -7,10 +7,10 @@ import numpy as np
 import numpy.linalg as npl
 from scipy import ndimage
 
-from .. import references
-from ..due import due
-from ..extract import download_peaks2maps_model
-from ..utils import _determine_chunk_size
+from nimare import references
+from nimare.due import due
+from nimare.extract import download_peaks2maps_model
+from nimare.utils import _determine_chunk_size
 
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "2"
 LGR = logging.getLogger(__name__)

--- a/nimare/references.py
+++ b/nimare/references.py
@@ -1,5 +1,5 @@
 """References to be imported and injected at relevant places throughout the library."""
-from .due import BibTeX, Doi
+from nimare.due import BibTeX, Doi
 
 TEXT2BRAIN = Doi("https://doi.org/10.1007/978-3-030-00931-1_67")
 

--- a/nimare/results.py
+++ b/nimare/results.py
@@ -5,7 +5,7 @@ import os
 
 from nibabel.funcs import squeeze_image
 
-from .utils import get_masker
+from nimare.utils import get_masker
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/stats.py
+++ b/nimare/stats.py
@@ -4,7 +4,7 @@ import warnings
 
 import numpy as np
 
-from . import utils
+from nimare import utils
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/tests/conftest.py
+++ b/nimare/tests/conftest.py
@@ -9,8 +9,7 @@ from nilearn.image import resample_img
 
 import nimare
 from nimare.tests.utils import get_test_data_path
-
-from ..utils import get_resource_path
+from nimare.utils import get_resource_path
 
 # Only enable the following once in a while for a check for SettingWithCopyWarnings
 # pd.options.mode.chained_assignment = "raise"

--- a/nimare/tests/test_estimator_performance.py
+++ b/nimare/tests/test_estimator_performance.py
@@ -5,12 +5,12 @@ from contextlib import ExitStack as does_not_raise
 import numpy as np
 import pytest
 
-from ..correct import FDRCorrector, FWECorrector
-from ..generate import create_coordinate_dataset
-from ..meta import ale, kernel, mkda
-from ..results import MetaResult
-from ..utils import mm2vox
-from .utils import _check_p_values, _create_signal_mask, _transform_res
+from nimare.correct import FDRCorrector, FWECorrector
+from nimare.generate import create_coordinate_dataset
+from nimare.meta import ale, kernel, mkda
+from nimare.results import MetaResult
+from nimare.tests.utils import _check_p_values, _create_signal_mask, _transform_res
+from nimare.utils import mm2vox
 
 # set significance levels used for testing.
 ALPHA = 0.05

--- a/nimare/tests/test_generate.py
+++ b/nimare/tests/test_generate.py
@@ -4,8 +4,8 @@ from contextlib import ExitStack as does_not_raise
 import pytest
 from numpy.random import RandomState
 
-from ..dataset import Dataset
-from ..generate import (
+from nimare.dataset import Dataset
+from nimare.generate import (
     _array_like,
     _create_foci,
     _create_source,

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -10,8 +10,7 @@ from nilearn.input_data import NiftiLabelsMasker
 import nimare
 from nimare.correct import FDRCorrector, FWECorrector
 from nimare.meta import ibma
-
-from .utils import get_test_data_path
+from nimare.tests.utils import get_test_data_path
 
 
 @pytest.mark.parametrize(

--- a/nimare/tests/utils.py
+++ b/nimare/tests/utils.py
@@ -6,7 +6,7 @@ import nibabel as nib
 import numpy as np
 import pytest
 
-from ..meta.utils import compute_kda_ma
+from nimare.meta.utils import compute_kda_ma
 
 # set significance levels used for testing.
 # duplicated in test_estimator_performance

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -10,10 +10,10 @@ import pandas as pd
 from nilearn.reporting import get_clusters_table
 from scipy import stats
 
-from . import references
-from .base import Transformer
-from .due import due
-from .utils import _dict_to_coordinates, _dict_to_df, _listify, get_masker
+from nimare import references
+from nimare.base import Transformer
+from nimare.due import due
+from nimare.utils import _dict_to_coordinates, _dict_to_df, _listify, get_masker
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -15,8 +15,8 @@ import numpy as np
 import pandas as pd
 from nilearn.input_data import NiftiMasker
 
-from . import references
-from .due import due
+from nimare import references
+from nimare.due import due
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/workflows/conperm.py
+++ b/nimare/workflows/conperm.py
@@ -7,8 +7,8 @@ import numpy as np
 from nilearn.masking import apply_mask
 from nilearn.mass_univariate import permuted_ols
 
-from ..results import MetaResult
-from ..utils import get_template
+from nimare.results import MetaResult
+from nimare.utils import get_template
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/workflows/macm.py
+++ b/nimare/workflows/macm.py
@@ -4,9 +4,9 @@ import os
 import pathlib
 from shutil import copyfile
 
-from ..correct import FWECorrector
-from ..dataset import Dataset
-from ..meta import ALE
+from nimare.correct import FWECorrector
+from nimare.dataset import Dataset
+from nimare.meta import ALE
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/workflows/peaks2maps.py
+++ b/nimare/workflows/peaks2maps.py
@@ -8,9 +8,9 @@ from nilearn.image import resample_to_img
 from nilearn.masking import apply_mask
 from nilearn.mass_univariate import permuted_ols
 
-from ..base import MetaResult
-from ..io import convert_sleuth_to_dataset
-from ..meta.kernel import Peaks2MapsKernel
+from nimare.base import MetaResult
+from nimare.io import convert_sleuth_to_dataset
+from nimare.meta.kernel import Peaks2MapsKernel
 
 LGR = logging.getLogger(__name__)
 

--- a/nimare/workflows/scale.py
+++ b/nimare/workflows/scale.py
@@ -6,10 +6,10 @@ from shutil import copyfile
 
 import numpy as np
 
-from ..dataset import Dataset
-from ..io import convert_sleuth_to_dataset
-from ..meta import SCALE
-from ..utils import vox2mm
+from nimare.dataset import Dataset
+from nimare.io import convert_sleuth_to_dataset
+from nimare.meta import SCALE
+from nimare.utils import vox2mm
 
 LGR = logging.getLogger(__name__)
 


### PR DESCRIPTION
Closes None. Absolute imports are recommended by PEP8, and I think this will make it easier to identify any circular import problems as we start reorganizing base classes.