### PR TITLE
Dropping the memory-mapping option for Estimators and kernel transformers

### DIFF
--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -114,9 +114,9 @@ def gclda_decode_map(model, image, topic_priors=None, prior_weight=1):
 class CorrelationDecoder(Decoder):
     """Decode an unthresholded image by correlating the image with meta-analytic maps.
 
-    .. versionchanged:: 0.0.8
+    .. versionchanged:: 0.0.12
 
-        * [ENH] Add *low-memory* option to :class:`meta_estimator`
+        * Remove low-memory option in favor of sparse arrays.
 
     Parameters
     ----------
@@ -150,11 +150,10 @@ class CorrelationDecoder(Decoder):
         frequency_threshold=0.001,
         meta_estimator=None,
         target_image="z_desc-specificity",
-        memory_limit="1gb",
     ):
 
         if meta_estimator is None:
-            meta_estimator = MKDAChi2(memory_limit=memory_limit, kernel__memory_limit=memory_limit)
+            meta_estimator = MKDAChi2()
         else:
             meta_estimator = _check_type(meta_estimator, CBMAEstimator)
 
@@ -266,12 +265,10 @@ class CorrelationDistributionDecoder(Decoder):
         features=None,
         frequency_threshold=0.001,
         target_image="z",
-        memory_limit="1gb",
     ):
         self.feature_group = feature_group
         self.features = features
         self.frequency_threshold = frequency_threshold
-        self.memory_limit = memory_limit
         self._required_inputs["images"] = ("image", target_image)
 
     def _fit(self, dataset):
@@ -309,7 +306,6 @@ class CorrelationDistributionDecoder(Decoder):
                 feature_arr = _safe_transform(
                     test_imgs,
                     self.masker,
-                    memory_limit=self.memory_limit,
                     memfile=None,
                 )
                 images_[feature] = feature_arr

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -346,12 +346,10 @@ class ALESubtraction(PairwiseCBMAEstimator):
         ma_maps1 = self._collect_ma_maps(
             maps_key="ma_maps1",
             coords_key="coordinates1",
-            fname_idx=0,
         )
         ma_maps2 = self._collect_ma_maps(
             maps_key="ma_maps2",
             coords_key="coordinates2",
-            fname_idx=1,
         )
 
         n_grp1, n_voxels = ma_maps1.shape
@@ -364,14 +362,6 @@ class ALESubtraction(PairwiseCBMAEstimator):
 
         # Combine the MA maps into a single array to draw from for null distribution
         ma_arr = np.vstack((ma_maps1, ma_maps2))
-
-        if isinstance(ma_maps1, np.memmap):
-            LGR.debug(f"Closing memmap at {ma_maps1.filename}")
-            ma_maps1._mmap.close()
-
-        if isinstance(ma_maps2, np.memmap):
-            LGR.debug(f"Closing memmap at {ma_maps2.filename}")
-            ma_maps2._mmap.close()
 
         del ma_maps1, ma_maps2
 
@@ -591,7 +581,6 @@ class SCALE(CBMAEstimator):
         ma_values = self._collect_ma_maps(
             coords_key="coordinates",
             maps_key="ma_maps",
-            fname_idx=0,
         )
 
         # Determine bins for null distribution histogram
@@ -602,10 +591,6 @@ class SCALE(CBMAEstimator):
         )
 
         stat_values = self._compute_summarystat_est(ma_values)
-
-        if isinstance(ma_values, np.memmap):
-            LGR.debug(f"Closing memmap at {ma_values.filename}")
-            ma_values._mmap.close()
 
         iter_df = self.inputs_["coordinates"].copy()
         rand_idx = np.random.choice(self.xyz.shape[0], size=(iter_df.shape[0], self.n_iters))

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -20,11 +20,9 @@ from nimare.utils import (
     _add_metadata_to_dataframe,
     _check_ncores,
     _check_type,
-    _safe_transform,
     get_masker,
     mm2vox,
     tqdm_joblib,
-    use_memmap,
     vox2mm,
 )
 
@@ -36,6 +34,7 @@ class CBMAEstimator(Estimator):
 
     .. versionchanged:: 0.0.12
 
+        * Remove *low_memory* option
         * CBMA-specific elements of ``MetaEstimator`` excised and moved into ``CBMAEstimator``.
         * Generic kwargs and args converted to named kwargs. All remaining kwargs are for kernels.
 
@@ -63,11 +62,10 @@ class CBMAEstimator(Estimator):
     # An individual CBMAEstimator may override this.
     _required_inputs = {"coordinates": ("coordinates", None)}
 
-    def __init__(self, kernel_transformer, *, mask=None, memory_limit=None, **kwargs):
+    def __init__(self, kernel_transformer, *, mask=None, **kwargs):
         if mask is not None:
             mask = get_masker(mask)
         self.masker = mask
-        self.memory_limit = memory_limit
 
         # Identify any kwargs
         kernel_args = {k: v for k, v in kwargs.items() if k.startswith("kernel__")}
@@ -143,7 +141,6 @@ class CBMAEstimator(Estimator):
                 filter_func=np.mean,
             )
 
-    @use_memmap(LGR, n_files=1)
     def _fit(self, dataset):
         """Perform coordinate-based meta-analysis on dataset.
 
