### PR TITLE
Pin minimum version of pandas

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     nilearn>=0.7.1
     numba  # used by sparse
     numpy
-    pandas
+    pandas>=1.1.0
     pymare~=0.0.4rc2  # nimare.meta.ibma and stats
     requests  # nimare.extract
     scikit-learn  # nimare.annotate and nimare.decode


### PR DESCRIPTION
using pandas 1.0.3, and 1.0.4 throw errors, but 1.1.0 does not when assigning values to columns that do not yet exist in a pandas dataframe: 
(this line)
https://github.com/neurostuff/NiMARE/blob/cb542af17c4f969afd05e4fd381a1200a1e4817c/nimare/meta/cbma/base.py#L127

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- make minimal pandas version 1.1.0
-
