### PR TITLE
Add citation information to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,63 @@ pip install nimare
 pip install git+https://github.com/neurostuff/NiMARE.git
 ```
 
+## Citing NiMARE
+
+If you use NiMARE in your research, we recommend citing the Zenodo DOI associated with the NiMARE version you used,
+as well as the NeuroLibre preprint for the NiMARE Jupyter book.
+You can find the Zenodo DOI associated with each NiMARE release at https://zenodo.org/record/6642243#.YqiXNy-B1KM.
+
+```BibTeX
+# This is the NeuroLibre preprint.
+@article{Salo2022,
+  doi = {10.55458/neurolibre.00007},
+  url = {https://doi.org/10.55458/neurolibre.00007},
+  year = {2022},
+  publisher = {The Open Journal},
+  volume = {1},
+  number = {1},
+  pages = {7},
+  author = {Taylor Salo and Tal Yarkoni and Thomas E. Nichols and Jean-Baptiste Poline and Murat Bilgel and Katherine L. Bottenhorn and Dorota Jarecka and James D. Kent and Adam Kimbler and Dylan M. Nielson and Kendra M. Oudyk and Julio A. Peraza and Alexandre Pérez and Puck C. Reeders and Julio A. Yanes and Angela R. Laird},
+  title = {NiMARE: Neuroimaging Meta-Analysis Research Environment},
+  journal = {NeuroLibre}
+}
+
+# This is the Zenodo citation for version 0.0.11.
+@software{salo_taylor_2022_5826281,
+  author       = {Salo, Taylor and
+                  Yarkoni, Tal and
+                  Nichols, Thomas E. and
+                  Poline, Jean-Baptiste and
+                  Kent, James D. and
+                  Gorgolewski, Krzysztof J. and
+                  Glerean, Enrico and
+                  Bottenhorn, Katherine L. and
+                  Bilgel, Murat and
+                  Wright, Jessey and
+                  Reeders, Puck and
+                  Kimbler, Adam and
+                  Nielson, Dylan N. and
+                  Yanes, Julio A. and
+                  Pérez, Alexandre and
+                  Oudyk, Kendra M. and
+                  Jarecka, Dorota and
+                  Enge, Alexander and
+                  Peraza, Julio A. and
+                  Laird, Angela R.},
+  title        = {neurostuff/NiMARE: 0.0.11},
+  month        = jan,
+  year         = 2022,
+  publisher    = {Zenodo},
+  version      = {0.0.11},
+  doi          = {10.5281/zenodo.5826281},
+  url          = {https://doi.org/10.5281/zenodo.5826281}
+}
+```
+
+To cite NiMARE in your manuscript, we recommend something like the following:
+
+> We used NiMARE v0.0.11 (RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b).
+
 ## Contributing
 
 Please see our [contributing guidelines](https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Python library for coordinate- and image-based meta-analysis.
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Join the chat at https://mattermost.brainhack.org/brainhack/channels/nimare](https://img.shields.io/badge/mattermost-join_chat%20%E2%86%92-brightgreen.svg)](https://mattermost.brainhack.org/brainhack/channels/nimare)
 [![RRID:SCR_017398](https://img.shields.io/badge/RRID-SCR__017398-blue.svg)](https://scicrunch.org/scicrunch/Resources/record/nlx_144509-1/SCR_017398/resolver?q=nimare&l=nimare)
+[![DOI](http://neurolibre.herokuapp.com/papers/10.55458/neurolibre.00007/status.svg)](https://doi.org/10.55458/neurolibre.00007)
 
 Currently, NiMARE implements a range of image- and coordinate-based meta-analytic algorithms, as well as several methods for advanced meta-analytic methods, like automated annotation and functional decoding.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,65 @@ To install NiMARE check out our `installation guide`_.
 .. image:: _static/nimare_overview.png
    :align: center
 
+Citing NiMARE
+-------------
+
+If you use NiMARE in your research, we recommend citing the Zenodo DOI associated with the NiMARE version you used,
+as well as the NeuroLibre preprint for the NiMARE Jupyter book.
+You can find the Zenodo DOI associated with each NiMARE release at https://zenodo.org/record/6642243#.YqiXNy-B1KM.
+
+.. code-block:: bibtex
+   :caption: BibTeX entries for NiMARE version 0.0.11.
+
+   # This is the NeuroLibre preprint.
+   @article{Salo2022,
+   doi = {10.55458/neurolibre.00007},
+   url = {https://doi.org/10.55458/neurolibre.00007},
+   year = {2022},
+   publisher = {The Open Journal},
+   volume = {1},
+   number = {1},
+   pages = {7},
+   author = {Taylor Salo and Tal Yarkoni and Thomas E. Nichols and Jean-Baptiste Poline and Murat Bilgel and Katherine L. Bottenhorn and Dorota Jarecka and James D. Kent and Adam Kimbler and Dylan M. Nielson and Kendra M. Oudyk and Julio A. Peraza and Alexandre Pérez and Puck C. Reeders and Julio A. Yanes and Angela R. Laird},
+   title = {NiMARE: Neuroimaging Meta-Analysis Research Environment},
+   journal = {NeuroLibre}
+   }
+
+   # This is the Zenodo citation for version 0.0.11.
+   @software{salo_taylor_2022_5826281,
+   author       = {Salo, Taylor and
+                     Yarkoni, Tal and
+                     Nichols, Thomas E. and
+                     Poline, Jean-Baptiste and
+                     Kent, James D. and
+                     Gorgolewski, Krzysztof J. and
+                     Glerean, Enrico and
+                     Bottenhorn, Katherine L. and
+                     Bilgel, Murat and
+                     Wright, Jessey and
+                     Reeders, Puck and
+                     Kimbler, Adam and
+                     Nielson, Dylan N. and
+                     Yanes, Julio A. and
+                     Pérez, Alexandre and
+                     Oudyk, Kendra M. and
+                     Jarecka, Dorota and
+                     Enge, Alexander and
+                     Peraza, Julio A. and
+                     Laird, Angela R.},
+   title        = {neurostuff/NiMARE: 0.0.11},
+   month        = jan,
+   year         = 2022,
+   publisher    = {Zenodo},
+   version      = {0.0.11},
+   doi          = {10.5281/zenodo.5826281},
+   url          = {https://doi.org/10.5281/zenodo.5826281}
+   }
+
+Then, to cite NiMARE in your manuscript, we recommend something like the following:
+
+   We used NiMARE v0.0.11 (RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b).
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,6 +48,10 @@ To install NiMARE check out our `installation guide`_.
    :target: https://scicrunch.org/scicrunch/Resources/record/nlx_144509-1/SCR_017398/resolver?q=nimare&l=nimare
    :alt: RRID:SCR_017398
 
+.. image:: http://neurolibre.herokuapp.com/papers/10.55458/neurolibre.00007/status.svg
+   :target: https://doi.org/10.55458/neurolibre.00007
+   :alt: NeuroLibre preprint
+
 .. _installation guide: installation.html
 
 .. image:: _static/nimare_overview.png

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -279,6 +279,19 @@
   doi={10.1371/journal.pcbi.1005649}
 }
 
+@article{Salo2022,
+  doi = {10.55458/neurolibre.00007},
+  url = {https://doi.org/10.55458/neurolibre.00007},
+  year = {2022},
+  publisher = {The Open Journal},
+  volume = {1},
+  number = {1},
+  pages = {7},
+  author = {Taylor Salo and Tal Yarkoni and Thomas E. Nichols and Jean-Baptiste Poline and Murat Bilgel and Katherine L. Bottenhorn and Dorota Jarecka and James D. Kent and Adam Kimbler and Dylan M. Nielson and Kendra M. Oudyk and Julio A. Peraza and Alexandre Pérez and Puck C. Reeders and Julio A. Yanes and Angela R. Laird},
+  title = {NiMARE: Neuroimaging Meta-Analysis Research Environment},
+  journal = {NeuroLibre}
+}
+
 @article{shaffer1995multiple,
   title={Multiple hypothesis testing},
   author={Shaffer, Juliet Popper},

--- a/nimare/workflows/ale.py
+++ b/nimare/workflows/ale.py
@@ -6,6 +6,7 @@ from shutil import copyfile
 
 import numpy as np
 
+from nimare import __version__
 from nimare.correct import FWECorrector
 from nimare.diagnostics import FocusCounter
 from nimare.io import convert_sleuth_to_dataset
@@ -40,8 +41,10 @@ def ale_sleuth_workflow(
         boilerplate = """
 An activation likelihood estimation (ALE; Turkeltaub, Eden, Jones, & Zeffiro,
 2002; Eickhoff, Bzdok, Laird, Kurth, & Fox, 2012; Turkeltaub et al., 2012)
-meta-analysis was performed using NiMARE. The input dataset included {n_foci}
-foci from {n_subs} participants across {n_exps} studies/experiments.
+meta-analysis was performed using NiMARE {__version__}
+(RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b).
+The input dataset included {n_foci} foci from {n_subs} participants across
+{n_exps} studies/experiments.
 
 Modeled activation maps were generated for each study/experiment by convolving
 each focus with a Gaussian kernel {fwhm_str}.
@@ -71,23 +74,32 @@ ALE value was recorded.
 
 References
 ----------
-- Eickhoff, S. B., Bzdok, D., Laird, A. R., Kurth, F., & Fox, P. T. (2012).
-Activation likelihood estimation meta-analysis revisited. NeuroImage,
-59(3), 2349-2361.
-- Fonov, V., Evans, A. C., Botteron, K., Almli, C. R., McKinstry, R. C.,
-Collins, D. L., & Brain Development Cooperative Group. (2011).
-Unbiased average age-appropriate atlases for pediatric studies.
-Neuroimage, 54(1), 313-327.
-- Fonov, V. S., Evans, A. C., McKinstry, R. C., Almli, C. R., & Collins, D. L.
-(2009). Unbiased nonlinear average age-appropriate brain templates from birth
-to adulthood. NeuroImage, (47), S102.
-- Turkeltaub, P. E., Eden, G. F., Jones, K. M., & Zeffiro, T. A. (2002).
-Meta-analysis of the functional neuroanatomy of single-word reading: method
-and validation. NeuroImage, 16(3 Pt 1), 765-780.
-- Turkeltaub, P. E., Eickhoff, S. B., Laird, A. R., Fox, M., Wiener, M.,
-& Fox, P. (2012). Minimizing within-experiment and within-group effects in
-Activation Likelihood Estimation meta-analyses. Human Brain Mapping,
-33(1), 1-13.
+-   Eickhoff, S. B., Bzdok, D., Laird, A. R., Kurth, F., & Fox, P. T. (2012).
+    Activation likelihood estimation meta-analysis revisited. NeuroImage,
+    59(3), 2349-2361.
+-   Fonov, V., Evans, A. C., Botteron, K., Almli, C. R., McKinstry, R. C.,
+    Collins, D. L., & Brain Development Cooperative Group. (2011).
+    Unbiased average age-appropriate atlases for pediatric studies.
+    Neuroimage, 54(1), 313-327.
+-   Fonov, V. S., Evans, A. C., McKinstry, R. C., Almli, C. R., & Collins, D. L.
+    (2009). Unbiased nonlinear average age-appropriate brain templates from birth
+    to adulthood. NeuroImage, (47), S102.
+-   Salo et al. (2022). NiMARE: Neuroimaging Meta-Analysis Research Environment.
+    NeuroLibre Reproducible Preprint Server, 1(1), 7, https://doi.org/10.55458/neurolibre.00007.
+-   Salo, Taylor, Yarkoni, Tal, Nichols, Thomas E., Poline, Jean-Baptiste, Kent, James D.,
+    Gorgolewski, Krzysztof J., Glerean, Enrico, Bottenhorn, Katherine L., Bilgel, Murat,
+    Wright, Jessey, Reeders, Puck, Kimbler, Adam, Nielson, Dylan N., Yanes, Julio A.,
+    Pérez, Alexandre, Oudyk, Kendra M., Jarecka, Dorota, Enge, Alexander,
+    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {__version__}
+    ({__version__}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
+    **NOTE** Please replace this with the version-specific Zenodo reference in your manuscript.
+-   Turkeltaub, P. E., Eden, G. F., Jones, K. M., & Zeffiro, T. A. (2002).
+    Meta-analysis of the functional neuroanatomy of single-word reading: method
+    and validation. NeuroImage, 16(3 Pt 1), 765-780.
+-   Turkeltaub, P. E., Eickhoff, S. B., Laird, A. R., Fox, M., Wiener, M.,
+    & Fox, P. (2012). Minimizing within-experiment and within-group effects in
+    Activation Likelihood Estimation meta-analyses. Human Brain Mapping,
+    33(1), 1-13.
         """
 
         ale = ALE(kernel__fwhm=fwhm)
@@ -123,7 +135,8 @@ Activation Likelihood Estimation meta-analyses. Human Brain Mapping,
         boilerplate = """
 Activation likelihood estimation (ALE; Turkeltaub, Eden, Jones, & Zeffiro,
 2002; Eickhoff, Bzdok, Laird, Kurth, & Fox, 2012; Turkeltaub et al., 2012)
-meta-analyses were performed using NiMARE for each of two datasets.
+meta-analyses were performed using NiMARE {__version__}
+(RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b) for each of two datasets.
 The first input dataset included {n_foci1} foci from {n_subs1} participants
 across {n_exps1} studies/experiments. The second input dataset included
 {n_foci2} foci from {n_subs2} participants across {n_exps2} studies/experiments.
@@ -153,27 +166,36 @@ et al. (2005). {n_iters} iterations were performed.
 
 References
 ----------
-- Turkeltaub, P. E., Eden, G. F., Jones, K. M., & Zeffiro, T. A. (2002).
-Meta-analysis of the functional neuroanatomy of single-word reading: method
-and validation. NeuroImage, 16(3 Pt 1), 765-780.
-- Eickhoff, S. B., Bzdok, D., Laird, A. R., Kurth, F., & Fox, P. T. (2012).
-Activation likelihood estimation meta-analysis revisited. NeuroImage,
-59(3), 2349-2361.
-- Turkeltaub, P. E., Eickhoff, S. B., Laird, A. R., Fox, M., Wiener, M.,
-& Fox, P. (2012). Minimizing within-experiment and within-group effects in
-Activation Likelihood Estimation meta-analyses. Human Brain Mapping,
-33(1), 1-13.
-- Fonov, V., Evans, A. C., Botteron, K., Almli, C. R., McKinstry, R. C.,
-Collins, D. L., & Brain Development Cooperative Group. (2011).
-Unbiased average age-appropriate atlases for pediatric studies.
-Neuroimage, 54(1), 313-327.
-- Fonov, V. S., Evans, A. C., McKinstry, R. C., Almli, C. R., & Collins, D. L.
-(2009). Unbiased nonlinear average age-appropriate brain templates from birth
-to adulthood. NeuroImage, (47), S102.
-- Laird, A. R., Fox, P. M., Price, C. J., Glahn, D. C., Uecker, A. M.,
-Lancaster, J. L., ... & Fox, P. T. (2005). ALE meta-analysis: Controlling the
-false discovery rate and performing statistical contrasts. Human brain mapping,
-25(1), 155-164.
+-   Turkeltaub, P. E., Eden, G. F., Jones, K. M., & Zeffiro, T. A. (2002).
+    Meta-analysis of the functional neuroanatomy of single-word reading: method
+    and validation. NeuroImage, 16(3 Pt 1), 765-780.
+-   Eickhoff, S. B., Bzdok, D., Laird, A. R., Kurth, F., & Fox, P. T. (2012).
+    Activation likelihood estimation meta-analysis revisited. NeuroImage,
+    59(3), 2349-2361.
+-   Salo et al. (2022). NiMARE: Neuroimaging Meta-Analysis Research Environment.
+    NeuroLibre Reproducible Preprint Server, 1(1), 7, https://doi.org/10.55458/neurolibre.00007.
+-   Salo, Taylor, Yarkoni, Tal, Nichols, Thomas E., Poline, Jean-Baptiste, Kent, James D.,
+    Gorgolewski, Krzysztof J., Glerean, Enrico, Bottenhorn, Katherine L., Bilgel, Murat,
+    Wright, Jessey, Reeders, Puck, Kimbler, Adam, Nielson, Dylan N., Yanes, Julio A.,
+    Pérez, Alexandre, Oudyk, Kendra M., Jarecka, Dorota, Enge, Alexander,
+    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {__version__}
+    ({__version__}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
+    **NOTE** Please replace this with the version-specific Zenodo reference in your manuscript.
+-   Turkeltaub, P. E., Eickhoff, S. B., Laird, A. R., Fox, M., Wiener, M.,
+    & Fox, P. (2012). Minimizing within-experiment and within-group effects in
+    Activation Likelihood Estimation meta-analyses. Human Brain Mapping,
+    33(1), 1-13.
+-   Fonov, V., Evans, A. C., Botteron, K., Almli, C. R., McKinstry, R. C.,
+    Collins, D. L., & Brain Development Cooperative Group. (2011).
+    Unbiased average age-appropriate atlases for pediatric studies.
+    Neuroimage, 54(1), 313-327.
+-   Fonov, V. S., Evans, A. C., McKinstry, R. C., Almli, C. R., & Collins, D. L.
+    (2009). Unbiased nonlinear average age-appropriate brain templates from birth
+    to adulthood. NeuroImage, (47), S102.
+-   Laird, A. R., Fox, P. M., Price, C. J., Glahn, D. C., Uecker, A. M.,
+    Lancaster, J. L., ... & Fox, P. T. (2005). ALE meta-analysis: Controlling the
+    false discovery rate and performing statistical contrasts. Human brain mapping,
+    25(1), 155-164.
         """
 
         ale1 = ALE(kernel__fwhm=fwhm)

--- a/nimare/workflows/ale.py
+++ b/nimare/workflows/ale.py
@@ -26,6 +26,7 @@ def ale_sleuth_workflow(
 ):
     """Perform ALE meta-analysis from Sleuth text file."""
     from nimare import __version__
+
     LGR.info("Loading coordinates...")
 
     if fwhm:

--- a/nimare/workflows/ale.py
+++ b/nimare/workflows/ale.py
@@ -41,7 +41,7 @@ def ale_sleuth_workflow(
         boilerplate = """
 An activation likelihood estimation (ALE; Turkeltaub, Eden, Jones, & Zeffiro,
 2002; Eickhoff, Bzdok, Laird, Kurth, & Fox, 2012; Turkeltaub et al., 2012)
-meta-analysis was performed using NiMARE {__version__}
+meta-analysis was performed using NiMARE {version}
 (RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b).
 The input dataset included {n_foci} foci from {n_subs} participants across
 {n_exps} studies/experiments.
@@ -90,8 +90,8 @@ References
     Gorgolewski, Krzysztof J., Glerean, Enrico, Bottenhorn, Katherine L., Bilgel, Murat,
     Wright, Jessey, Reeders, Puck, Kimbler, Adam, Nielson, Dylan N., Yanes, Julio A.,
     Pérez, Alexandre, Oudyk, Kendra M., Jarecka, Dorota, Enge, Alexander,
-    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {__version__}
-    ({__version__}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
+    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {version}
+    ({version}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
     **NOTE** Please replace this with the version-specific Zenodo reference in your manuscript.
 -   Turkeltaub, P. E., Eden, G. F., Jones, K. M., & Zeffiro, T. A. (2002).
     Meta-analysis of the functional neuroanatomy of single-word reading: method
@@ -123,6 +123,7 @@ References
             unc=v_thr,
             n_iters=n_iters,
             fwhm_str=fwhm_str,
+            version=__version__,
         )
     else:
         dset1 = convert_sleuth_to_dataset(sleuth_file, target="ale_2mm")
@@ -135,7 +136,7 @@ References
         boilerplate = """
 Activation likelihood estimation (ALE; Turkeltaub, Eden, Jones, & Zeffiro,
 2002; Eickhoff, Bzdok, Laird, Kurth, & Fox, 2012; Turkeltaub et al., 2012)
-meta-analyses were performed using NiMARE {__version__}
+meta-analyses were performed using NiMARE {version}
 (RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b) for each of two datasets.
 The first input dataset included {n_foci1} foci from {n_subs1} participants
 across {n_exps1} studies/experiments. The second input dataset included
@@ -178,8 +179,8 @@ References
     Gorgolewski, Krzysztof J., Glerean, Enrico, Bottenhorn, Katherine L., Bilgel, Murat,
     Wright, Jessey, Reeders, Puck, Kimbler, Adam, Nielson, Dylan N., Yanes, Julio A.,
     Pérez, Alexandre, Oudyk, Kendra M., Jarecka, Dorota, Enge, Alexander,
-    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {__version__}
-    ({__version__}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
+    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {version}
+    ({version}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
     **NOTE** Please replace this with the version-specific Zenodo reference in your manuscript.
 -   Turkeltaub, P. E., Eickhoff, S. B., Laird, A. R., Fox, M., Wiener, M.,
     & Fox, P. (2012). Minimizing within-experiment and within-group effects in
@@ -230,6 +231,7 @@ References
             unc=v_thr,
             n_iters=n_iters,
             fwhm_str=fwhm_str,
+            version=__version__,
         )
 
     if output_dir is None:

--- a/nimare/workflows/ale.py
+++ b/nimare/workflows/ale.py
@@ -6,7 +6,6 @@ from shutil import copyfile
 
 import numpy as np
 
-from nimare import __version__
 from nimare.correct import FWECorrector
 from nimare.diagnostics import FocusCounter
 from nimare.io import convert_sleuth_to_dataset
@@ -26,6 +25,7 @@ def ale_sleuth_workflow(
     n_cores=1,
 ):
     """Perform ALE meta-analysis from Sleuth text file."""
+    from nimare import __version__
     LGR.info("Loading coordinates...")
 
     if fwhm:

--- a/nimare/workflows/conperm.py
+++ b/nimare/workflows/conperm.py
@@ -25,22 +25,32 @@ def conperm_workflow(contrast_images, mask_image=None, output_dir=None, prefix="
 
     boilerplate = """
 A contrast permutation analysis was performed on a sample of {n_studies}
-images. A brain mask derived from the MNI 152 template (Fonov et al., 2009;
-Fonov et al., 2011) was applied at 2x2x2mm resolution. The sign flipping
+images with NiMARE {__version__} (RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b).
+A brain mask derived from the MNI 152 template (Fonov et al., 2009; Fonov et al., 2011)
+was applied at 2x2x2mm resolution. The sign flipping
 method used was implemented as described in Maumet & Nichols (2016), with
 {n_iters} iterations used to estimate the null distribution.
 
 References
 ----------
-- Fonov, V., Evans, A. C., Botteron, K., Almli, C. R., McKinstry, R. C.,
-Collins, D. L., & Brain Development Cooperative Group. (2011).
-Unbiased average age-appropriate atlases for pediatric studies.
-Neuroimage, 54(1), 313-327.
-- Fonov, V. S., Evans, A. C., McKinstry, R. C., Almli, C. R., & Collins, D. L.
-(2009). Unbiased nonlinear average age-appropriate brain templates from birth
-to adulthood. NeuroImage, (47), S102.
-- Maumet, C., & Nichols, T. E. (2016). Minimal Data Needed for Valid & Accurate
-Image-Based fMRI Meta-Analysis. https://doi.org/10.1101/048249
+-   Fonov, V., Evans, A. C., Botteron, K., Almli, C. R., McKinstry, R. C.,
+    Collins, D. L., & Brain Development Cooperative Group. (2011).
+    Unbiased average age-appropriate atlases for pediatric studies.
+    Neuroimage, 54(1), 313-327.
+-   Fonov, V. S., Evans, A. C., McKinstry, R. C., Almli, C. R., & Collins, D. L.
+    (2009). Unbiased nonlinear average age-appropriate brain templates from birth
+    to adulthood. NeuroImage, (47), S102.
+-   Maumet, C., & Nichols, T. E. (2016). Minimal Data Needed for Valid & Accurate
+    Image-Based fMRI Meta-Analysis. https://doi.org/10.1101/048249
+-   Salo et al. (2022). NiMARE: Neuroimaging Meta-Analysis Research Environment.
+    NeuroLibre Reproducible Preprint Server, 1(1), 7, https://doi.org/10.55458/neurolibre.00007.
+-   Salo, Taylor, Yarkoni, Tal, Nichols, Thomas E., Poline, Jean-Baptiste, Kent, James D.,
+    Gorgolewski, Krzysztof J., Glerean, Enrico, Bottenhorn, Katherine L., Bilgel, Murat,
+    Wright, Jessey, Reeders, Puck, Kimbler, Adam, Nielson, Dylan N., Yanes, Julio A.,
+    Pérez, Alexandre, Oudyk, Kendra M., Jarecka, Dorota, Enge, Alexander,
+    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {__version__}
+    ({__version__}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
+    **NOTE** Please replace this with the version-specific Zenodo reference in your manuscript.
     """
 
     LGR.info("Performing meta-analysis.")

--- a/nimare/workflows/conperm.py
+++ b/nimare/workflows/conperm.py
@@ -7,6 +7,7 @@ import numpy as np
 from nilearn.masking import apply_mask
 from nilearn.mass_univariate import permuted_ols
 
+from nimare import __version__
 from nimare.results import MetaResult
 from nimare.utils import get_template
 
@@ -25,7 +26,7 @@ def conperm_workflow(contrast_images, mask_image=None, output_dir=None, prefix="
 
     boilerplate = """
 A contrast permutation analysis was performed on a sample of {n_studies}
-images with NiMARE {__version__} (RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b).
+images with NiMARE {version} (RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b).
 A brain mask derived from the MNI 152 template (Fonov et al., 2009; Fonov et al., 2011)
 was applied at 2x2x2mm resolution. The sign flipping
 method used was implemented as described in Maumet & Nichols (2016), with
@@ -48,8 +49,8 @@ References
     Gorgolewski, Krzysztof J., Glerean, Enrico, Bottenhorn, Katherine L., Bilgel, Murat,
     Wright, Jessey, Reeders, Puck, Kimbler, Adam, Nielson, Dylan N., Yanes, Julio A.,
     Pérez, Alexandre, Oudyk, Kendra M., Jarecka, Dorota, Enge, Alexander,
-    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {__version__}
-    ({__version__}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
+    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {version}
+    ({version}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
     **NOTE** Please replace this with the version-specific Zenodo reference in your manuscript.
     """
 
@@ -69,7 +70,11 @@ References
     # The t_test function will stand in for the Estimator in the results object
     res = MetaResult(permuted_ols, mask_image, maps=res)
 
-    boilerplate = boilerplate.format(n_studies=n_studies, n_iters=n_iters)
+    boilerplate = boilerplate.format(
+        n_studies=n_studies,
+        n_iters=n_iters,
+        version=__version__,
+    )
 
     if output_dir is None:
         output_dir = os.getcwd()

--- a/nimare/workflows/conperm.py
+++ b/nimare/workflows/conperm.py
@@ -7,7 +7,6 @@ import numpy as np
 from nilearn.masking import apply_mask
 from nilearn.mass_univariate import permuted_ols
 
-from nimare import __version__
 from nimare.results import MetaResult
 from nimare.utils import get_template
 
@@ -16,6 +15,8 @@ LGR = logging.getLogger(__name__)
 
 def conperm_workflow(contrast_images, mask_image=None, output_dir=None, prefix="", n_iters=10000):
     """Run a contrast permutation workflow."""
+    from nimare import __version__
+
     if mask_image is None:
         target = "mni152_2mm"
         mask_image = get_template(target, mask="brain")

--- a/nimare/workflows/macm.py
+++ b/nimare/workflows/macm.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 from shutil import copyfile
 
+from nimare import __version__
 from nimare.correct import FWECorrector
 from nimare.dataset import Dataset
 from nimare.meta import ALE
@@ -30,7 +31,7 @@ Meta-analytic connectivity modeling (MACM; Laird et al., 2009; Robinson et al.,
 2009; Eickhoff et al., 2010) analysis was performed with the activation
 likelihood estimation (ALE; Turkeltaub, Eden, Jones, & Zeffiro, 2002; Eickhoff,
 Bzdok, Laird, Kurth, & Fox, 2012; Turkeltaub et al., 2012) meta-analysis
-algorithm using NiMARE {__version__} (RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b).
+algorithm using NiMARE {version} (RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b).
 The input dataset included {n_foci_db} foci from {n_subs_db} participants across
 {n_exps_db} studies/experiments, from which studies/experiments were selected for analysis
 if they had at least one focus inside the target mask.
@@ -100,8 +101,8 @@ References
     Gorgolewski, Krzysztof J., Glerean, Enrico, Bottenhorn, Katherine L., Bilgel, Murat,
     Wright, Jessey, Reeders, Puck, Kimbler, Adam, Nielson, Dylan N., Yanes, Julio A.,
     Pérez, Alexandre, Oudyk, Kendra M., Jarecka, Dorota, Enge, Alexander,
-    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {__version__}
-    ({__version__}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
+    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {version}
+    ({version}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
     **NOTE** Please replace this with the version-specific Zenodo reference in your manuscript.
     """
 
@@ -120,6 +121,7 @@ References
         n_foci_sel=sel_dset.coordinates.shape[0],
         unc=v_thr,
         n_iters=n_iters,
+        version=__version__,
     )
 
     if output_dir is None:

--- a/nimare/workflows/macm.py
+++ b/nimare/workflows/macm.py
@@ -4,7 +4,6 @@ import os
 import pathlib
 from shutil import copyfile
 
-from nimare import __version__
 from nimare.correct import FWECorrector
 from nimare.dataset import Dataset
 from nimare.meta import ALE
@@ -16,6 +15,8 @@ def macm_workflow(
     dataset_file, mask_file, output_dir=None, prefix=None, n_iters=10000, v_thr=0.001, n_cores=1
 ):
     """Perform MACM with ALE algorithm."""
+    from nimare import __version__
+
     LGR.info("Loading coordinates...")
     dset = Dataset(dataset_file)
     sel_ids = dset.get_studies_by_mask(mask_file)

--- a/nimare/workflows/macm.py
+++ b/nimare/workflows/macm.py
@@ -30,11 +30,12 @@ Meta-analytic connectivity modeling (MACM; Laird et al., 2009; Robinson et al.,
 2009; Eickhoff et al., 2010) analysis was performed with the activation
 likelihood estimation (ALE; Turkeltaub, Eden, Jones, & Zeffiro, 2002; Eickhoff,
 Bzdok, Laird, Kurth, & Fox, 2012; Turkeltaub et al., 2012) meta-analysis
-algorithm using NiMARE. The input dataset included {n_foci_db}
-foci from {n_subs_db} participants across {n_exps_db} studies/experiments, from
-which studies/experiments were selected for analysis if they had at least one
-focus inside the target mask. The resulting sample included {n_foci_sel}
-foci from {n_subs_sel} participants across {n_exps_sel} studies/experiments.
+algorithm using NiMARE {__version__} (RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b).
+The input dataset included {n_foci_db} foci from {n_subs_db} participants across
+{n_exps_db} studies/experiments, from which studies/experiments were selected for analysis
+if they had at least one focus inside the target mask.
+The resulting sample included {n_foci_sel} foci from {n_subs_sel} participants across
+{n_exps_sel} studies/experiments.
 
 Modeled activation maps were generated for each study/experiment by convolving
 each focus with a Gaussian kernel determined by the study/experiment's sample
@@ -64,35 +65,44 @@ drawn from a gray matter template and the maximum ALE value was recorded.
 
 References
 ----------
-- Eickhoff, S. B., Bzdok, D., Laird, A. R., Kurth, F., & Fox, P. T. (2012).
-Activation likelihood estimation meta-analysis revisited. NeuroImage,
-59(3), 2349–2361.
-- Eickhoff, S. B., Jbabdi, S., Caspers, S., Laird, A. R., Fox, P. T., Zilles,
-K., & Behrens, T. E. (2010). Anatomical and functional connectivity of
-cytoarchitectonic areas within the human parietal operculum. Journal of
-Neuroscience, 30(18), 6409-6421.
-- Fonov, V., Evans, A. C., Botteron, K., Almli, C. R., McKinstry, R. C.,
-Collins, D. L., & Brain Development Cooperative Group. (2011).
-Unbiased average age-appropriate atlases for pediatric studies.
-Neuroimage, 54(1), 313-327.
-- Fonov, V. S., Evans, A. C., McKinstry, R. C., Almli, C. R., & Collins, D. L.
-(2009). Unbiased nonlinear average age-appropriate brain templates from birth
-to adulthood. NeuroImage, (47), S102.
-- Laird, A. R., Eickhoff, S. B., Li, K., Robin, D. A., Glahn, D. C., &
-Fox, P. T. (2009). Investigating the functional heterogeneity of the default
-mode network using coordinate-based meta-analytic modeling. The Journal of
-Neuroscience: The Official Journal of the Society for Neuroscience, 29(46),
-14496–14505.
-- Robinson, J. L., Laird, A. R., Glahn, D. C., Lovallo, W. R., & Fox, P. T.
-(2009). Metaanalytic connectivity modeling: Delineating the functional
-connectivity of the human amygdala. Human Brain Mapping, 31(2), 173-184.
-- Turkeltaub, P. E., Eden, G. F., Jones, K. M., & Zeffiro, T. A. (2002).
-Meta-analysis of the functional neuroanatomy of single-word reading: method
-and validation. NeuroImage, 16(3 Pt 1), 765–780.
-- Turkeltaub, P. E., Eickhoff, S. B., Laird, A. R., Fox, M., Wiener, M.,
-& Fox, P. (2012). Minimizing within-experiment and within-group effects in
-Activation Likelihood Estimation meta-analyses. Human Brain Mapping,
-33(1), 1–13.
+-   Eickhoff, S. B., Bzdok, D., Laird, A. R., Kurth, F., & Fox, P. T. (2012).
+    Activation likelihood estimation meta-analysis revisited. NeuroImage,
+    59(3), 2349-2361.
+-   Eickhoff, S. B., Jbabdi, S., Caspers, S., Laird, A. R., Fox, P. T., Zilles,
+    K., & Behrens, T. E. (2010). Anatomical and functional connectivity of
+    cytoarchitectonic areas within the human parietal operculum. Journal of
+    Neuroscience, 30(18), 6409-6421.
+-   Fonov, V., Evans, A. C., Botteron, K., Almli, C. R., McKinstry, R. C.,
+    Collins, D. L., & Brain Development Cooperative Group. (2011).
+    Unbiased average age-appropriate atlases for pediatric studies.
+    Neuroimage, 54(1), 313-327.
+-   Fonov, V. S., Evans, A. C., McKinstry, R. C., Almli, C. R., & Collins, D. L.
+    (2009). Unbiased nonlinear average age-appropriate brain templates from birth
+    to adulthood. NeuroImage, (47), S102.
+-   Laird, A. R., Eickhoff, S. B., Li, K., Robin, D. A., Glahn, D. C., &
+    Fox, P. T. (2009). Investigating the functional heterogeneity of the default
+    mode network using coordinate-based meta-analytic modeling. The Journal of
+    Neuroscience: The Official Journal of the Society for Neuroscience, 29(46),
+    14496-14505.
+-   Robinson, J. L., Laird, A. R., Glahn, D. C., Lovallo, W. R., & Fox, P. T.
+    (2009). Metaanalytic connectivity modeling: Delineating the functional
+    connectivity of the human amygdala. Human Brain Mapping, 31(2), 173-184.
+-   Turkeltaub, P. E., Eden, G. F., Jones, K. M., & Zeffiro, T. A. (2002).
+    Meta-analysis of the functional neuroanatomy of single-word reading: method
+    and validation. NeuroImage, 16(3 Pt 1), 765-780.
+-   Turkeltaub, P. E., Eickhoff, S. B., Laird, A. R., Fox, M., Wiener, M.,
+    & Fox, P. (2012). Minimizing within-experiment and within-group effects in
+    Activation Likelihood Estimation meta-analyses. Human Brain Mapping,
+    33(1), 1-13.
+-   Salo et al. (2022). NiMARE: Neuroimaging Meta-Analysis Research Environment.
+    NeuroLibre Reproducible Preprint Server, 1(1), 7, https://doi.org/10.55458/neurolibre.00007.
+-   Salo, Taylor, Yarkoni, Tal, Nichols, Thomas E., Poline, Jean-Baptiste, Kent, James D.,
+    Gorgolewski, Krzysztof J., Glerean, Enrico, Bottenhorn, Katherine L., Bilgel, Murat,
+    Wright, Jessey, Reeders, Puck, Kimbler, Adam, Nielson, Dylan N., Yanes, Julio A.,
+    Pérez, Alexandre, Oudyk, Kendra M., Jarecka, Dorota, Enge, Alexander,
+    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {__version__}
+    ({__version__}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
+    **NOTE** Please replace this with the version-specific Zenodo reference in your manuscript.
     """
 
     LGR.info("Performing meta-analysis...")

--- a/nimare/workflows/scale.py
+++ b/nimare/workflows/scale.py
@@ -6,6 +6,7 @@ from shutil import copyfile
 
 import numpy as np
 
+from nimare import __version__
 from nimare.dataset import Dataset
 from nimare.io import convert_sleuth_to_dataset
 from nimare.meta import SCALE
@@ -38,7 +39,7 @@ def scale_workflow(
 
     boilerplate = """
 A specific coactivation likelihood estimation (SCALE; Langner et al., 2014)
-meta-analysis was performed using NiMARE {__version__}
+meta-analysis was performed using NiMARE {version}
 (RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b).
 The input dataset included {n} studies/experiments.
 
@@ -56,8 +57,8 @@ References
     Gorgolewski, Krzysztof J., Glerean, Enrico, Bottenhorn, Katherine L., Bilgel, Murat,
     Wright, Jessey, Reeders, Puck, Kimbler, Adam, Nielson, Dylan N., Yanes, Julio A.,
     Pérez, Alexandre, Oudyk, Kendra M., Jarecka, Dorota, Enge, Alexander,
-    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {__version__}
-    ({__version__}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
+    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {version}
+    ({version}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
     **NOTE** Please replace this with the version-specific Zenodo reference in your manuscript.
     """
     boilerplate = boilerplate.format(
@@ -65,6 +66,7 @@ References
         thr=v_thr,
         bl=baseline if baseline else "a gray matter template",
         n_iters=n_iters,
+        version=__version__,
     )
 
     # At the moment, the baseline file should be an n_coords X 3 list of matrix

--- a/nimare/workflows/scale.py
+++ b/nimare/workflows/scale.py
@@ -38,17 +38,27 @@ def scale_workflow(
 
     boilerplate = """
 A specific coactivation likelihood estimation (SCALE; Langner et al., 2014)
-meta-analysis was performed using NiMARE. The input dataset included {n}
-studies/experiments.
+meta-analysis was performed using NiMARE {__version__}
+(RRID:SCR_017398; Salo et al., 2022a; Salo et al., 2022b).
+The input dataset included {n} studies/experiments.
 
 Voxel-specific null distributions were generated using base rates from {bl}
 with {n_iters} iterations. Results were thresholded at p < {thr}.
 
 References
 ----------
-- Langner, R., Rottschy, C., Laird, A. R., Fox, P. T., & Eickhoff, S. B. (2014).
-Meta-analytic connectivity modeling revisited: controlling for activation base
-rates. NeuroImage, 99, 559-570.
+-   Langner, R., Rottschy, C., Laird, A. R., Fox, P. T., & Eickhoff, S. B. (2014).
+    Meta-analytic connectivity modeling revisited: controlling for activation base
+    rates. NeuroImage, 99, 559-570.
+-   Salo et al. (2022). NiMARE: Neuroimaging Meta-Analysis Research Environment.
+    NeuroLibre Reproducible Preprint Server, 1(1), 7, https://doi.org/10.55458/neurolibre.00007.
+-   Salo, Taylor, Yarkoni, Tal, Nichols, Thomas E., Poline, Jean-Baptiste, Kent, James D.,
+    Gorgolewski, Krzysztof J., Glerean, Enrico, Bottenhorn, Katherine L., Bilgel, Murat,
+    Wright, Jessey, Reeders, Puck, Kimbler, Adam, Nielson, Dylan N., Yanes, Julio A.,
+    Pérez, Alexandre, Oudyk, Kendra M., Jarecka, Dorota, Enge, Alexander,
+    Peraza, Julio A., ... Laird, Angela R. (2022). neurostuff/NiMARE: {__version__}
+    ({__version__}). Zenodo. https://doi.org/10.5281/zenodo.6642243.
+    **NOTE** Please replace this with the version-specific Zenodo reference in your manuscript.
     """
     boilerplate = boilerplate.format(
         n=len(dset.ids),

--- a/nimare/workflows/scale.py
+++ b/nimare/workflows/scale.py
@@ -6,7 +6,6 @@ from shutil import copyfile
 
 import numpy as np
 
-from nimare import __version__
 from nimare.dataset import Dataset
 from nimare.io import convert_sleuth_to_dataset
 from nimare.meta import SCALE
@@ -30,6 +29,8 @@ def scale_workflow(
     --------
     This method is not yet implemented.
     """
+    from nimare import __version__
+
     if dataset_file.endswith(".json"):
         dset = Dataset(dataset_file, target="mni152_2mm")
     elif dataset_file.endswith(".txt"):


### PR DESCRIPTION
Closes #710.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Create sections on citing NiMARE to `README.md` and `docs/index.rst`.
- Add Zenodo and NeuroLibre references to workflow boilerplates.
    - The Zenodo one is for 0.0.12rc7, but I added a note about grabbing the appropriate version's DOI.
    - The conperm boilerplate is no longer accurate since we switched to using nilearn.
- I didn't add duecredit citations for the DOIs, but given #694, I don't know if it's worth it.
- Add the NeuroLibre badge as well.