@@ -159,7 +156,6 @@ class CBMAEstimator(Estimator):
         ma_values = self._collect_ma_maps(
             coords_key="coordinates",
             maps_key="ma_maps",
-            fname_idx=0,
         )
 
         # Infer a weight vector, when applicable. Primarily used only for MKDADensity.
@@ -179,12 +175,6 @@ class CBMAEstimator(Estimator):
             # A hidden option only used for internal validation/testing
             self._compute_null_reduced_montecarlo(ma_values, n_iters=self.n_iters)
 
-        # Only should occur when MA maps have been pre-generated in the Dataset and a memory_limit
-        # is set. The memmap must be closed.
-        if isinstance(ma_values, np.memmap):
-            LGR.debug(f"Closing memmap at {ma_values.filename}")
-            ma_values._mmap.close()
-
         p_values, z_values = self._summarystat_to_p(stat_values, null_method=self.null_method)
 
         images = {"stat": stat_values, "p": p_values, "z": z_values}
@@ -199,7 +189,7 @@ class CBMAEstimator(Estimator):
         """
         return None
 
-    def _collect_ma_maps(self, coords_key="coordinates", maps_key="ma_maps", fname_idx=0):
+    def _collect_ma_maps(self, coords_key="coordinates", maps_key="ma_maps"):
         """Collect modeled activation maps from Estimator inputs.
 
         Parameters
@@ -213,30 +203,15 @@ class CBMAEstimator(Estimator):
             This key should only be present if the kernel transformer was already fitted to the
             input Dataset.
             Default is "ma_maps".
-        fname_idx : :obj:`int`, optional
-            When the Estimator is set with ``memory_limit`` as a string,
-            there is a ``memmap_filenames`` attribute that is a list of filenames or Nones.
-            This parameter specifies which item in that list should be used for a memory-mapped
-            array. Default is 0.
 
         Returns
         -------
-        ma_maps : :obj:`numpy.ndarray` or :obj:`numpy.memmap`
+        ma_maps : :obj:`numpy.ndarray`
             2D numpy array of shape (n_studies, n_voxels) with MA values.
