### PR TITLE
Use sparse array in ALEKernel

### DIFF
--- a/nimare/generate.py
+++ b/nimare/generate.py
@@ -270,7 +270,7 @@ def _create_foci(foci, foci_percentage, fwhm, n_studies, n_noise_foci, rng, spac
         for peak in ground_truth_foci_ijks
         if peak.size
     }
-    foci_prob_maps = {k: v.todense() for k, v in foci_prob_maps.items()}
+    # foci_prob_maps = {k: v.todense() for k, v in foci_prob_maps.items()}
 
     # get study specific instances of each foci
     signal_studies = int(round(foci_percentage * n_studies))

--- a/nimare/generate.py
+++ b/nimare/generate.py
@@ -270,6 +270,7 @@ def _create_foci(foci, foci_percentage, fwhm, n_studies, n_noise_foci, rng, spac
         for peak in ground_truth_foci_ijks
         if peak.size
     }
+    foci_prob_maps = {k: v.todense() for k, v in foci_prob_maps.items()}
 
     # get study specific instances of each foci
     signal_studies = int(round(foci_percentage * n_studies))

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -339,9 +339,14 @@ class ALEKernel(KernelTransformer):
                 else:
                     kern = kernels[sample_size]
 
-            kernel_data = compute_ale_ma(mask.shape, ijk, kern)
+            ma_values = compute_ale_ma(mask.shape, ijk, kern)
 
-            transformed.append(kernel_data)
+            # Convert dense array to sparse
+            nonzero_idx = np.vstack(np.where(ma_values))
+            nonzero_values = ma_values[nonzero_idx[0, :], nonzero_idx[1, :], nonzero_idx[2, :]]
+            ma_values = sparse.COO(nonzero_idx, nonzero_values, shape=mask.shape)
+
+            transformed.append(ma_values)
 
         return transformed, exp_ids
 

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -340,14 +340,14 @@ class ALEKernel(KernelTransformer):
                 else:
                     kern = kernels[sample_size]
 
-            ma_values = compute_ale_ma(mask.shape, ijk, kern)
+            kernel_data = compute_ale_ma(mask.shape, ijk, kern)
 
             # Convert dense array to sparse
-            nonzero_idx = np.vstack(np.where(ma_values))
-            nonzero_values = ma_values[nonzero_idx[0, :], nonzero_idx[1, :], nonzero_idx[2, :]]
-            ma_values = sparse.COO(nonzero_idx, nonzero_values, shape=mask.shape)
+            nonzero_idx = np.vstack(np.where(kernel_data))
+            nonzero_values = kernel_data[nonzero_idx[0, :], nonzero_idx[1, :], nonzero_idx[2, :]]
+            kernel_data = sparse.COO(nonzero_idx, nonzero_values, shape=mask.shape)
 
-            transformed.append(ma_values)
+            transformed.append(kernel_data)
 
         return transformed, exp_ids
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -417,8 +417,8 @@ def compute_ale_ma(shape, ijk, kernel):
 
     Returns
     -------
-    ma_values : :obj:`sparse._coo.core.COO`
-        3D sparse array containing MA values.
+    ma_values : array-like
+        3d array of modeled activation values.
     """
     ma_values = np.zeros(shape)
     mid = int(np.floor(kernel.shape[0] / 2.0))
@@ -456,12 +456,7 @@ def compute_ale_ma(shape, ijk, kernel):
                 ma_values[xl:xh, yl:yh, zl:zh], kernel[xlk:xhk, ylk:yhk, zlk:zhk]
             )
 
-    # Convert dense array to sparse
-    nonzero_idx = np.vstack(np.where(ma_values))
-    nonzero_values = ma_values[nonzero_idx[0, :], nonzero_idx[1, :], nonzero_idx[2, :]]
-    kernel_data = sparse.COO(nonzero_idx, nonzero_values, shape=shape)
-
-    return kernel_data
+    return ma_values
 
 
 @due.dcite(references.ALE_KERNEL, description="Introduces sample size-dependent kernels to ALE.")

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -417,8 +417,8 @@ def compute_ale_ma(shape, ijk, kernel):
 
     Returns
     -------
-    ma_values : array-like
-        1d array of modeled activation values.
+    ma_values : :obj:`sparse._coo.core.COO`
+        3D sparse array containing MA values.
     """
     ma_values = np.zeros(shape)
     mid = int(np.floor(kernel.shape[0] / 2.0))

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -455,7 +455,13 @@ def compute_ale_ma(shape, ijk, kernel):
             ma_values[xl:xh, yl:yh, zl:zh] = np.maximum(
                 ma_values[xl:xh, yl:yh, zl:zh], kernel[xlk:xhk, ylk:yhk, zlk:zhk]
             )
-    return ma_values
+
+    # Convert dense array to sparse
+    nonzero_idx = np.vstack(np.where(ma_values))
+    nonzero_values = ma_values[nonzero_idx[0, :], nonzero_idx[1, :], nonzero_idx[2, :]]
+    kernel_data = sparse.COO(nonzero_idx, nonzero_values, shape=shape)
+
+    return kernel_data
 
 
 @due.dcite(references.ALE_KERNEL, description="Introduces sample size-dependent kernels to ALE.")


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #692.

**NOTE**: This isn't optimized at all. I just tacked the conversion on to the end of `compute_ale_ma`.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Convert MA map to sparse array in `ALEKernel._transform`.
- Convert sparse arrays from `compute_ale_ma` back into dense arrays within `generate._create_foci`.