### PR TITLE
Support `vfwe_only` in CBMAEstimator even when `null_method` isn't `montecarlo`

### DIFF
--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -464,7 +464,14 @@ class CBMAEstimator(MetaEstimator):
             "histweights_level-voxel_corr-fwe_method-montecarlo"
         ] = histweights
 
-    def _correct_fwe_montecarlo_permutation(self, iter_xyz, iter_df, conn, voxel_thresh):
+    def _correct_fwe_montecarlo_permutation(
+        self,
+        iter_xyz,
+        iter_df,
+        conn,
+        voxel_thresh,
+        vfwe_only,
+    ):
         """Run a single Monte Carlo permutation of a dataset.
 
         Does the shared work between vFWE and cFWE.
@@ -481,6 +488,7 @@ class CBMAEstimator(MetaEstimator):
             The 3D structuring array for labeling clusters.
         voxel_thresh : :obj:`float`
             Uncorrected summary statistic threshold for defining clusters.
+        vfwe_only
 
         Returns
         -------
@@ -503,11 +511,14 @@ class CBMAEstimator(MetaEstimator):
         # Voxel-level inference
         iter_max_value = np.max(iter_ss_map)
 
-        # Cluster-level inference
-        iter_ss_map = self.masker.inverse_transform(iter_ss_map).get_fdata().copy()
-        iter_max_size, iter_max_mass = _calculate_cluster_measures(
-            iter_ss_map, voxel_thresh, conn, tail="upper"
-        )
+        if vfwe_only:
+            iter_max_size, iter_max_mass = None, None
+        else:
+            # Cluster-level inference
+            iter_ss_map = self.masker.inverse_transform(iter_ss_map).get_fdata().copy()
+            iter_max_size, iter_max_mass = _calculate_cluster_measures(
+                iter_ss_map, voxel_thresh, conn, tail="upper"
+            )
 
         return iter_max_value, iter_max_size, iter_max_mass
 
@@ -547,8 +558,6 @@ class CBMAEstimator(MetaEstimator):
         vfwe_only : :obj:`bool`, optional
             If True, only calculate the voxel-level FWE-corrected maps. Voxel-level correction
             can be performed very quickly if the Estimator's ``null_method`` was "montecarlo".
-            If this is set to True and the original null method was not montecarlo, an exception
-            will be raised.
             Default is False.
 
         Returns
@@ -601,7 +610,7 @@ class CBMAEstimator(MetaEstimator):
         """
         stat_values = result.get_map("stat", return_type="array")
 
-        if vfwe_only:
+        if vfwe_only and (self.null_method == "montecarlo"):
             if self.null_method != "montecarlo":
                 raise ValueError(
                     "In order to run this method with the 'vfwe_only' option, "
@@ -618,6 +627,13 @@ class CBMAEstimator(MetaEstimator):
             )
 
         else:
