### PR TITLE
Add warning when coordinates dataset contains both positive and negative z_stats

### DIFF
--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -105,11 +105,15 @@ class Dataset(NiMAREBase):
         self.basepath = None
 
         if "z_stat" in self.coordinates.columns:
-            # Raise warning if coordinates dataset contains both positive and negative z_stats
-            if ((self.coordinates["z_stat"].values >= 0).any()) and (
-                (self.coordinates["z_stat"].values < 0).any()
-            ):
-                warnings.warn("Coordinates dataset contains both positive and negative z_stats")
+            # "z_stat" column may contain Nones
+            if not self.coordinates["z_stat"].isna().any():
+                # Raise warning if coordinates dataset contains both positive and negative z_stats
+                if ((self.coordinates["z_stat"].values >= 0).any()) and (
+                    (self.coordinates["z_stat"].values < 0).any()
+                ):
+                    warnings.warn(
+                        "Coordinates dataset contains both positive and negative z_stats"
+                    )
 
     def __repr__(self):
         """Show basic Dataset representation.

--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import logging
 import os.path as op
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -102,6 +103,13 @@ class Dataset(NiMAREBase):
         self.metadata = _dict_to_df(id_df, data, key="metadata")
         self.texts = _dict_to_df(id_df, data, key="text")
         self.basepath = None
+
+        if "z_stat" in self.coordinates.columns:
+            # Raise warning if coordinates dataset contains both positive and negative z_stats
+            if ((self.coordinates["z_stat"].values >= 0).any()) and (
+                (self.coordinates["z_stat"].values < 0).any()
+            ):
+                warnings.warn("Coordinates dataset contains both positive and negative z_stats")
 
     def __repr__(self):
         """Show basic Dataset representation.

--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -115,7 +115,9 @@ class Dataset(NiMAREBase):
                     (self.coordinates["z_stat"].values < 0).any()
                 ):
                     warnings.warn(
-                        "Coordinates dataset contains both positive and negative z_stats"
+                        "Coordinates dataset contains both positive and negative z_stats. "
+                        "The algorithms currently implemented in NiMARE are designed for "
+                        "one-sided tests. This might lead to unexpected results."
                     )
 
     def __repr__(self):

--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -107,6 +107,9 @@ class Dataset(NiMAREBase):
         if "z_stat" in self.coordinates.columns:
             # "z_stat" column may contain Nones
             if not self.coordinates["z_stat"].isna().any():
+                # Ensure z_stat is treated as float
+                self.coordinates["z_stat"] = self.coordinates["z_stat"].astype(float)
+
                 # Raise warning if coordinates dataset contains both positive and negative z_stats
                 if ((self.coordinates["z_stat"].values >= 0).any()) and (
                     (self.coordinates["z_stat"].values < 0).any()

--- a/nimare/tests/test_dataset.py
+++ b/nimare/tests/test_dataset.py
@@ -1,5 +1,8 @@
 """Test nimare.dataset (Dataset IO/transformations)."""
+import copy
+import json
 import os.path as op
+import warnings
 
 import nibabel as nib
 import numpy as np
@@ -51,3 +54,45 @@ def test_empty_dset():
     # dictionary with no information
     minimal_dict = {"study-0": {"contrasts": {"1": {}}}}
     dataset.Dataset(minimal_dict)
+
+
+def test_posneg_warning():
+    """Smoke test for nimare.dataset.Dataset initialization with positive and negative z_stat."""
+    db_file = op.join(get_test_data_path(), "neurosynth_dset.json")
+    with open(db_file, "r") as f_obj:
+        data = json.load(f_obj)
+
+    data_pos_zstats = copy.deepcopy(data)
+    data_neg_zstats = copy.deepcopy(data)
+    for pid in data.keys():
+        for expid in data[pid]["contrasts"].keys():
+            exp = data[pid]["contrasts"][expid]
+
+            if "coords" not in exp.keys():
+                continue
+
+            if "z_stat" not in exp["coords"].keys():
+                continue
+
+            n_zstats = len(exp["coords"]["z_stat"])
+            rand_arr = np.random.randn(n_zstats)
+            rand_pos_arr = np.abs(rand_arr)
+            rand_neg_arr = np.abs(rand_arr) * -1
+
+            data[pid]["contrasts"][expid]["coords"]["z_stat"] = rand_arr.tolist()
+            data_neg_zstats[pid]["contrasts"][expid]["coords"]["z_stat"] = rand_neg_arr.tolist()
+            data_pos_zstats[pid]["contrasts"][expid]["coords"]["z_stat"] = rand_pos_arr.tolist()
+
+    # Test Warning is raised if there are positive and negative z-stat
+    with pytest.warns(UserWarning, match=r"positive and negative z_stats"):
+        dset_posneg = dataset.Dataset(data)
+
+    # Test Warning is not raised if there are only positive or negative z-stat
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        dset_pos = dataset.Dataset(data_pos_zstats)
+        dset_neg = dataset.Dataset(data_neg_zstats)
+
+    assert isinstance(dset_posneg, nimare.dataset.Dataset)
+    assert isinstance(dset_pos, nimare.dataset.Dataset)
+    assert isinstance(dset_neg, nimare.dataset.Dataset)

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -3,6 +3,7 @@
 import copy
 import logging
 import os.path as op
+import warnings
 
 import nibabel as nib
 import numpy as np
@@ -456,9 +457,15 @@ class ImagesToCoordinates(NiMAREBase):
             original_ids = set(old_coordinates_df["id"])
             metadata.loc[metadata["id"].isin(original_ids), "coordinate_source"] = "original"
 
-        # ensure z_stat is treated as float
         if "z_stat" in coordinates_df.columns:
+            # ensure z_stat is treated as float
             coordinates_df["z_stat"] = coordinates_df["z_stat"].astype(float)
+
+            # Raise warning if coordinates dataset contains both positive and negative z_stats
+            if ((coordinates_df["z_stat"].values >= 0).any()) and (
+                (coordinates_df["z_stat"].values < 0).any()
+            ):
+                warnings.warn("Coordinates dataset contains both positive and negative z_stats")
 
         new_dataset = copy.deepcopy(dataset)
         new_dataset.coordinates = coordinates_df

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -465,7 +465,11 @@ class ImagesToCoordinates(NiMAREBase):
             if ((coordinates_df["z_stat"].values >= 0).any()) and (
                 (coordinates_df["z_stat"].values < 0).any()
             ):
-                warnings.warn("Coordinates dataset contains both positive and negative z_stats")
+                warnings.warn(
+                    "Coordinates dataset contains both positive and negative z_stats. "
+                    "The algorithms currently implemented in NiMARE are designed for "
+                    "one-sided tests. This might lead to unexpected results."
+                )
 
         new_dataset = copy.deepcopy(dataset)
         new_dataset.coordinates = coordinates_df


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #465.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Check for `z_stat` in `Dataset.coordinates.columns`.
- Check if there are values with `z_stat >= 0` AND `z_stat < 0` in `Dataset.__init__()` and when the `ImagesToCoordinates.transform()` is applied.