-            This will be a memmap if MA maps have been pre-generated.
         """
         if maps_key in self.inputs_.keys():
             LGR.debug(f"Loading pre-generated MA maps ({maps_key}).")
-            if self.memory_limit:
-                # perform transform on chunks of the input maps
-                ma_maps = _safe_transform(
-                    self.inputs_[maps_key],
-                    masker=self.masker,
-                    memory_limit=self.memory_limit,
-                    memfile=self.memmap_filenames[fname_idx],
-                )
-            else:
-                ma_maps = self.masker.transform(self.inputs_[maps_key])
+            ma_maps = self.masker.transform(self.inputs_[maps_key])
 
         else:
             LGR.debug(f"Generating MA maps from coordinates ({coords_key}).")

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -320,16 +320,9 @@ class MKDAChi2(PairwiseCBMAEstimator):
         ma_maps1 = self._collect_ma_maps(
             maps_key="ma_maps1",
             coords_key="coordinates1",
-            fname_idx=0,
         )
         n_selected = ma_maps1.shape[0]
         n_selected_active_voxels = np.sum(ma_maps1.astype(bool), axis=0)
-
-        # Close the memmap.
-        # Deleting the variable should be enough, but I'd prefer to be explicit.
-        if isinstance(ma_maps1, np.memmap):
-            LGR.debug(f"Closing memmap at {ma_maps1.filename}")
-            ma_maps1._mmap.close()
 
         del ma_maps1
 
@@ -337,16 +330,9 @@ class MKDAChi2(PairwiseCBMAEstimator):
         ma_maps2 = self._collect_ma_maps(
             maps_key="ma_maps2",
             coords_key="coordinates2",
-            fname_idx=1,
         )
         n_unselected = ma_maps2.shape[0]
         n_unselected_active_voxels = np.sum(ma_maps2.astype(bool), axis=0)
-
-        # Close the memmap.
-        # Deleting the variable should be enough, but I'd prefer to be explicit.
-        if isinstance(ma_maps2, np.memmap):
-            LGR.debug(f"Closing memmap at {ma_maps2.filename}")
-            ma_maps2._mmap.close()
 
         del ma_maps2
 

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -25,13 +25,7 @@ from nimare.meta.utils import (
     compute_p2m_ma,
     get_ale_kernel,
 )
-from nimare.utils import (
-    _add_metadata_to_dataframe,
-    _safe_transform,
-    mm2vox,
-    use_memmap,
-    vox2mm,
-)
+from nimare.utils import _add_metadata_to_dataframe, _safe_transform, mm2vox, vox2mm
 
 LGR = logging.getLogger(__name__)
 
@@ -84,7 +78,6 @@ class KernelTransformer(NiMAREBase):
         )
         self.image_type = f"{param_str}_{self.__class__.__name__}"
 
-    @use_memmap(LGR)
     def transform(self, dataset, masker=None, return_type="image"):
         """Generate modeled activation images for each Contrast in dataset.
 
@@ -202,31 +195,21 @@ class KernelTransformer(NiMAREBase):
 
         transformed_maps = self._transform(mask, coordinates)
 
-        # This will be a numpy.ndarray or numpy.memmap if the kernel is an (M)KDAKernel or
-        # memory_limit is set, respectively.
+        # This will be a numpy.ndarray if the kernel is an (M)KDAKernel.
         if not isinstance(transformed_maps[0], (list, tuple)):
             if return_type == "array":
                 ma_arr = transformed_maps[0][:, mask_data]
-                # If this array is a memmap, then the file needs to be closed
-                if isinstance(transformed_maps[0], np.memmap):
-                    LGR.debug(f"Closing memmap at {transformed_maps[0].filename}")
-                    transformed_maps[0]._mmap.close()
 
                 return ma_arr
             else:
                 # Transform into an length-N list of length-2 tuples,
-                # composed of a 3D array/memmap and a string with the ID.
+                # composed of a 3D array and a string with the ID.
                 transformed_maps = list(zip(*transformed_maps))
 
         imgs = []
         for (kernel_data, id_) in transformed_maps:
-            if isinstance(kernel_data, np.memmap):
-                # Convert data to a numpy array if it's a memmap
-                kernel_data = np.array(kernel_data)
 
             if return_type == "array":
-                # NOTE: This will never be a memmap because memory_limit[!None]+return_type[array]
-                # is dealt with above.
                 img = kernel_data[mask_data]
                 imgs.append(img)
             elif return_type == "image":
@@ -238,11 +221,6 @@ class KernelTransformer(NiMAREBase):
                 out_file = os.path.join(dataset.basepath, self.filename_pattern.format(id=id_))
                 img.to_filename(out_file)
                 dataset.images.loc[dataset.images["id"] == id_, self.image_type] = out_file
