### PR TITLE
Add parameter estimate standard error to IBMA results

### DIFF
--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -28,6 +28,10 @@ Some of the values found in NiMARE include:
 - ``chi2``: Chi-squared value
 - ``prob``: Probability value
 - ``stat``: Test value of meta-analytic algorithm (e.g., ALE values for ALE, OF values for MKDA)
+- ``est``: Parameter estimate (IBMA only)
+- ``se``: Standard error of the parameter estimate (IBMA only)
+- ``tau2``: Estimated between-study variance (IBMA only)
+- ``sigma2``: Estimated within-study variance (IBMA only)
 
 Next, a series of key/value pairs describe the methods applied to generate the map.
 

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -271,6 +271,10 @@ class Stouffers(IBMAEstimator):
 class WeightedLeastSquares(IBMAEstimator):
     """Weighted least-squares meta-regression.
 
+    .. versionchanged:: 0.0.12
+
+        * Add "se" to outputs.
+
     .. versionchanged:: 0.0.8
 
         * [FIX] Remove single-dimensional entries of each array of returns (:obj:`dict`).
@@ -357,6 +361,10 @@ class WeightedLeastSquares(IBMAEstimator):
 class DerSimonianLaird(IBMAEstimator):
     """DerSimonian-Laird meta-regression estimator.
 
+    .. versionchanged:: 0.0.12
+
+        * Add "se" to outputs.
+
     .. versionchanged:: 0.0.8
 
         * [FIX] Remove single-dimensional entries of each array of returns (:obj:`dict`).
@@ -431,6 +439,10 @@ class DerSimonianLaird(IBMAEstimator):
 class Hedges(IBMAEstimator):
     """Hedges meta-regression estimator.
 
+    .. versionchanged:: 0.0.12
+
+        * Add "se" to outputs.
+
     .. versionchanged:: 0.0.8
 
         * [FIX] Remove single-dimensional entries of each array of returns (:obj:`dict`).
@@ -503,6 +515,10 @@ class Hedges(IBMAEstimator):
 
 class SampleSizeBasedLikelihood(IBMAEstimator):
     """Method estimates with known sample sizes but unknown sampling variances.
+
+    .. versionchanged:: 0.0.12
+
+        * Add "se" and "sigma2" to outputs.
 
     .. versionchanged:: 0.0.8
 
@@ -598,7 +614,7 @@ class VarianceBasedLikelihood(IBMAEstimator):
 
     .. versionchanged:: 0.0.12
 
-        Add "tau2" output.
+        Add "se" output.
 
     .. versionchanged:: 0.0.8
 

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -135,6 +135,13 @@ class Fishers(IBMAEstimator):
     -----
     Requires ``z`` images.
 
+    :meth:`fit` produces a :class:`~nimare.results.MetaResult` object with the following maps:
+
+    ============== ===============================================================================
+    "z"            Z-statistic map from one-sample test.
+    "p"            P-value map from one-sample test.
+    ============== ===============================================================================
+
     Warnings
     --------
     Masking approaches which average across voxels (e.g., NiftiLabelsMaskers)
@@ -195,6 +202,13 @@ class Stouffers(IBMAEstimator):
     Notes
     -----
     Requires ``z`` images and optionally the sample size metadata field.
+
+    :meth:`fit` produces a :class:`~nimare.results.MetaResult` object with the following maps:
+
+    ============== ===============================================================================
+    "z"            Z-statistic map from one-sample test.
+    "p"            P-value map from one-sample test.
+    ============== ===============================================================================
 
     Warnings
     --------
@@ -279,6 +293,15 @@ class WeightedLeastSquares(IBMAEstimator):
     -----
     Requires ``beta`` and ``varcope`` images.
 
+    :meth:`fit` produces a :class:`~nimare.results.MetaResult` object with the following maps:
+
+    ============== ===============================================================================
+    "z"            Z-statistic map from one-sample test.
+    "p"            P-value map from one-sample test.
+    "est"          Fixed effects estimate for intercept test.
+    "se"           Standard error of fixed effects estimate.
+    ============== ===============================================================================
+
     Warnings
     --------
     Masking approaches which average across voxels (e.g., NiftiLabelsMaskers)
@@ -347,6 +370,16 @@ class DerSimonianLaird(IBMAEstimator):
     -----
     Requires ``beta`` and ``varcope`` images.
 
+    :meth:`fit` produces a :class:`~nimare.results.MetaResult` object with the following maps:
+
+    ============== ===============================================================================
+    "z"            Z-statistic map from one-sample test.
+    "p"            P-value map from one-sample test.
+    "est"          Fixed effects estimate for intercept test.
+    "se"           Standard error of fixed effects estimate.
+    "tau2"         Estimated between-study variance.
+    ============== ===============================================================================
+
     Warnings
     --------
     Masking approaches which average across voxels (e.g., NiftiLabelsMaskers)
