### PR TITLE
Reduce memory usage of `KernelTransformer.transform` and `meta.utils.compute_kda_ma`

### DIFF
--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -154,7 +154,7 @@ class CorrelationDecoder(Decoder):
     ):
 
         if meta_estimator is None:
-            meta_estimator = MKDAChi2(memory_limit=memory_limit, kernel__memory_limit=memory_limit)
+            meta_estimator = MKDAChi2()
         else:
             meta_estimator = _check_type(meta_estimator, CBMAEstimator)
 

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -189,7 +189,7 @@ class CBMAEstimator(Estimator):
         """
         return None
 
-    def _collect_ma_maps(self, coords_key="coordinates", maps_key="ma_maps"):
+    def _collect_ma_maps(self, coords_key="coordinates", maps_key="ma_maps", return_type="array"):
         """Collect modeled activation maps from Estimator inputs.
 
         Parameters

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -199,7 +199,9 @@ class CBMAEstimator(Estimator):
         """
         return None
 
-    def _collect_ma_maps(self, coords_key="coordinates", maps_key="ma_maps", fname_idx=0):
+    def _collect_ma_maps(
+        self, coords_key="coordinates", maps_key="ma_maps", fname_idx=0, return_type="array"
+    ):
         """Collect modeled activation maps from Estimator inputs.
 
         Parameters
@@ -240,10 +242,11 @@ class CBMAEstimator(Estimator):
 
         else:
             LGR.debug(f"Generating MA maps from coordinates ({coords_key}).")
+
             ma_maps = self.kernel_transformer.transform(
                 self.inputs_[coords_key],
                 masker=self.masker,
-                return_type="array",
+                return_type=return_type,
             )
 
         return ma_maps

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -401,8 +401,6 @@ class MKDAChi2(PairwiseCBMAEstimator):
 
         del n_selected, n_unselected
 
-        # print(cells)
-
         pFgA_chi2_vals = two_way(cells)
 
         del n_selected_active_voxels, n_unselected_active_voxels

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -322,6 +322,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
         ma_maps1 = self._collect_ma_maps(
             maps_key="ma_maps1",
             coords_key="coordinates1",
+            return_type="sparse",
         )
         n_selected = ma_maps1.shape[0]
         n_selected_active_voxels = ma_maps1.sum(axis=0)
@@ -331,7 +332,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
             mask = masker.mask_img
             mask_data = mask.get_fdata().astype(bool)
 
-            # Indexing the sparse array is slow, perfor masking in the dense array
+            # Indexing the sparse array is slow, perform masking in the dense array
             n_selected_active_voxels = n_selected_active_voxels.todense().reshape(-1)
             n_selected_active_voxels = n_selected_active_voxels[mask_data.reshape(-1)]
 
@@ -342,6 +343,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
         ma_maps2 = self._collect_ma_maps(
             maps_key="ma_maps2",
             coords_key="coordinates2",
+            return_type="sparse",
         )
         n_unselected = ma_maps2.shape[0]
         n_unselected_active_voxels = ma_maps2.sum(axis=0)

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -1,4 +1,5 @@
 """CBMA methods from the multilevel kernel density analysis (MKDA) family."""
+import gc
 import logging
 
 import nibabel as nib
@@ -332,6 +333,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
             ma_maps1._mmap.close()
 
         del ma_maps1