-
-        # If this array is a memmap, then the file needs to be closed
-        if isinstance(transformed_maps[0][0], np.memmap):
-            LGR.debug(f"Closing memmap at {transformed_maps[0][0].filename}")
-            transformed_maps[0][0]._mmap.close()
 
         del kernel_data, transformed_maps
 
@@ -274,8 +252,7 @@ class KernelTransformer(NiMAREBase):
 
         Returns
         -------
-        transformed_maps : N-length list of (3D array, str) tuples or (4D array, 1D array) tuple \
-                or (4D memmap, 1D array) tuple
+        transformed_maps : N-length list of (3D array, str) tuples or (4D array, 1D array) tuple
             Transformed data, containing one element for each study.
 
             -   Case 1: A kernel that is not an (M)KDAKernel, with no memory limit.
@@ -283,10 +260,6 @@ class KernelTransformer(NiMAREBase):
 
             -   Case 2: (M)KDAKernel, with no memory limit.
                 There is a length-2 tuple with a 4D numpy array of the shape (N, X, Y, Z),
-                containing all of the MA maps, and a numpy array of shape (N,) with the study IDs.
-
-            -   Case 3: Any kernel, with memory_limit set, so memmaps will be used.
-                There is a length-2 tuple with a 4D memmap array of the shape (N, X, Y, Z),
                 containing all of the MA maps, and a numpy array of shape (N,) with the study IDs.
         """
         pass
@@ -307,9 +280,9 @@ class ALEKernel(KernelTransformer):
     will be determined on a study-wise basis based on the sample sizes available in the input,
     via the method described in :footcite:t:`eickhoff2012activation`.
 
-    .. versionchanged:: 0.0.8
+    .. versionchanged:: 0.0.12
 
-        * [ENH] Add low-memory option for kernel transformers.
+        * Remove low-memory option in favor of sparse arrays for kernel transformers.
 
     Parameters
     ----------
@@ -322,41 +295,24 @@ class ALEKernel(KernelTransformer):
         formulae from Eickhoff et al. (2012). This sample size overwrites
         the Contrast-specific sample sizes in the dataset, in order to hold
         kernel constant across Contrasts. Mutually exclusive with ``fwhm``.
-    memory_limit : :obj:`str` or None, optional
-        Memory limit to apply to data. If None, no memory management will be applied.
-        Otherwise, the memory limit will be used to (1) assign memory-mapped files and
-        (2) restrict memory during array creation to the limit.
-        Default is None.
 
     References
     ----------
     .. footbibliography::
     """
 
-    def __init__(self, fwhm=None, sample_size=None, memory_limit=None):
+    def __init__(self, fwhm=None, sample_size=None):
         if fwhm is not None and sample_size is not None:
             raise ValueError('Only one of "fwhm" and "sample_size" may be provided.')
         self.fwhm = fwhm
         self.sample_size = sample_size
-        self.memory_limit = memory_limit
 
     def _transform(self, mask, coordinates):
         kernels = {}  # retain kernels in dictionary to speed things up
         exp_ids = coordinates["id"].unique()
 
-        if self.memory_limit:
-            # Use a memmapped 4D array
-            transformed_shape = (len(exp_ids),) + mask.shape
-            transformed = np.memmap(
-                self.memmap_filenames[0],
-                dtype=float,
-                mode="w+",
-                shape=transformed_shape,
-            )
-        else:
-            # Use a list of tuples
-            transformed = []
-
+        # Use a list of tuples
+        transformed = []
         for i_exp, id_ in enumerate(exp_ids):
             data = coordinates.loc[coordinates["id"] == id_]
 
@@ -385,26 +341,17 @@ class ALEKernel(KernelTransformer):
 
             kernel_data = compute_ale_ma(mask.shape, ijk, kern)
 
-            if self.memory_limit:
-                transformed[i_exp, :, :, :] = kernel_data
+            transformed.append((kernel_data, id_))
 