@@ -386,11 +419,11 @@ class DerSimonianLaird(IBMAEstimator):
 
         fe_stats = est_summary.get_fe_stats()
         results = {
-            "tau2": _boolean_unmask(est_summary.tau2.squeeze(), self.inputs_["aggressive_mask"]),
             "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
             "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
             "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
             "se": _boolean_unmask(fe_stats["se"].squeeze(), self.inputs_["aggressive_mask"]),
+            "tau2": _boolean_unmask(est_summary.tau2.squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 
@@ -410,6 +443,16 @@ class Hedges(IBMAEstimator):
     Notes
     -----
     Requires ``beta`` and ``varcope`` images.
+
+    :meth:`fit` produces a :class:`~nimare.results.MetaResult` object with the following maps:
+
+    ============== ===============================================================================
+    "z"            Z-statistic map from one-sample test.
+    "p"            P-value map from one-sample test.
+    "est"          Fixed effects estimate for intercept test.
+    "se"           Standard error of fixed effects estimate.
+    "tau2"         Estimated between-study variance.
+    ============== ===============================================================================
 
     Warnings
     --------
@@ -449,11 +492,11 @@ class Hedges(IBMAEstimator):
         est_summary = est.summary()
         fe_stats = est_summary.get_fe_stats()
         results = {
-            "tau2": _boolean_unmask(est_summary.tau2.squeeze(), self.inputs_["aggressive_mask"]),
             "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
             "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
             "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
             "se": _boolean_unmask(fe_stats["se"].squeeze(), self.inputs_["aggressive_mask"]),
+            "tau2": _boolean_unmask(est_summary.tau2.squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 
@@ -483,6 +526,17 @@ class SampleSizeBasedLikelihood(IBMAEstimator):
     Notes
     -----
     Requires ``beta`` images and sample size from metadata.
+
+    :meth:`fit` produces a :class:`~nimare.results.MetaResult` object with the following maps:
+
+    ============== ===============================================================================
+    "z"            Z-statistic map from one-sample test.
+    "p"            P-value map from one-sample test.
+    "est"          Fixed effects estimate for intercept test.
+    "se"           Standard error of fixed effects estimate.
+    "tau2"         Estimated between-study variance.
+    "sigma2"       Estimated within-study variance. Assumed to be the same for all studies.
+    ============== ===============================================================================
 
     Homogeneity of sigma^2 across studies is assumed.
     The ML and REML solutions are obtained via SciPy's scalar function
@@ -526,17 +580,25 @@ class SampleSizeBasedLikelihood(IBMAEstimator):
         est_summary = est.summary()
         fe_stats = est_summary.get_fe_stats()
         results = {
-            "tau2": _boolean_unmask(est_summary.tau2.squeeze(), self.inputs_["aggressive_mask"]),
             "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
             "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
             "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
             "se": _boolean_unmask(fe_stats["se"].squeeze(), self.inputs_["aggressive_mask"]),
+            "tau2": _boolean_unmask(est_summary.tau2.squeeze(), self.inputs_["aggressive_mask"]),
+            "sigma2": _boolean_unmask(
+                est.params_["sigma2"].squeeze(),
+                self.inputs_["aggressive_mask"],
+            ),
         }
         return results
 
 
 class VarianceBasedLikelihood(IBMAEstimator):
     """A likelihood-based meta-analysis method for estimates with known variances.
+
+    .. versionchanged:: 0.0.12
+
+        Add "tau2" output.
 
     .. versionchanged:: 0.0.8
 
@@ -561,6 +623,16 @@ class VarianceBasedLikelihood(IBMAEstimator):
     Notes
     -----
     Requires ``beta`` and ``varcope`` images.
+
+    :meth:`fit` produces a :class:`~nimare.results.MetaResult` object with the following maps:
+
+    ============== ===============================================================================
+    "z"            Z-statistic map from one-sample test.
+    "p"            P-value map from one-sample test.
+    "est"          Fixed effects estimate for intercept test.
+    "se"           Standard error of fixed effects estimate.
+    "tau2"         Estimated between-study variance.
+    ============== ===============================================================================
 
     The ML and REML solutions are obtained via SciPy's scalar function
     minimizer (:func:`scipy.optimize.minimize`).
@@ -614,11 +686,11 @@ class VarianceBasedLikelihood(IBMAEstimator):
         est_summary = est.summary()
         fe_stats = est_summary.get_fe_stats()
         results = {
-            "tau2": _boolean_unmask(est_summary.tau2.squeeze(), self.inputs_["aggressive_mask"]),
             "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
             "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
             "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
             "se": _boolean_unmask(fe_stats["se"].squeeze(), self.inputs_["aggressive_mask"]),
+            "tau2": _boolean_unmask(est_summary.tau2.squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 
@@ -645,6 +717,13 @@ class PermutedOLS(IBMAEstimator):
     Notes
     -----
     Requires ``z`` images.
+
+    :meth:`fit` produces a :class:`~nimare.results.MetaResult` object with the following maps:
+
+    ============== ===============================================================================
+    "t"            T-statistic map from one-sample test.
+    "z"            Z-statistic map from one-sample test.
+    ============== ===============================================================================
 
     Available correction methods: :func:`PermutedOLS.correct_fwe_montecarlo`
 
@@ -724,8 +803,7 @@ class PermutedOLS(IBMAEstimator):
         images : :obj:`dict`
             Dictionary of 1D arrays corresponding to masked images generated by
             the correction procedure. The following arrays are generated by
-            this method: 'z_vthresh', 'p_level-voxel', 'z_level-voxel', and
-            'logp_level-cluster'.
+            this method: 'p_level-voxel', 'z_level-voxel', 'logp_level-voxel'.
 
         See Also
         --------

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -319,17 +319,13 @@ class WeightedLeastSquares(IBMAEstimator):
         est = pymare.estimators.WeightedLeastSquares(tau2=self.tau2)
         est.fit_dataset(pymare_dset)
         est_summary = est.summary()
+
+        fe_stats = est_summary.get_fe_stats()
         # tau2 is an float, not a map, so it can't go in the results dictionary
         results = {
-            "z": _boolean_unmask(
-                est_summary.get_fe_stats()["z"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
-            "p": _boolean_unmask(
-                est_summary.get_fe_stats()["p"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
-            "est": _boolean_unmask(
-                est_summary.get_fe_stats()["est"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
+            "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
+            "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
+            "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 
@@ -386,17 +382,13 @@ class DerSimonianLaird(IBMAEstimator):
         pymare_dset = pymare.Dataset(y=self.inputs_["beta_maps"], v=self.inputs_["varcope_maps"])
         est.fit_dataset(pymare_dset)
         est_summary = est.summary()
+
+        fe_stats = est_summary.get_fe_stats()
         results = {
             "tau2": _boolean_unmask(est_summary.tau2.squeeze(), self.inputs_["aggressive_mask"]),
-            "z": _boolean_unmask(
-                est_summary.get_fe_stats()["z"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
-            "p": _boolean_unmask(
-                est_summary.get_fe_stats()["p"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
-            "est": _boolean_unmask(
-                est_summary.get_fe_stats()["est"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
+            "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
+            "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
+            "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 
@@ -453,17 +445,12 @@ class Hedges(IBMAEstimator):
         pymare_dset = pymare.Dataset(y=self.inputs_["beta_maps"], v=self.inputs_["varcope_maps"])
         est.fit_dataset(pymare_dset)
         est_summary = est.summary()
+        fe_stats = est_summary.get_fe_stats()
         results = {
             "tau2": _boolean_unmask(est_summary.tau2.squeeze(), self.inputs_["aggressive_mask"]),
-            "z": _boolean_unmask(
-                est_summary.get_fe_stats()["z"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
-            "p": _boolean_unmask(
-                est_summary.get_fe_stats()["p"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
-            "est": _boolean_unmask(
-                est_summary.get_fe_stats()["est"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
+            "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
+            "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
+            "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 
@@ -534,17 +521,12 @@ class SampleSizeBasedLikelihood(IBMAEstimator):
         est = pymare.estimators.SampleSizeBasedLikelihoodEstimator(method=self.method)
         est.fit_dataset(pymare_dset)
         est_summary = est.summary()
+        fe_stats = est_summary.get_fe_stats()
         results = {
             "tau2": _boolean_unmask(est_summary.tau2.squeeze(), self.inputs_["aggressive_mask"]),
-            "z": _boolean_unmask(
-                est_summary.get_fe_stats()["z"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
-            "p": _boolean_unmask(
-                est_summary.get_fe_stats()["p"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
-            "est": _boolean_unmask(
-                est_summary.get_fe_stats()["est"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
+            "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
+            "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
+            "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 
@@ -626,17 +608,12 @@ class VarianceBasedLikelihood(IBMAEstimator):
         pymare_dset = pymare.Dataset(y=self.inputs_["beta_maps"], v=self.inputs_["varcope_maps"])
         est.fit_dataset(pymare_dset)
         est_summary = est.summary()
+        fe_stats = est_summary.get_fe_stats()
         results = {
             "tau2": _boolean_unmask(est_summary.tau2.squeeze(), self.inputs_["aggressive_mask"]),
-            "z": _boolean_unmask(
-                est_summary.get_fe_stats()["z"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
-            "p": _boolean_unmask(
-                est_summary.get_fe_stats()["p"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
-            "est": _boolean_unmask(
-                est_summary.get_fe_stats()["est"].squeeze(), self.inputs_["aggressive_mask"]
-            ),
+            "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
+            "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
+            "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -485,7 +485,7 @@ class SampleSizeBasedLikelihood(IBMAEstimator):
     Requires ``beta`` images and sample size from metadata.
 
     Homogeneity of sigma^2 across studies is assumed.
-    The ML and REML solutions are obtained via SciPy’s scalar function
+    The ML and REML solutions are obtained via SciPy's scalar function
     minimizer (:func:`scipy.optimize.minimize`).
     Parameters to ``minimize()`` can be passed in as keyword arguments.
 

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -326,6 +326,7 @@ class WeightedLeastSquares(IBMAEstimator):
             "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
             "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
             "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
+            "se": _boolean_unmask(fe_stats["se"].squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 
@@ -389,6 +390,7 @@ class DerSimonianLaird(IBMAEstimator):
             "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
             "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
             "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
+            "se": _boolean_unmask(fe_stats["se"].squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 
@@ -451,6 +453,7 @@ class Hedges(IBMAEstimator):
             "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
             "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
             "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
+            "se": _boolean_unmask(fe_stats["se"].squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 
@@ -527,6 +530,7 @@ class SampleSizeBasedLikelihood(IBMAEstimator):
             "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
             "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
             "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
+            "se": _boolean_unmask(fe_stats["se"].squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 
@@ -614,6 +618,7 @@ class VarianceBasedLikelihood(IBMAEstimator):
             "z": _boolean_unmask(fe_stats["z"].squeeze(), self.inputs_["aggressive_mask"]),
             "p": _boolean_unmask(fe_stats["p"].squeeze(), self.inputs_["aggressive_mask"]),
             "est": _boolean_unmask(fe_stats["est"].squeeze(), self.inputs_["aggressive_mask"]),
+            "se": _boolean_unmask(fe_stats["se"].squeeze(), self.inputs_["aggressive_mask"]),
         }
         return results
 

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -99,6 +99,13 @@ def test_ibma_smoke(testdata_ibma, meta, meta_kwargs, corrector, corrector_kwarg
     """Smoke test for IBMA estimators."""
     meta = meta(**meta_kwargs)
     res = meta.fit(testdata_ibma)
+    assert "z" in res.maps_.keys()
+    assert "p" in res.maps_.keys()
+    assert "est" in res.maps_.keys()
+    assert "se" in res.maps_.keys()
+    if meta.__class__.__name__ != "WeightedLeastSquares":
+        assert "tau2" in res.maps_.keys()
+
     z_img = res.get_map("z")
     assert isinstance(res, nimare.results.MetaResult)
     assert res.get_map("z", return_type="array").ndim == 1

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -99,12 +99,12 @@ def test_ibma_smoke(testdata_ibma, meta, meta_kwargs, corrector, corrector_kwarg
     """Smoke test for IBMA estimators."""
     meta = meta(**meta_kwargs)
     res = meta.fit(testdata_ibma)
-    assert "z" in res.maps_.keys()
-    assert "p" in res.maps_.keys()
-    assert "est" in res.maps_.keys()
-    assert "se" in res.maps_.keys()
+    assert "z" in res.maps.keys()
+    assert "p" in res.maps.keys()
+    assert "est" in res.maps.keys()
+    assert "se" in res.maps.keys()
     if meta.__class__.__name__ != "WeightedLeastSquares":
-        assert "tau2" in res.maps_.keys()
+        assert "tau2" in res.maps.keys()
 
     z_img = res.get_map("z")
     assert isinstance(res, nimare.results.MetaResult)

--- a/setup.cfg
+++ b/setup.cfg
@@ -96,7 +96,7 @@ minimum =
     nilearn==0.7.1
     numpy==1.18
     pandas==1.1
-    pymare==0.0.4rc1
+    pymare==0.0.4rc2
     scikit-learn==0.22
     scipy==1.5  # 1.6 drops Python 3.6 support
 all =

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ install_requires =
     numba  # used by sparse
     numpy
     pandas
-    pymare~=0.0.4rc1  # nimare.meta.ibma and stats
+    pymare~=0.0.4rc2  # nimare.meta.ibma and stats
     requests  # nimare.extract
     scikit-learn  # nimare.annotate and nimare.decode
     scipy


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None, but is related to #277.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Clean up some of the IBMA code.
- Add "se" to IBMA results, for applicable Estimators.
- Add "sigma2" to SampleSizeBasedEstimator outputs.
- Document the additional outputs in `docs/outputs.rst`.