+        gc.collect()
 
         # Generate MA maps and calculate count variables for second dataset
         ma_maps2 = self._collect_ma_maps(
@@ -349,6 +351,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
             ma_maps2._mmap.close()
 
         del ma_maps2
+        gc.collect()
 
         n_mappables = n_selected + n_unselected
 

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -212,12 +212,17 @@ class KernelTransformer(Transformer):
                 # Transform into an length-N list of length-2 tuples,
                 # composed of a 3D array/memmap and a string with the ID.
                 transformed_maps = list(zip(*transformed_maps))
+        else:
+            transformed_maps = list(zip(*transformed_maps))
 
         imgs = []
         for (kernel_data, id_) in transformed_maps:
             if isinstance(kernel_data, np.memmap):
                 # Convert data to a numpy array if it's a memmap
                 kernel_data = np.array(kernel_data)
+            else:
+                # Convert sparse to dense array
+                kernel_data = kernel_data.todense()
 
             if return_type == "array":
                 # NOTE: This will never be a memmap because memory_limit[!None]+return_type[array]

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -14,6 +14,7 @@ from hashlib import md5
 import nibabel as nib
 import numpy as np
 import pandas as pd
+import sparse
 from nilearn import image
 
 from .. import references
@@ -212,7 +213,7 @@ class KernelTransformer(Transformer):
                 # Transform into an length-N list of length-2 tuples,
                 # composed of a 3D array/memmap and a string with the ID.
                 transformed_maps = list(zip(*transformed_maps))
-        else:
+        elif isinstance(transformed_maps[0][0], sparse._compressed.compressed.GCXS):
             transformed_maps = list(zip(*transformed_maps))
 
         imgs = []
@@ -220,7 +221,7 @@ class KernelTransformer(Transformer):
             if isinstance(kernel_data, np.memmap):
                 # Convert data to a numpy array if it's a memmap
                 kernel_data = np.array(kernel_data)
-            else:
+            elif isinstance(kernel_data, sparse._compressed.compressed.GCXS):
                 # Convert sparse to dense array
                 kernel_data = kernel_data.todense()
 

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -6,6 +6,7 @@ size and test statistic values).
 """
 from __future__ import division
 
+import gc
 import logging
 import os
 import warnings
@@ -219,7 +220,6 @@ class KernelTransformer(NiMAREBase):
                 # composed of a 3D array/memmap and a string with the ID.
                 transformed_maps = list(zip(*transformed_maps))
 
-        # idx = 0
         imgs = []
         if isinstance(transformed_maps[0], sparse._coo.core.COO):
             for idx, id_ in enumerate(transformed_maps[1]):
@@ -264,6 +264,7 @@ class KernelTransformer(NiMAREBase):
             transformed_maps[0][0]._mmap.close()
 
         del kernel_data, transformed_maps
+        gc.collect()
 
         if return_type == "array":
             return np.vstack(imgs)

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -98,7 +98,7 @@ class KernelTransformer(NiMAREBase):
             Mask to apply to MA maps. Required if ``dataset`` is a DataFrame.
             If None (and ``dataset`` is a Dataset), the Dataset's masker attribute will be used.
             Default is None.
-        return_type : {'array', 'image', 'dataset'}, optional
+        return_type : {'sparse', 'array', 'image', 'dataset'}, optional
             Whether to return a numpy array ('array'), a list of niimgs ('image'),
             or a Dataset with MA images saved as files ('dataset').
             Default is 'image'.
@@ -122,7 +122,7 @@ class KernelTransformer(NiMAREBase):
         image_type : str
             Name of the corresponding column in the Dataset.images DataFrame.
         """
-        if return_type not in ("array", "image", "dataset"):
+        if return_type not in ("sparse", "array", "image", "dataset"):
             raise ValueError('Argument "return_type" must be "image", "array", or "dataset".')
 
         if isinstance(dataset, pd.DataFrame):
@@ -222,6 +222,9 @@ class KernelTransformer(NiMAREBase):
 
         imgs = []
         if isinstance(transformed_maps[0], sparse._coo.core.COO):
+            if return_type == "sparse":
+                return transformed_maps[0]
+
             for idx, id_ in enumerate(transformed_maps[1]):
                 kernel_data = transformed_maps[0][idx].todense()
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -5,8 +5,8 @@ import os
 import nibabel as nib
 import numpy as np
 import numpy.linalg as npl
-from scipy import ndimage
 import sparse
+from scipy import ndimage
 
 from .. import references
 from ..due import due
@@ -465,7 +465,7 @@ def get_ale_kernel(img, sample_size=None, fwhm=None):
         uncertain_subjects = (11.6 / (2 * np.sqrt(2 / np.pi)) * np.sqrt(8 * np.log(2))) / np.sqrt(
             sample_size
         )  # pylint: disable=no-member