+            if vfwe_only:
+                LGR.warn(
+                    "In order to run this method with the 'vfwe_only' option, "
+                    "the Estimator must use the 'montecarlo' null_method. "
+                    "Running permutations from scratch."
+                )
+
             null_xyz = vox2mm(
                 np.vstack(np.where(self.masker.mask_img.get_fdata())).T,
                 self.masker.mask_img.affine,
@@ -642,56 +658,73 @@ class CBMAEstimator(MetaEstimator):
             with tqdm_joblib(tqdm(total=n_iters)):
                 perm_results = Parallel(n_jobs=n_cores)(
                     delayed(self._correct_fwe_montecarlo_permutation)(
-                        iter_xyzs[i_iter], iter_df=iter_df, conn=conn, voxel_thresh=ss_thresh
+                        iter_xyzs[i_iter],
+                        iter_df=iter_df,
+                        conn=conn,
+                        voxel_thresh=ss_thresh,
+                        vfwe_only=vfwe_only,
                     )
                     for i_iter in range(n_iters)
                 )
 
             fwe_voxel_max, fwe_cluster_size_max, fwe_cluster_mass_max = zip(*perm_results)
 
-            # Cluster-level FWE
-            # Extract the summary statistics in voxel-wise (3D) form, threshold, and cluster-label
-            thresh_stat_values = self.masker.inverse_transform(stat_values).get_fdata()
-            thresh_stat_values[thresh_stat_values <= ss_thresh] = 0
-            labeled_matrix, _ = ndimage.measurements.label(thresh_stat_values, conn)
+            if not vfwe_only:
+                # Cluster-level FWE
+                # Extract the summary statistics in voxel-wise (3D) form, threshold, and
+                # cluster-label
+                thresh_stat_values = self.masker.inverse_transform(stat_values).get_fdata()
+                thresh_stat_values[thresh_stat_values <= ss_thresh] = 0
+                labeled_matrix, _ = ndimage.measurements.label(thresh_stat_values, conn)
 
-            cluster_labels, idx, cluster_sizes = np.unique(
-                labeled_matrix,
-                return_inverse=True,
-                return_counts=True,
-            )
-            assert cluster_labels[0] == 0
+                cluster_labels, idx, cluster_sizes = np.unique(
+                    labeled_matrix,
+                    return_inverse=True,
+                    return_counts=True,
+                )
+                assert cluster_labels[0] == 0
 
-            # Cluster mass-based inference
-            cluster_masses = np.zeros(cluster_labels.shape)
-            for i_val in cluster_labels:
-                if i_val == 0:
-                    cluster_masses[i_val] = 0
+                # Cluster mass-based inference
+                cluster_masses = np.zeros(cluster_labels.shape)
+                for i_val in cluster_labels:
+                    if i_val == 0:
+                        cluster_masses[i_val] = 0
 
-                cluster_mass = np.sum(thresh_stat_values[labeled_matrix == i_val] - ss_thresh)
-                cluster_masses[i_val] = cluster_mass
+                    cluster_mass = np.sum(thresh_stat_values[labeled_matrix == i_val] - ss_thresh)
+                    cluster_masses[i_val] = cluster_mass
 
-            p_cmfwe_vals = null_to_p(cluster_masses, fwe_cluster_mass_max, "upper")
-            p_cmfwe_map = p_cmfwe_vals[np.reshape(idx, labeled_matrix.shape)]
+                p_cmfwe_vals = null_to_p(cluster_masses, fwe_cluster_mass_max, "upper")
+                p_cmfwe_map = p_cmfwe_vals[np.reshape(idx, labeled_matrix.shape)]
 
-            p_cmfwe_values = np.squeeze(
-                self.masker.transform(nib.Nifti1Image(p_cmfwe_map, self.masker.mask_img.affine))
-            )
-            logp_cmfwe_values = -np.log10(p_cmfwe_values)
-            logp_cmfwe_values[np.isinf(logp_cmfwe_values)] = -np.log10(np.finfo(float).eps)
-            z_cmfwe_values = p_to_z(p_cmfwe_values, tail="one")
+                p_cmfwe_values = np.squeeze(
+                    self.masker.transform(
+                        nib.Nifti1Image(p_cmfwe_map, self.masker.mask_img.affine)
+                    )
+                )
+                logp_cmfwe_values = -np.log10(p_cmfwe_values)
+                logp_cmfwe_values[np.isinf(logp_cmfwe_values)] = -np.log10(np.finfo(float).eps)
+                z_cmfwe_values = p_to_z(p_cmfwe_values, tail="one")
 
-            # Cluster size-based inference
-            cluster_sizes[0] = 0  # replace background's "cluster size" with zeros
-            p_csfwe_vals = null_to_p(cluster_sizes, fwe_cluster_size_max, "upper")
-            p_csfwe_map = p_csfwe_vals[np.reshape(idx, labeled_matrix.shape)]
+                # Cluster size-based inference
+                cluster_sizes[0] = 0  # replace background's "cluster size" with zeros
+                p_csfwe_vals = null_to_p(cluster_sizes, fwe_cluster_size_max, "upper")
+                p_csfwe_map = p_csfwe_vals[np.reshape(idx, labeled_matrix.shape)]
 
-            p_csfwe_values = np.squeeze(
-                self.masker.transform(nib.Nifti1Image(p_csfwe_map, self.masker.mask_img.affine))
-            )
-            logp_csfwe_values = -np.log10(p_csfwe_values)
-            logp_csfwe_values[np.isinf(logp_csfwe_values)] = -np.log10(np.finfo(float).eps)
-            z_csfwe_values = p_to_z(p_csfwe_values, tail="one")
+                p_csfwe_values = np.squeeze(
+                    self.masker.transform(
+                        nib.Nifti1Image(p_csfwe_map, self.masker.mask_img.affine)
+                    )
+                )
+                logp_csfwe_values = -np.log10(p_csfwe_values)
+                logp_csfwe_values[np.isinf(logp_csfwe_values)] = -np.log10(np.finfo(float).eps)
+                z_csfwe_values = p_to_z(p_csfwe_values, tail="one")
+
+                self.null_distributions_[
+                    "values_desc-size_level-cluster_corr-fwe_method-montecarlo"
+                ] = fwe_cluster_size_max
+                self.null_distributions_[
+                    "values_desc-mass_level-cluster_corr-fwe_method-montecarlo"
+                ] = fwe_cluster_mass_max
 
             # Voxel-level FWE
             LGR.info("Using null distribution for voxel-level FWE correction.")
@@ -699,12 +732,6 @@ class CBMAEstimator(MetaEstimator):
             self.null_distributions_[
                 "values_level-voxel_corr-fwe_method-montecarlo"
             ] = fwe_voxel_max
-            self.null_distributions_[
-                "values_desc-size_level-cluster_corr-fwe_method-montecarlo"
-            ] = fwe_cluster_size_max
-            self.null_distributions_[
-                "values_desc-mass_level-cluster_corr-fwe_method-montecarlo"
-            ] = fwe_cluster_mass_max
 
         z_vfwe_values = p_to_z(p_vfwe_values, tail="one")
         logp_vfwe_values = -np.log10(p_vfwe_values)


### PR DESCRIPTION
Closes #385. Most of this code is excised from #659.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Allow `vfwe_only`, even when `null_method == 'approximate'`. This should run more quickly than the cluster-level approach.