-                # Write changes to disk
-                transformed.flush()
-            else:
-                transformed.append((kernel_data, id_))
-
-        if self.memory_limit:
-            return transformed, exp_ids
-        else:
-            return transformed
+        return transformed
 
 
 class KDAKernel(KernelTransformer):
     """Generate KDA modeled activation images from coordinates.
 
-    .. versionchanged:: 0.0.8
+    .. versionchanged:: 0.0.12
 
-        * [ENH] Add low-memory option for kernel transformers.
+        * Remove low-memory option for kernel transformers.
 
     Parameters
     ----------
@@ -412,19 +359,13 @@ class KDAKernel(KernelTransformer):
         Sphere radius, in mm.
     value : :obj:`int`, optional
         Value for sphere.
-    memory_limit : :obj:`str` or None, optional
-        Memory limit to apply to data. If None, no memory management will be applied.
-        Otherwise, the memory limit will be used to (1) assign memory-mapped files and
-        (2) restrict memory during array creation to the limit.
-        Default is None.
     """
 
     _sum_overlap = True
 
-    def __init__(self, r=10, value=1, memory_limit=None):
+    def __init__(self, r=10, value=1):
         self.r = float(r)
         self.value = value
-        self.memory_limit = memory_limit
 
     def _transform(self, mask, coordinates):
         dims = mask.shape
@@ -440,8 +381,6 @@ class KDAKernel(KernelTransformer):
             self.value,
             exp_idx,
             sum_overlap=self._sum_overlap,
-            memory_limit=self.memory_limit,
-            memmap_filename=self.memmap_filenames[0],
         )
         exp_ids = np.unique(exp_idx)
         return transformed, exp_ids
@@ -450,9 +389,9 @@ class KDAKernel(KernelTransformer):
 class MKDAKernel(KDAKernel):
     """Generate MKDA modeled activation images from coordinates.
 
-    .. versionchanged:: 0.0.8
+    .. versionchanged:: 0.0.12
 
-        * [ENH] Add low-memory option for kernel transformers.
+        * Remove low-memory option in favor of sparse arrays for kernel transformers.
 
     Parameters
     ----------
@@ -460,11 +399,6 @@ class MKDAKernel(KDAKernel):
         Sphere radius, in mm.
     value : :obj:`int`, optional
         Value for sphere.
-    memory_limit : :obj:`str` or None, optional
-        Memory limit to apply to data. If None, no memory management will be applied.
-        Otherwise, the memory limit will be used to (1) assign memory-mapped files and
-        (2) restrict memory during array creation to the limit.
-        Default is None.
     """
 
     _sum_overlap = False

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -169,7 +169,7 @@ def test_ALE_montecarlo_null_unit(testdata_cbma, tmp_path_factory):
     tmpdir = tmp_path_factory.mktemp("test_ALE_montecarlo_null_unit")
     out_file = os.path.join(tmpdir, "file.pkl.gz")
 
-    meta = ale.ALE(null_method="montecarlo", n_iters=10, kernel__memory_limit="1gb")
+    meta = ale.ALE(null_method="montecarlo", n_iters=10)
     res = meta.fit(testdata_cbma)
     assert "stat" in res.maps.keys()
     assert "p" in res.maps.keys()

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -51,7 +51,6 @@ def test_ALE_ma_map_reuse(testdata_cbma, tmp_path_factory, caplog):
     with caplog.at_level(logging.DEBUG, logger="nimare.meta.cbma.base"):
         meta.fit(dset)
     assert "Loading pre-generated MA maps" in caplog.text
-    assert "Closing memmap at" in caplog.text
 
 
 def test_ALESubtraction_ma_map_reuse(testdata_cbma, tmp_path_factory, caplog):

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -47,7 +47,7 @@ def test_ALE_ma_map_reuse(testdata_cbma, tmp_path_factory, caplog):
 
     # If there is a memory limit along with pre-generated images, then we should still see the
     # logger message.
-    meta = ale.ALE(kernel__sample_size=20, memory_limit="100mb")
+    meta = ale.ALE(kernel__sample_size=20)
     with caplog.at_level(logging.DEBUG, logger="nimare.meta.cbma.base"):
         meta.fit(dset)
     assert "Loading pre-generated MA maps" in caplog.text

--- a/nimare/tests/test_meta_kernel.py
+++ b/nimare/tests/test_meta_kernel.py
@@ -125,30 +125,6 @@ def test_kernel_smoke(testdata_cbma, kern, kwargs, set_kwargs):
     assert np.array_equal(ma_maps1, ma_maps2)
 
 