-        fwhm = np.sqrt(uncertain_subjects ** 2 + uncertain_templates ** 2)
+        fwhm = np.sqrt(uncertain_subjects**2 + uncertain_templates**2)
 
     fwhm_vox = fwhm / np.sqrt(np.prod(img.header.get_zooms()))
     sigma_vox = (

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -289,6 +289,7 @@ def compute_kda_ma(
     .. versionchanged:: 0.0.12
 
         * Remove low-memory option in favor of sparse arrays.
+        * Return 4D sparse array.
 
     .. versionadded:: 0.0.4
 
@@ -317,7 +318,7 @@ def compute_kda_ma(
 
     Returns
     -------
-    kernel_data : :obj:`sparse._coo.core.COO` or kernel_data: :obj:`numpy.array`
+    kernel_data : :obj:`sparse._coo.core.COO`
         4D sparse array. If `exp_idx` is none, a 3d array in the same
         shape as the `shape` argument is returned. If `exp_idx` is passed, a 4d array
         is returned, where the first dimension has size equal to the number of
@@ -336,7 +337,7 @@ def compute_kda_ma(
     cube = np.vstack([row.ravel() for row in np.mgrid[xx, yy, zz]])
     kernel = cube[:, np.sum(np.dot(np.diag(vox_dims), cube) ** 2, 0) ** 0.5 <= r]
 
-    # Preallocate coords and data array, np.concatenate is too slow
+    # Preallocate coords array, np.concatenate is too slow
     n_coords = ijks.shape[0] * kernel.shape[1]  # = n_peaks * n_voxels
     coords = np.zeros((4, n_coords), dtype=int)
     temp_idx = 0
@@ -359,6 +360,7 @@ def compute_kda_ma(
 
     if not sum_overlap:
         coords = np.unique(coords, axis=1)
+
     data = np.full(coords.shape[1], value)
     kernel_data = sparse.COO(coords, data, shape=kernel_shape)
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -327,11 +327,14 @@ def compute_kda_ma(
 
     Returns
     -------
-    kernel_data : :obj:`numpy.array`
-        3d or 4d array. If `exp_idx` is none, a 3d array in the same shape as
-        the `shape` argument is returned. If `exp_idx` is passed, a 4d array
+    kernel_data_lst : :obj:`list` of :class:`sparse._compressed.compressed.GCXS` \
+            or kernel_data: :obj:`numpy.array`
+        If memmap_filename is passed, 3d or 4d array. If `exp_idx` is none, a 3d array in the same 
+        shape as the `shape` argument is returned. If `exp_idx` is passed, a 4d array
         is returned, where the first dimension has size equal to the number of
         unique experiments, and the remaining 3 dimensions are equal to `shape`.
+        If memmap_filename is None, a list of MA sparse arrays. The list dimension 
+        has size equal to the number of unique experiments
     """
     if exp_idx is None:
         exp_idx = np.ones(len(ijks))

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -329,7 +329,7 @@ def compute_kda_ma(
     -------
     kernel_data_lst : :obj:`list` of :class:`sparse._compressed.compressed.GCXS` \
             or kernel_data: :obj:`numpy.array`
-        If memmap_filename is passed, 3d or 4d array. If `exp_idx` is none, a 3d array in the same 
+        If memmap_filename is passed, 3d or 4d array. If `exp_idx` is none, a 3d array in the same
         shape as the `shape` argument is returned. If `exp_idx` is passed, a 4d array
         is returned, where the first dimension has size equal to the number of
         unique experiments, and the remaining 3 dimensions are equal to `shape`.

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -333,7 +333,7 @@ def compute_kda_ma(
         shape as the `shape` argument is returned. If `exp_idx` is passed, a 4d array
         is returned, where the first dimension has size equal to the number of
         unique experiments, and the remaining 3 dimensions are equal to `shape`.
-        If memmap_filename is None, a list of MA sparse arrays. The list dimension 
+        If memmap_filename is None, a list of MA sparse arrays. The list dimension
         has size equal to the number of unique experiments
     """
     if exp_idx is None:

--- a/nimare/tests/utils.py
+++ b/nimare/tests/utils.py
@@ -49,15 +49,15 @@ def _create_signal_mask(ground_truth_foci_ijks, mask):
     sig_prob_map = compute_kda_ma(
         dims, vox_dims, ground_truth_foci_ijks, r=2, value=1, sum_overlap=False
     )
-    if isinstance(sig_prob_map, sparse._compressed.compressed.GCXS):
-        sig_prob_map = sig_prob_map.todense()
+    if isinstance(sig_prob_map[0], sparse._compressed.compressed.GCXS):
+        sig_prob_map = sig_prob_map[0].todense()
 
     # area where I'm reasonably certain there are not significant results
     nonsig_prob_map = compute_kda_ma(
         dims, vox_dims, ground_truth_foci_ijks, r=14, value=1, sum_overlap=False
     )
-    if isinstance(nonsig_prob_map, sparse._compressed.compressed.GCXS):
-        nonsig_prob_map = nonsig_prob_map.todense()
+    if isinstance(nonsig_prob_map[0], sparse._compressed.compressed.GCXS):
+        nonsig_prob_map = nonsig_prob_map[0].todense()
 
     sig_map = nib.Nifti1Image((sig_prob_map == 1).astype(int), affine=mask.affine)
     nonsig_map = nib.Nifti1Image((nonsig_prob_map == 0).astype(int), affine=mask.affine)

--- a/nimare/tests/utils.py
+++ b/nimare/tests/utils.py
@@ -5,7 +5,6 @@ from contextlib import ExitStack as does_not_raise
 import nibabel as nib
 import numpy as np
 import pytest
-import sparse
 
 from nimare.meta.utils import compute_kda_ma
 
@@ -49,15 +48,13 @@ def _create_signal_mask(ground_truth_foci_ijks, mask):
     sig_prob_map = compute_kda_ma(
         dims, vox_dims, ground_truth_foci_ijks, r=2, value=1, sum_overlap=False
     )
-    if isinstance(sig_prob_map[0], sparse._coo.core.COO):
-        sig_prob_map = sig_prob_map[0].todense()
+    sig_prob_map = sig_prob_map[0].todense()
 
     # area where I'm reasonably certain there are not significant results
     nonsig_prob_map = compute_kda_ma(
         dims, vox_dims, ground_truth_foci_ijks, r=14, value=1, sum_overlap=False
     )
-    if isinstance(nonsig_prob_map[0], sparse._coo.core.COO):
-        nonsig_prob_map = nonsig_prob_map[0].todense()
+    nonsig_prob_map = nonsig_prob_map[0].todense()
 
     sig_map = nib.Nifti1Image((sig_prob_map == 1).astype(int), affine=mask.affine)
     nonsig_map = nib.Nifti1Image((nonsig_prob_map == 0).astype(int), affine=mask.affine)

--- a/nimare/tests/utils.py
+++ b/nimare/tests/utils.py
@@ -49,14 +49,14 @@ def _create_signal_mask(ground_truth_foci_ijks, mask):
     sig_prob_map = compute_kda_ma(
         dims, vox_dims, ground_truth_foci_ijks, r=2, value=1, sum_overlap=False
     )
-    if isinstance(sig_prob_map[0], sparse._compressed.compressed.GCXS):
+    if isinstance(sig_prob_map[0], sparse._coo.core.COO):
         sig_prob_map = sig_prob_map[0].todense()
 
     # area where I'm reasonably certain there are not significant results
     nonsig_prob_map = compute_kda_ma(
         dims, vox_dims, ground_truth_foci_ijks, r=14, value=1, sum_overlap=False
     )
-    if isinstance(nonsig_prob_map[0], sparse._compressed.compressed.GCXS):
+    if isinstance(nonsig_prob_map[0], sparse._coo.core.COO):
         nonsig_prob_map = nonsig_prob_map[0].todense()
 
     sig_map = nib.Nifti1Image((sig_prob_map == 1).astype(int), affine=mask.affine)

--- a/nimare/tests/utils.py
+++ b/nimare/tests/utils.py
@@ -5,6 +5,7 @@ from contextlib import ExitStack as does_not_raise
 import nibabel as nib
 import numpy as np
 import pytest
+import sparse
 
 from ..meta.utils import compute_kda_ma
 
@@ -48,11 +49,16 @@ def _create_signal_mask(ground_truth_foci_ijks, mask):
     sig_prob_map = compute_kda_ma(
         dims, vox_dims, ground_truth_foci_ijks, r=2, value=1, sum_overlap=False
     )
+    if isinstance(sig_prob_map, sparse._compressed.compressed.GCXS):
+        sig_prob_map = sig_prob_map.todense()
 
     # area where I'm reasonably certain there are not significant results
     nonsig_prob_map = compute_kda_ma(
         dims, vox_dims, ground_truth_foci_ijks, r=14, value=1, sum_overlap=False
     )
+    if isinstance(nonsig_prob_map, sparse._compressed.compressed.GCXS):
+        nonsig_prob_map = nonsig_prob_map.todense()
+
     sig_map = nib.Nifti1Image((sig_prob_map == 1).astype(int), affine=mask.affine)
     nonsig_map = nib.Nifti1Image((nonsig_prob_map == 0).astype(int), affine=mask.affine)
     return sig_map, nonsig_map

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
     requests
     scikit-learn
     scipy
-    sparse
+    sparse>=0.13.0
     statsmodels!=0.13.2  # this version doesn't install properly
     tqdm
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     matplotlib<3.5  # this is for nilearn, which doesn't include it in its reqs
     nibabel>=3.0.0
     nilearn>=0.7.1
+    numba
     numpy
     pandas
     pymare>=0.0.3rc2

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ install_requires =
     requests
     scikit-learn
     scipy
+    sparse
     statsmodels!=0.13.2  # this version doesn't install properly
     tqdm
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,14 +46,14 @@ install_requires =
     matplotlib<3.5  # this is for nilearn, which doesn't include it in its reqs
     nibabel>=3.0.0
     nilearn>=0.7.1
-    numba
+    numba  # used by sparse
     numpy
     pandas
     pymare>=0.0.3rc2
     requests
     scikit-learn
     scipy
-    sparse>=0.13.0
+    sparse>=0.13.0  # for kernel transformers
     statsmodels!=0.13.2  # this version doesn't install properly
     tqdm
 packages = find:


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Replace the 4D array in the (M)KDA with a list of 3D sparse arrays (one for each experiment) to avoid the high memory peak in the `KernelTransformer.transform` and `meta.utils.compute_kda_ma`.

There is probably a better way to introduce the sparse array here, but the current proposal works well with almost no modification to the kernel transformer.