-@pytest.mark.parametrize(
-    "kern, kwargs",
-    [
-        (kernel.ALEKernel, {"sample_size": 20}),
-        (kernel.KDAKernel, {}),
-        (kernel.MKDAKernel, {}),
-    ],
-)
-def test_kernel_low_high_memory(testdata_cbma, tmp_path_factory, kern, kwargs):
-    """Compare kernel results when memory_limit is used vs. not."""
-    kern_low_mem = kern(memory_limit="1gb", **kwargs)
-    kern_spec_mem = kern(memory_limit="2gb", **kwargs)
-    kern_high_mem = kern(memory_limit=None, **kwargs)
-    trans_kwargs = {"dataset": testdata_cbma, "return_type": "array"}
-    assert np.array_equal(
-        kern_low_mem.transform(**trans_kwargs),
-        kern_high_mem.transform(**trans_kwargs),
-    )
-    assert np.array_equal(
-        kern_low_mem.transform(**trans_kwargs),
-        kern_spec_mem.transform(**trans_kwargs),
-    )
-
-
 def test_ALEKernel_fwhm(testdata_cbma):
     """Peaks of ALE kernel maps should match the foci fed in (assuming focus isn't masked out).
 

--- a/nimare/tests/test_meta_mkda.py
+++ b/nimare/tests/test_meta_mkda.py
@@ -85,15 +85,6 @@ def test_MKDADensity_montecarlo_null(testdata_cbma):
     assert "logp_desc-size_level-cluster_corr-FWE_method-montecarlo" not in cres2.maps
 
 
-def test_MKDADensity_memory_limit(testdata_cbma):
-    """Smoke test for MKDADensity with memory_limit option."""
-    meta = MKDADensity(null_method="montecarlo", n_iters=10, memory_limit="1gb")
-    res = meta.fit(testdata_cbma)
-    assert meta.memory_limit
-    assert not meta.kernel_transformer.memory_limit
-    assert isinstance(res, nimare.results.MetaResult)
-
-
 def test_MKDAChi2_fdr(testdata_cbma):
     """Smoke test for MKDAChi2."""
     meta = MKDAChi2()
@@ -133,32 +124,6 @@ def test_MKDAChi2_fwe_2core(testdata_cbma):
     corr_2core = FWECorrector(method="montecarlo", n_iters=5, n_cores=2)
     cres_2core = corr_2core.transform(res)
     assert isinstance(cres_2core, nimare.results.MetaResult)
-
-
-def test_MKDAChi2_memory_limit(testdata_cbma):
-    """Smoke test for MKDAChi2 with memory_limit option."""
-    meta = MKDAChi2(memory_limit="1gb")
-    res = meta.fit(testdata_cbma, testdata_cbma)
-    assert meta.memory_limit
-    assert not meta.kernel_transformer.memory_limit
-    assert isinstance(res, nimare.results.MetaResult)
-
-
-def test_MKDAChi2_memory_limit_reuse(testdata_cbma, tmp_path_factory):
-    """Smoke test for MKDAChi2 with memory_limit option, in which a memory-mapped array is used."""
-    tmpdir = tmp_path_factory.mktemp("test_MKDAChi2_memory_limit_reuse")
-
-    # Generate MKDAKernel MA maps as files in the Dataset
-    testdata_cbma.update_path(tmpdir)
-    kern = MKDAKernel()
-    dset = kern.transform(testdata_cbma, return_type="dataset")
-
-    # Reuse the MA files, loading them as a memory-mapped array
-    meta = MKDAChi2(memory_limit="1gb")
-    res = meta.fit(dset, dset)
-    assert meta.memory_limit
-    assert not meta.kernel_transformer.memory_limit
-    assert isinstance(res, nimare.results.MetaResult)
 
 
 def test_KDA_approximate_null(testdata_cbma):


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Dropping the memory-mapping option for Estimators and kernel transformers in this PR to rebase the PR #676  that supports the use of sparse arrays.
