### PR TITLE
Use sparse array in ALE, ALESubtraction, SCALE, KDA, and MKDADensity

### DIFF
--- a/nimare/generate.py
+++ b/nimare/generate.py
@@ -267,7 +267,7 @@ def _create_foci(foci, foci_percentage, fwhm, n_studies, n_noise_foci, rng, spac
     # create a probability map for each peak
     kernel = get_ale_kernel(template_img, fwhm)[1]
     foci_prob_maps = {
-        tuple(peak): compute_ale_ma(template_data, np.atleast_2d(peak), kernel).reshape(
+        tuple(peak): compute_ale_ma(template_data, np.atleast_2d(peak), kernels=kernel).reshape(
             template_data.shape
         )
         for peak in ground_truth_foci_ijks

--- a/nimare/generate.py
+++ b/nimare/generate.py
@@ -267,7 +267,7 @@ def _create_foci(foci, foci_percentage, fwhm, n_studies, n_noise_foci, rng, spac
     # create a probability map for each peak
     kernel = get_ale_kernel(template_img, fwhm)[1]
     foci_prob_maps = {
-        tuple(peak): compute_ale_ma(template_data, np.atleast_2d(peak), kernels=kernel).reshape(
+        tuple(peak): compute_ale_ma(template_img, np.atleast_2d(peak), kernels=kernel).reshape(
             template_data.shape
         )
         for peak in ground_truth_foci_ijks

--- a/nimare/generate.py
+++ b/nimare/generate.py
@@ -267,7 +267,7 @@ def _create_foci(foci, foci_percentage, fwhm, n_studies, n_noise_foci, rng, spac
     # create a probability map for each peak
     kernel = get_ale_kernel(template_img, fwhm)[1]
     foci_prob_maps = {
-        tuple(peak): compute_ale_ma(template_img, np.atleast_2d(peak), kernels=kernel).reshape(
+        tuple(peak): compute_ale_ma(template_img, np.atleast_2d(peak), kernel=kernel).reshape(
             template_data.shape
         )
         for peak in ground_truth_foci_ijks

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -383,13 +383,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
         n_voxels = diff_ale_values.shape[0]
 
         # Combine the MA maps into a single array to draw from for null distribution
-        if isinstance(ma_maps1, sparse._coo.core.COO) and isinstance(
-            ma_maps2, sparse._coo.core.COO
-        ):
-            ma_arr = sparse.concatenate((ma_maps1, ma_maps2))
-        else:
-            # For ma_map_reuse
-            ma_arr = np.vstack((ma_maps1, ma_maps2))
+        ma_arr = sparse.concatenate((ma_maps1, ma_maps2))
 
         del ma_maps1, ma_maps2
 

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -162,7 +162,7 @@ class ALE(CBMAEstimator):
             stat_values = stat_values[mask_data.reshape(-1)]
 
             # This is used by _compute_null_approximate
-            self.n_mask_voxels = stat_values.shape[0]
+            self.__n_mask_voxels = stat_values.shape[0]
 
         return stat_values
 

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -243,7 +243,7 @@ class ALE(CBMAEstimator):
             n_mask_voxels = np.count_nonzero(mask_data)
 
             n_exp = ma_values.shape[0]
-            n_bins = bin_edges.shape[0] - 1
+            n_bins = bin_centers.shape[0]
             ma_hists = np.zeros((n_exp, n_bins))
             data = ma_values.data
             coords = ma_values.coords

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -179,7 +179,7 @@ class ALE(CBMAEstimator):
         """
         if isinstance(ma_maps, list):
             ma_values = self.masker.transform(ma_maps)
-        elif isinstance(ma_maps, sparse._coo.core.COO):
+        elif isinstance(ma_maps, (np.ndarray, sparse._coo.core.COO)):
             ma_values = ma_maps
         else:
             raise ValueError(f"Unsupported data type '{type(ma_maps)}'")
@@ -189,7 +189,11 @@ class ALE(CBMAEstimator):
         # Assuming values of 0, .001, .002, etc., bins are -.0005-.0005, .0005-.0015, etc.
         INV_STEP_SIZE = 100000
         step_size = 1 / INV_STEP_SIZE
-        max_ma_values = ma_values.max(axis=[1, 2, 3]).todense()
+        if isinstance(ma_values, sparse._coo.core.COO):
+            # Need to convert to dense because np.ceil is too slow with sparse
+            max_ma_values = ma_values.max(axis=[1, 2, 3]).todense()
+        else:
+            max_ma_values = np.max(ma_values, axis=1)
 
         # round up based on resolution
         max_ma_values = np.ceil(max_ma_values * INV_STEP_SIZE) / INV_STEP_SIZE
@@ -215,12 +219,16 @@ class ALE(CBMAEstimator):
         """
         if isinstance(ma_maps, list):
             ma_values = self.masker.transform(ma_maps)
-        elif isinstance(ma_maps, sparse._coo.core.COO):
+        elif isinstance(ma_maps, (np.ndarray, sparse._coo.core.COO)):
             ma_values = ma_maps
         else:
             raise ValueError(f"Unsupported data type '{type(ma_maps)}'")
 
         assert "histogram_bins" in self.null_distributions_.keys()
+
+        def just_histogram(*args, **kwargs):
+            """Collect the first output (weights) from numpy histogram."""
+            return np.histogram(*args, **kwargs)[0].astype(float)
 
         # Derive bin edges from histogram bin centers for numpy histogram function
         bin_centers = self.null_distributions_["histogram_bins"]
@@ -229,22 +237,27 @@ class ALE(CBMAEstimator):
         bin_edges = bin_centers - (step_size / 2)
         bin_edges = np.append(bin_centers, bin_centers[-1] + step_size)
 
-        n_exp = ma_values.shape[0]
-        n_bins = bin_centers.shape[0]
-        ma_hists = np.zeros((n_exp, n_bins))
-        data = ma_values.data
-        coords = ma_values.coords
-        for exp_idx in range(n_exp):
-            # The first column of coords is the fourth dimension of the dense array
-            study_ma_values = data[coords[0, :] == exp_idx]
+        if isinstance(ma_values, sparse._coo.core.COO):
+            n_exp = ma_values.shape[0]
+            n_bins = bin_centers.shape[0]
+            ma_hists = np.zeros((n_exp, n_bins))
+            data = ma_values.data
+            coords = ma_values.coords
+            for exp_idx in range(n_exp):
+                # The first column of coords is the fourth dimension of the dense array
+                study_ma_values = data[coords[0, :] == exp_idx]
 
-            n_nonzero_voxels = study_ma_values.shape[0]
-            n_zero_voxels = self.n_mask_voxels - n_nonzero_voxels
+                n_nonzero_voxels = study_ma_values.shape[0]
+                n_zero_voxels = self.n_mask_voxels - n_nonzero_voxels
 
-            ma_hists[exp_idx, :] = np.histogram(study_ma_values, bins=bin_edges, density=False)[
-                0
-            ].astype(float)
-            ma_hists[exp_idx, 0] += n_zero_voxels
+                ma_hists[exp_idx, :] = np.histogram(
+                    study_ma_values, bins=bin_edges, density=False
+                )[0].astype(float)
+                ma_hists[exp_idx, 0] += n_zero_voxels
+        else:
+            ma_hists = np.apply_along_axis(
+                just_histogram, 1, ma_values, bins=bin_edges, density=False
+            )
 
         # Normalize MA histograms to get probabilities
         ma_hists /= ma_hists.sum(1)[:, None]

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -177,7 +177,6 @@ class ALE(CBMAEstimator):
         ----------
         ma_maps : :obj:`sparse._coo.core.COO`
             MA maps.
-            The ma_maps can be a 4d sparse array of MA maps,
 
         Notes
         -----
@@ -208,7 +207,6 @@ class ALE(CBMAEstimator):
         ----------
         ma_maps : :obj:`sparse._coo.core.COO`
             MA maps.
-            The ma_maps can be 4D sparse array of MA maps,
 
         Notes
         -----

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -248,6 +248,7 @@ class ALE(CBMAEstimator):
             data = ma_values.data
             coords = ma_values.coords
             for exp_idx in range(n_exp):
+                # The first column of coords is the fourth dimension of the dense array
                 study_ma_values = data[coords[0, :] == exp_idx]
 
                 n_nonzero_voxels = study_ma_values.shape[0]

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -384,10 +384,12 @@ class ALESubtraction(PairwiseCBMAEstimator):
         ma_maps1 = self._collect_ma_maps(
             maps_key="ma_maps1",
             coords_key="coordinates1",
+            return_type="array",
         )
         ma_maps2 = self._collect_ma_maps(
             maps_key="ma_maps2",
             coords_key="coordinates2",
+            return_type="array",
         )
 
         n_grp1, n_voxels = ma_maps1.shape

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -155,8 +155,8 @@ class ALE(CBMAEstimator):
 
         # np.array type is used by _determine_histogram_bins to calculate max_poss_ale
         if isinstance(stat_values, sparse._coo.core.COO):
-            masker = self.dataset.masker if not self.masker else self.masker
-            mask_data = masker.mask_img.get_fdata().astype(bool)
+            # NOTE: This may not work correctly with a non-NiftiMasker.
+            mask_data = self.masker.mask_img.get_fdata().astype(bool)
 
             stat_values = stat_values.todense().reshape(-1)  # Indexing a .reshape(-1) is faster
             stat_values = stat_values[mask_data.reshape(-1)]
@@ -171,7 +171,12 @@ class ALE(CBMAEstimator):
 
         Parameters
         ----------
-        ma_maps
+        ma_maps : list of imgs, numpy.ndarray or sparse._coo.core.COO
+            MA maps.
+            The ma_maps can be:
+            (1) a list of imgs containing MA values
+            (2) a 1d contrast-len or 2d contrast-by-voxel array of MA values,
+            or (3) a 4d sparse array of MA maps,
 
         Notes
         -----
@@ -207,8 +212,12 @@ class ALE(CBMAEstimator):
 
         Parameters
         ----------
-        ma_maps : list of imgs or numpy.ndarray
+        ma_maps : list of imgs, numpy.ndarray or sparse._coo.core.COO
             MA maps.
+            The ma_maps can be:
+            (1) a list of imgs containing MA values
+            (2) a 1d contrast-len or 2d contrast-by-voxel array of MA values,
+            or (3) a 4d sparse array of MA maps,
 
         Notes
         -----
@@ -248,7 +257,7 @@ class ALE(CBMAEstimator):
                 study_ma_values = data[coords[0, :] == exp_idx]
 
                 n_nonzero_voxels = study_ma_values.shape[0]
-                n_zero_voxels = self.n_mask_voxels - n_nonzero_voxels
+                n_zero_voxels = self.__n_mask_voxels - n_nonzero_voxels
 
                 ma_hists[exp_idx, :] = np.histogram(
                     study_ma_values, bins=bin_edges, density=False
@@ -465,6 +474,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
         stat_values = 1.0 - np.prod(1.0 - ma_values, axis=0)
 
         if isinstance(stat_values, sparse._coo.core.COO):
+            # NOTE: This may not work correctly with a non-NiftiMasker.
             mask_data = self.masker.mask_img.get_fdata().astype(bool)
 
             stat_values = stat_values.todense().reshape(-1)  # Indexing a .reshape(-1) is faster
@@ -689,6 +699,7 @@ class SCALE(CBMAEstimator):
         stat_values = 1.0 - np.prod(1.0 - ma_values, axis=0)
 
         if isinstance(stat_values, sparse._coo.core.COO):
+            # NOTE: This may not work correctly with a non-NiftiMasker.
             mask_data = self.masker.mask_img.get_fdata().astype(bool)
 
             stat_values = stat_values.todense().reshape(-1)  # Indexing a .reshape(-1) is faster

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -34,6 +34,10 @@ LGR = logging.getLogger(__name__)
 class ALE(CBMAEstimator):
     """Activation likelihood estimation.
 
+    .. versionchanged:: 0.0.12
+
+        - Use a 4D sparse array for modeled activation maps.
+
     Parameters
     ----------
     kernel_transformer : :obj:`~nimare.meta.kernel.KernelTransformer`, optional
@@ -279,6 +283,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
         - Use memmapped array for null distribution and remove ``memory_limit`` parameter.
         - Support parallelization and add progress bar.
         - Add ALE-difference (stat) and -log10(p) (logp) maps to results.
+        - Use a 4D sparse array for modeled activation maps.
 
     .. versionchanged:: 0.0.8
 
@@ -510,6 +515,7 @@ class SCALE(CBMAEstimator):
 
         - Remove unused parameters ``voxel_thresh`` and ``memory_limit``.
         - Use memmapped array for null distribution.
+        - Use a 4D sparse array for modeled activation maps.
 
     .. versionchanged:: 0.0.10
 

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -238,9 +238,7 @@ class ALE(CBMAEstimator):
 
         if isinstance(ma_values, sparse._coo.core.COO):
             masker = self.dataset.masker if not self.masker else self.masker
-            mask = masker.mask_img
-            mask_data = mask.get_fdata().astype(bool)
-            n_mask_voxels = np.count_nonzero(mask_data)
+            n_mask_voxels = np.count_nonzero(masker.mask_img.get_fdata().astype(bool))
 
             n_exp = ma_values.shape[0]
             n_bins = bin_centers.shape[0]

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -621,6 +621,7 @@ class SCALE(CBMAEstimator):
         ma_values = self._collect_ma_maps(
             coords_key="coordinates",
             maps_key="ma_maps",
+            return_type="array",
         )
 
         # Determine bins for null distribution histogram

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -171,12 +171,11 @@ class ALE(CBMAEstimator):
 
         Parameters
         ----------
-        ma_maps : list of imgs, numpy.ndarray or sparse._coo.core.COO
+        ma_maps : list of imgs or sparse._coo.core.COO
             MA maps.
             The ma_maps can be:
             (1) a list of imgs containing MA values
-            (2) a 1d contrast-len or 2d contrast-by-voxel array of MA values,
-            or (3) a 4d sparse array of MA maps,
+            or (2) a 4d sparse array of MA maps,
 
         Notes
         -----
@@ -184,7 +183,7 @@ class ALE(CBMAEstimator):
         """
         if isinstance(ma_maps, list):
             ma_values = self.masker.transform(ma_maps)
-        elif isinstance(ma_maps, (np.ndarray, sparse._coo.core.COO)):
+        elif isinstance(ma_maps, sparse._coo.core.COO):
             ma_values = ma_maps
         else:
             raise ValueError(f"Unsupported data type '{type(ma_maps)}'")
@@ -194,11 +193,8 @@ class ALE(CBMAEstimator):
         # Assuming values of 0, .001, .002, etc., bins are -.0005-.0005, .0005-.0015, etc.
         INV_STEP_SIZE = 100000
         step_size = 1 / INV_STEP_SIZE
-        if isinstance(ma_values, sparse._coo.core.COO):
-            # Need to convert to dense because np.ceil is too slow with sparse
-            max_ma_values = ma_values.max(axis=[1, 2, 3]).todense()
-        else:
-            max_ma_values = np.max(ma_values, axis=1)
+        # Need to convert to dense because np.ceil is too slow with sparse
+        max_ma_values = ma_values.max(axis=[1, 2, 3]).todense()
 
         # round up based on resolution
         max_ma_values = np.ceil(max_ma_values * INV_STEP_SIZE) / INV_STEP_SIZE
@@ -212,12 +208,11 @@ class ALE(CBMAEstimator):
 
         Parameters
         ----------
-        ma_maps : list of imgs, numpy.ndarray or sparse._coo.core.COO
+        ma_maps : list of imgs or sparse._coo.core.COO
             MA maps.
             The ma_maps can be:
             (1) a list of imgs containing MA values
-            (2) a 1d contrast-len or 2d contrast-by-voxel array of MA values,
-            or (3) a 4d sparse array of MA maps,
+            or (2) a 4d sparse array of MA maps,
 
         Notes
         -----
@@ -228,16 +223,12 @@ class ALE(CBMAEstimator):
         """
         if isinstance(ma_maps, list):
             ma_values = self.masker.transform(ma_maps)
-        elif isinstance(ma_maps, (np.ndarray, sparse._coo.core.COO)):
+        elif isinstance(ma_maps, sparse._coo.core.COO):
             ma_values = ma_maps
         else:
             raise ValueError(f"Unsupported data type '{type(ma_maps)}'")
 
         assert "histogram_bins" in self.null_distributions_.keys()
-
-        def just_histogram(*args, **kwargs):
-            """Collect the first output (weights) from numpy histogram."""
-            return np.histogram(*args, **kwargs)[0].astype(float)
 
         # Derive bin edges from histogram bin centers for numpy histogram function
         bin_centers = self.null_distributions_["histogram_bins"]
@@ -246,27 +237,22 @@ class ALE(CBMAEstimator):
         bin_edges = bin_centers - (step_size / 2)
         bin_edges = np.append(bin_centers, bin_centers[-1] + step_size)
 
-        if isinstance(ma_values, sparse._coo.core.COO):
-            n_exp = ma_values.shape[0]
-            n_bins = bin_centers.shape[0]
-            ma_hists = np.zeros((n_exp, n_bins))
-            data = ma_values.data
-            coords = ma_values.coords
-            for exp_idx in range(n_exp):
-                # The first column of coords is the fourth dimension of the dense array
-                study_ma_values = data[coords[0, :] == exp_idx]
+        n_exp = ma_values.shape[0]
+        n_bins = bin_centers.shape[0]
+        ma_hists = np.zeros((n_exp, n_bins))
+        data = ma_values.data
+        coords = ma_values.coords
+        for exp_idx in range(n_exp):
+            # The first column of coords is the fourth dimension of the dense array
+            study_ma_values = data[coords[0, :] == exp_idx]
 
-                n_nonzero_voxels = study_ma_values.shape[0]
-                n_zero_voxels = self.__n_mask_voxels - n_nonzero_voxels
+            n_nonzero_voxels = study_ma_values.shape[0]
+            n_zero_voxels = self.__n_mask_voxels - n_nonzero_voxels
 
-                ma_hists[exp_idx, :] = np.histogram(
-                    study_ma_values, bins=bin_edges, density=False
-                )[0].astype(float)
-                ma_hists[exp_idx, 0] += n_zero_voxels
-        else:
-            ma_hists = np.apply_along_axis(
-                just_histogram, 1, ma_values, bins=bin_edges, density=False
-            )
+            ma_hists[exp_idx, :] = np.histogram(study_ma_values, bins=bin_edges, density=False)[
+                0
+            ].astype(float)
+            ma_hists[exp_idx, 0] += n_zero_voxels
 
         # Normalize MA histograms to get probabilities
         ma_hists /= ma_hists.sum(1)[:, None]

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -104,12 +104,6 @@ class CBMAEstimator(Estimator):
         """
         masker = self.masker or dataset.masker
 
-        if not isinstance(masker, NiftiMasker):
-            raise ValueError(
-                f"A {type(masker)} mask has been detected. "
-                "Only NiftiMaskers are allowed for this Estimator."
-            )
-
         mask_img = masker.mask_img or masker.labels_img
         if isinstance(mask_img, str):
             mask_img = nib.load(mask_img)
@@ -159,6 +153,13 @@ class CBMAEstimator(Estimator):
         """
         self.dataset = dataset
         self.masker = self.masker or dataset.masker
+
+        if not isinstance(self.masker, NiftiMasker):
+            raise ValueError(
+                f"A {type(self.masker)} mask has been detected. "
+                "Only NiftiMaskers are allowed for this Estimator."
+            )
+
         self.null_distributions_ = {}
 
         ma_values = self._collect_ma_maps(

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -6,6 +6,7 @@ from hashlib import md5
 import nibabel as nib
 import numpy as np
 import pandas as pd
+import sparse
 from joblib import Parallel, delayed
 from scipy import ndimage
 from tqdm.auto import tqdm
@@ -156,6 +157,7 @@ class CBMAEstimator(Estimator):
         ma_values = self._collect_ma_maps(
             coords_key="coordinates",
             maps_key="ma_maps",
+            return_type="sparse",
         )
 
         # Infer a weight vector, when applicable. Primarily used only for MKDADensity.
@@ -253,6 +255,8 @@ class CBMAEstimator(Estimator):
         elif isinstance(data, list):
             ma_values = self.masker.transform(data)
         elif isinstance(data, np.ndarray):
+            ma_values = data
+        elif isinstance(data, sparse._coo.core.COO):
             ma_values = data
         elif not isinstance(data, np.ndarray):
             raise ValueError(f"Unsupported data type '{type(data)}'")

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -190,7 +190,7 @@ class CBMAEstimator(Estimator):
         """
         return None
 
-    def _collect_ma_maps(self, coords_key="coordinates", maps_key="ma_maps", return_type="sparse"):
+    def _collect_ma_maps(self, coords_key="coordinates", maps_key="ma_maps"):
         """Collect modeled activation maps from Estimator inputs.
 
         Parameters
@@ -207,8 +207,10 @@ class CBMAEstimator(Estimator):
 
         Returns
         -------
-        ma_maps : :obj:`sparse._coo.core.COO`
-            4D sparse array of shape (n_studies, mask.shape) with MA maps.
+        ma_maps : :obj:`numpy.ndarray`, or :obj:`sparse._coo.core.COO`
+            Return a 2D numpy array of shape (n_studies, n_voxels) with MA values,
+            if pre-generated MA maps exist. Otherwise, a 4D sparse array of shape
+            (n_studies, mask.shape) with MA maps is returned.
         """
         if maps_key in self.inputs_.keys():
             LGR.debug(f"Loading pre-generated MA maps ({maps_key}).")
@@ -220,7 +222,7 @@ class CBMAEstimator(Estimator):
             ma_maps = self.kernel_transformer.transform(
                 self.inputs_[coords_key],
                 masker=self.masker,
-                return_type=return_type,
+                return_type="sparse",
             )
 
         return ma_maps

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -39,6 +39,7 @@ class CBMAEstimator(Estimator):
         * Remove *low_memory* option
         * CBMA-specific elements of ``MetaEstimator`` excised and moved into ``CBMAEstimator``.
         * Generic kwargs and args converted to named kwargs. All remaining kwargs are for kernels.
+        * Use a 4D sparse array for modeled activation maps.
 
     .. versionchanged:: 0.0.8
 
@@ -835,6 +836,10 @@ class CBMAEstimator(Estimator):
 
 class PairwiseCBMAEstimator(CBMAEstimator):
     """Base class for pairwise coordinate-based meta-analysis methods.
+
+    .. versionchanged:: 0.0.12
+
+        - Use a 4D sparse array for modeled activation maps.
 
     .. versionchanged:: 0.0.8
 

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -558,7 +558,7 @@ class CBMAEstimator(Estimator):
         iter_df[["x", "y", "z"]] = iter_xyz
 
         iter_ma_maps = self.kernel_transformer.transform(
-            iter_df, masker=self.masker, return_type="array"
+            iter_df, masker=self.masker, return_type="sparse"
         )
         iter_ss_map = self._compute_summarystat(iter_ma_maps)
 

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -69,12 +69,6 @@ class CBMAEstimator(Estimator):
             mask = get_masker(mask)
         self.masker = mask
 
-        if not isinstance(self.masker, NiftiMasker):
-            raise ValueError(
-                f"A {type(self.masker)} mask has been detected. "
-                "Only NiftiMaskers are allowed for this Estimator."
-            )
-
         # Identify any kwargs
         kernel_args = {k: v for k, v in kwargs.items() if k.startswith("kernel__")}
 
@@ -109,6 +103,12 @@ class CBMAEstimator(Estimator):
             and (3) sample sizes may be added to the "coordinates" key, as needed.
         """
         masker = self.masker or dataset.masker
+
+        if not isinstance(masker, NiftiMasker):
+            raise ValueError(
+                f"A {type(masker)} mask has been detected. "
+                "Only NiftiMaskers are allowed for this Estimator."
+            )
 
         mask_img = masker.mask_img or masker.labels_img
         if isinstance(mask_img, str):

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -414,6 +414,14 @@ class CBMAEstimator(Estimator):
         --------
         This method is only retained for testing and algorithm development.
         """
+        if isinstance(ma_maps, sparse._coo.core.COO):
+            masker = self.dataset.masker if not self.masker else self.masker
+            mask = masker.mask_img
+            mask_data = mask.get_fdata().astype(bool)
+
+            ma_maps = ma_maps.todense()
+            ma_maps = ma_maps[:, mask_data]
+
         n_studies, n_voxels = ma_maps.shape
         null_ijk = np.random.choice(np.arange(n_voxels), (n_iters, n_studies))
         iter_ma_values = ma_maps[np.arange(n_studies), tuple(null_ijk)].T

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 import sparse
 from joblib import Parallel, delayed
+from nilearn.input_data import NiftiMasker
 from scipy import ndimage
 from tqdm.auto import tqdm
 
@@ -67,6 +68,12 @@ class CBMAEstimator(Estimator):
         if mask is not None:
             mask = get_masker(mask)
         self.masker = mask
+
+        if not isinstance(self.masker, NiftiMasker):
+            raise ValueError(
+                f"A {type(self.masker)} mask has been detected. "
+                "Only NiftiMaskers are allowed for this Estimator."
+            )
 
         # Identify any kwargs
         kernel_args = {k: v for k, v in kwargs.items() if k.startswith("kernel__")}
@@ -215,7 +222,6 @@ class CBMAEstimator(Estimator):
         if maps_key in self.inputs_.keys():
             LGR.debug(f"Loading pre-generated MA maps ({maps_key}).")
             ma_maps = self.masker.transform(self.inputs_[maps_key])
-
         else:
             LGR.debug(f"Generating MA maps from coordinates ({coords_key}).")
 

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -252,7 +252,7 @@ class CBMAEstimator(Estimator):
         """
         if isinstance(data, pd.DataFrame):
             ma_values = self.kernel_transformer.transform(
-                data, masker=self.masker, return_type="array"
+                data, masker=self.masker, return_type="sparse"
             )
         elif isinstance(data, list):
             ma_values = self.masker.transform(data)
@@ -452,7 +452,7 @@ class CBMAEstimator(Estimator):
         iter_df[["x", "y", "z"]] = iter_xyz
 
         iter_ma_maps = self.kernel_transformer.transform(
-            iter_df, masker=self.masker, return_type="array"
+            iter_df, masker=self.masker, return_type="sparse"
         )
         iter_ss_map = self._compute_summarystat(iter_ma_maps)
 

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -500,7 +500,6 @@ class MKDAChi2(PairwiseCBMAEstimator):
             n_selected_active_voxels = n_selected_active_voxels[mask_data.reshape(-1)]
 
         del temp_ma_maps1
-        gc.collect()
 
         # Generate MA maps and calculate count variables for second dataset
         temp_ma_maps2 = self.kernel_transformer.transform(
@@ -513,7 +512,6 @@ class MKDAChi2(PairwiseCBMAEstimator):
             n_unselected_active_voxels = n_unselected_active_voxels[mask_data.reshape(-1)]
 
         del temp_ma_maps2
-        gc.collect()
 
         # Currently unused conditional probabilities
         # pAgF = n_selected_active_voxels / n_selected

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -28,6 +28,10 @@ class MKDADensity(CBMAEstimator):
 
     The MKDA density method was originally introduced in :footcite:t:`wager2007meta`.
 
+    .. versionchanged:: 0.0.12
+
+        - Use a 4D sparse array for modeled activation maps.
+
     Parameters
     ----------
     kernel_transformer : :obj:`~nimare.meta.kernel.KernelTransformer`, optional
@@ -247,6 +251,10 @@ class MKDAChi2(PairwiseCBMAEstimator):
     r"""Multilevel kernel density analysis- Chi-square analysis.
 
     The MKDA chi-square method was originally introduced in :footcite:t:`wager2007meta`.
+
+    .. versionchanged:: 0.0.12
+
+        - Use a 4D sparse array for modeled activation maps.
 
     .. versionchanged:: 0.0.8
 
@@ -935,6 +943,10 @@ class MKDAChi2(PairwiseCBMAEstimator):
 @due.dcite(references.KDA2, description="Also introduces the KDA algorithm.")
 class KDA(CBMAEstimator):
     r"""Kernel density analysis.
+
+    .. versionchanged:: 0.0.12
+
+        - Use a 4D sparse array for modeled activation maps.
 
     Parameters
     ----------

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -1,5 +1,4 @@
 """CBMA methods from the multilevel kernel density analysis (MKDA) family."""
-import gc
 import logging
 
 import nibabel as nib

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -82,6 +82,7 @@ class MKDADensity(CBMAEstimator):
 
         If ``null_method == "approximate"``:
 
+            -   ``histogram_means``: Array of mean value per experiment.
             -   ``histogram_bins``: Array of bin centers for the null distribution histogram,
                 ranging from zero to the maximum possible summary statistic value for the Dataset.
             -   ``histweights_corr-none_method-approximate``: Array of weights for the null
@@ -196,7 +197,8 @@ class MKDADensity(CBMAEstimator):
 
         Notes
         -----
-        This method adds one entry to the null_distributions_ dict attribute: "histogram_bins".
+        This method adds two entries to the null_distributions_ dict attribute: "histogram_bins",
+        and "histogram_means" only if ``null_method == "approximate"``.
         """
         if not isinstance(ma_maps, sparse._coo.core.COO):
             raise ValueError(f"Unsupported data type '{type(ma_maps)}'")
@@ -215,8 +217,10 @@ class MKDADensity(CBMAEstimator):
             prop_active[exp_idx] = np.mean(np.hstack([study_ma_values, np.zeros(n_zero_voxels)]))
 
         self.null_distributions_["histogram_bins"] = np.arange(len(prop_active) + 1, step=1)
-        # To speed things up in _compute_null_approximate, we save the means too,
-        self.null_distributions_["histogram_means"] = prop_active
+
+        if self.null_method.startswith("approximate"):
+            # To speed things up in _compute_null_approximate, we save the means too,
+            self.null_distributions_["histogram_means"] = prop_active
 
     def _compute_null_approximate(self, ma_maps):
         """Compute uncorrected null distribution using approximate solution.
@@ -228,8 +232,7 @@ class MKDADensity(CBMAEstimator):
 
         Notes
         -----
-        This method adds two entries to the null_distributions_ dict attribute:
-        "histogram_bins" and "histogram_weights".
+        This method adds one entry to the null_distributions_ dict attribute: "histogram_weights".
         """
         assert "histogram_means" in self.null_distributions_.keys()
 

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -341,7 +341,6 @@ class MKDAChi2(PairwiseCBMAEstimator):
         ma_maps1 = self._collect_ma_maps(
             maps_key="ma_maps1",
             coords_key="coordinates1",
-            return_type="sparse",
         )
         n_selected = ma_maps1.shape[0]
         n_selected_active_voxels = ma_maps1.sum(axis=0)
@@ -362,7 +361,6 @@ class MKDAChi2(PairwiseCBMAEstimator):
         ma_maps2 = self._collect_ma_maps(
             maps_key="ma_maps2",
             coords_key="coordinates2",
-            return_type="sparse",
         )
         n_unselected = ma_maps2.shape[0]
         n_unselected_active_voxels = ma_maps2.sum(axis=0)

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -186,7 +186,7 @@ class MKDADensity(CBMAEstimator):
 
         Parameters
         ----------
-        ma_maps : sparse._coo.core.COO
+        ma_maps : :obj:`sparse._coo.core.COO`
             MA maps.
             The ma_maps can be a 4d sparse array of MA maps,
 
@@ -1064,7 +1064,7 @@ class KDA(CBMAEstimator):
 
         Parameters
         ----------
-        ma_maps : numpy.ndarray or sparse._coo.core.COO
+        ma_maps : :obj:`numpy.ndarray` or :obj:`sparse._coo.core.COO`
             MA maps.
             The ma_maps can be:
             (1) a 1d contrast-len or 2d contrast-by-voxel array of MA values,
@@ -1098,7 +1098,7 @@ class KDA(CBMAEstimator):
 
         Parameters
         ----------
-        ma_maps : sparse._coo.core.COO
+        ma_maps : :obj:`sparse._coo.core.COO`
             MA maps.
             The ma_maps can be a 4d sparse array of MA maps,
 
@@ -1153,7 +1153,7 @@ class KDA(CBMAEstimator):
 
         Parameters
         ----------
-        ma_maps : imgs or sparse._coo.core.COO
+        ma_maps : :obj:`sparse._coo.core.COO`
             MA maps.
             The ma_maps can be a 4d sparse array of MA maps,
 

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -168,12 +168,16 @@ class MKDADensity(CBMAEstimator):
         ma_values = ma_values.reshape((ma_values.shape[0], -1))
         stat_values = ma_values.T.dot(self.weight_vec_)
 
-        # NOTE: This may not work correctly with a non-NiftiMasker.
-        mask_data = self.masker.mask_img.get_fdata().astype(bool)
+        if isinstance(ma_values, sparse._coo.core.COO):
+            # NOTE: This may not work correctly with a non-NiftiMasker.
+            mask_data = self.masker.mask_img.get_fdata().astype(bool)
 
-        stat_values = stat_values[mask_data.reshape(-1)].ravel()
-        # This is used by _compute_null_approximate
-        self.__n_mask_voxels = stat_values.shape[0]
+            stat_values = stat_values[mask_data.reshape(-1)].ravel()
+            # This is used by _compute_null_approximate
+            self.__n_mask_voxels = stat_values.shape[0]
+        else:
+            # np.array type is used by _compute_null_reduced_montecarlo
+            stat_values = stat_values.ravel()
 
         return stat_values
 

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -1112,7 +1112,6 @@ class KDA(CBMAEstimator):
         ----------
         ma_maps : :obj:`sparse._coo.core.COO`
             MA maps.
-            The ma_maps can be a 4d sparse array of MA maps,
 
         Notes
         -----
@@ -1167,7 +1166,6 @@ class KDA(CBMAEstimator):
         ----------
         ma_maps : :obj:`sparse._coo.core.COO`
             MA maps.
-            The ma_maps can be a 4d sparse array of MA maps,
 
         Notes
         -----

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -217,8 +217,9 @@ class MKDADensity(CBMAEstimator):
         else:
             prop_active = ma_values.mean(1)
 
-        # This will be properly updated in _compute_null_approximate
-        self.null_distributions_["histogram_bins"] = prop_active
+        self.null_distributions_["histogram_bins"] = np.arange(len(prop_active) + 1, step=1)
+        # To speed things up in _compute_null_approximate, we save the means too,
+        self.null_distributions_["histogram_means"] = prop_active
 
     def _compute_null_approximate(self, ma_maps):
         """Compute uncorrected null distribution using approximate solution.
@@ -233,18 +234,18 @@ class MKDADensity(CBMAEstimator):
         This method adds two entries to the null_distributions_ dict attribute:
         "histogram_bins" and "histogram_weights".
         """
-        assert "histogram_bins" in self.null_distributions_.keys()
+        assert "histogram_means" in self.null_distributions_.keys()
 
         # MKDA maps are binary, so we only have k + 1 bins in the final
         # histogram, where k is the number of studies. We can analytically
         # compute the null distribution by convolution.
         # prop_active contains the mean value per experiment
-        prop_active = self.null_distributions_["histogram_bins"]
+        prop_active = self.null_distributions_["histogram_means"]
 
         ss_hist = 1.0
         for exp_prop in prop_active:
             ss_hist = np.convolve(ss_hist, [1 - exp_prop, exp_prop])
-        self.null_distributions_["histogram_bins"] = np.arange(len(prop_active) + 1, step=1)
+
         self.null_distributions_["histweights_corr-none_method-approximate"] = ss_hist
 
 

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -354,7 +354,6 @@ class MKDAChi2(PairwiseCBMAEstimator):
             n_selected_active_voxels = n_selected_active_voxels[mask_data.reshape(-1)]
 
         del ma_maps1
-        gc.collect()
 
         # Generate MA maps and calculate count variables for second dataset
         ma_maps2 = self._collect_ma_maps(
@@ -368,7 +367,6 @@ class MKDAChi2(PairwiseCBMAEstimator):
             n_unselected_active_voxels = n_unselected_active_voxels[mask_data.reshape(-1)]
 
         del ma_maps2
-        gc.collect()
 
         n_mappables = n_selected + n_unselected
 

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -315,6 +315,7 @@ class ALEKernel(KernelTransformer):
         exp_idx = coordinates["id"].values
 
         use_dict = True
+        kernels = None
         if self.sample_size is not None:
             sample_sizes = self.sample_size
             use_dict = False
@@ -330,7 +331,12 @@ class ALEKernel(KernelTransformer):
             kernels = {}  # retain kernels in dictionary to speed things up
 
         transformed = compute_ale_ma(
-            mask, ijks, kernels, exp_idx=exp_idx, sample_sizes=sample_sizes, use_dict=use_dict
+            mask,
+            ijks,
+            kernels=kernels,
+            exp_idx=exp_idx,
+            sample_sizes=sample_sizes,
+            use_dict=use_dict,
         )
 
         exp_ids = np.unique(exp_idx)

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -202,14 +202,13 @@ class KernelTransformer(NiMAREBase):
         if return_type == "sparse":
             return transformed_maps[0]
 
-        imgs = []
         # Loop over exp ids since sparse._coo.core.COO is not iterable
+        imgs = []
         for i_exp, id_ in enumerate(transformed_maps[1]):
-            # print(id_)
             if isinstance(transformed_maps[0][i_exp], sparse._coo.core.COO):
+                # This step is slow, but it is here just in case user want a
+                # return_type = "array", "image", or "dataset"
                 kernel_data = transformed_maps[0][i_exp].todense()
-            else:
-                kernel_data = transformed_maps[0][i_exp]
 
             if return_type == "array":
                 img = kernel_data[mask_data]

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -202,8 +202,8 @@ class KernelTransformer(NiMAREBase):
         if return_type == "sparse":
             return transformed_maps[0]
 
-        # Loop over exp ids since sparse._coo.core.COO is not iterable
         imgs = []
+        # Loop over exp ids since sparse._coo.core.COO is not iterable
         for i_exp, id_ in enumerate(transformed_maps[1]):
             if isinstance(transformed_maps[0][i_exp], sparse._coo.core.COO):
                 # This step is slow, but it is here just in case user want a
@@ -212,7 +212,6 @@ class KernelTransformer(NiMAREBase):
 
             if return_type == "array":
                 img = kernel_data[mask_data]
-                # print(img)
                 imgs.append(img)
             elif return_type == "image":
                 kernel_data *= mask_data
@@ -327,9 +326,6 @@ class ALEKernel(KernelTransformer):
             assert np.isfinite(self.fwhm), "FWHM must be finite number"
             _, kernels = get_ale_kernel(mask, fwhm=self.fwhm)
             use_dict = False
-
-        if use_dict:
-            kernels = {}  # retain kernels in dictionary to speed things up
 
         transformed = compute_ale_ma(
             mask,

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -329,7 +329,9 @@ class ALEKernel(KernelTransformer):
         if use_dict:
             kernels = {}  # retain kernels in dictionary to speed things up
 
-        transformed = compute_ale_ma(mask, ijks, exp_idx, sample_sizes, kernels, use_dict)
+        transformed = compute_ale_ma(
+            mask, ijks, kernels, exp_idx=exp_idx, sample_sizes=sample_sizes, use_dict=use_dict
+        )
 
         exp_ids = np.unique(exp_idx)
         return transformed, exp_ids

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -345,7 +345,7 @@ class KDAKernel(KernelTransformer):
 
     .. versionchanged:: 0.0.12
 
-        * Remove low-memory option for kernel transformers.
+        * Remove low-memory option in favor of sparse arrays for kernel transformers.
 
     Parameters
     ----------

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -319,8 +319,10 @@ class ALEKernel(KernelTransformer):
         if self.sample_size is not None:
             sample_sizes = self.sample_size
             use_dict = False
-        else:
+        elif self.fwhm is None:
             sample_sizes = coordinates["sample_size"].values
+        else:
+            sample_sizes = None
 
         if self.fwhm is not None:
             assert np.isfinite(self.fwhm), "FWHM must be finite number"

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -313,7 +313,7 @@ class ALEKernel(KernelTransformer):
         exp_idx = coordinates["id"].values
 
         use_dict = True
-        kernels = None
+        kernel = None
         if self.sample_size is not None:
             sample_sizes = self.sample_size
             use_dict = False
@@ -324,13 +324,13 @@ class ALEKernel(KernelTransformer):
 
         if self.fwhm is not None:
             assert np.isfinite(self.fwhm), "FWHM must be finite number"
-            _, kernels = get_ale_kernel(mask, fwhm=self.fwhm)
+            _, kernel = get_ale_kernel(mask, fwhm=self.fwhm)
             use_dict = False
 
         transformed = compute_ale_ma(
             mask,
             ijks,
-            kernels=kernels,
+            kernel=kernel,
             exp_idx=exp_idx,
             sample_sizes=sample_sizes,
             use_dict=use_dict,

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -366,14 +366,11 @@ class KDAKernel(KernelTransformer):
         self.value = value
 
     def _transform(self, mask, coordinates):
-        dims = mask.shape
-        vox_dims = mask.header.get_zooms()
 
         ijks = coordinates[["i", "j", "k"]].values
         exp_idx = coordinates["id"].values
         transformed = compute_kda_ma(
-            dims,
-            vox_dims,
+            mask,
             ijks,
             self.r,
             self.value,

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -432,8 +432,8 @@ def compute_ale_ma(mask, ijks, kernel=None, exp_idx=None, sample_sizes=None, use
         * This function now Return 4D sparse array.
         * `shape` parameter has been removed. That information is now extracted
           from the new parameter `mask`.
-        * Remove `ijk` in favor of `ijks`.
-        *  New parameters: `exp_idx`, `sample_sizes`, and `use_dict`.
+        * Replace `ijk` with `ijks`.
+        * New parameters: `exp_idx`, `sample_sizes`, and `use_dict`.
 
     Parameters
     ----------

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -379,11 +379,12 @@ def compute_kda_ma(
 
         all_spheres = _convolve_sphere(kernel, peaks)
 
-        if not sum_overlap:
-            # if not sum_overlap, counts=1
-            all_spheres, counts = unique_rows(all_spheres)
+        if sum_overlap:
+            # if sum_overlap, counts=list
+            all_spheres, counts = unique_rows(all_spheres, value, return_counts=True)
         else:
-            all_spheres, counts = unique_rows(all_spheres, return_counts=True)
+            # if not sum_overlap, counts=value
+            all_spheres, counts = unique_rows(all_spheres, value)
 
         # Mask coordinates beyond space
         idx = np.all(

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -424,6 +424,7 @@ def compute_ale_ma(mask, ijks, kernels=None, exp_idx=None, sample_sizes=None, us
         exp_idx = np.ones(len(ijks))
 
     shape = mask.shape
+    mask_data = mask.get_fdata().astype(bool)
 
     exp_idx_uniq, exp_idx = np.unique(exp_idx, return_inverse=True)
     n_studies = len(exp_idx_uniq)
@@ -487,8 +488,9 @@ def compute_ale_ma(mask, ijks, kernels=None, exp_idx=None, sample_sizes=None, us
                 ma_values[xl:xh, yl:yh, zl:zh] = np.maximum(
                     ma_values[xl:xh, yl:yh, zl:zh], kernel[xlk:xhk, ylk:yhk, zlk:zhk]
                 )
-
-        nonzero_idx = np.nonzero(ma_values)
+        # Set voxel outside the mask to zero.
+        ma_values[~mask_data] = 0
+        nonzero_idx = np.where(ma_values > 0)
 
         all_exp.append(np.full(nonzero_idx[0].shape[0], i_exp))
         all_coords.append(np.vstack(nonzero_idx))

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -397,7 +397,7 @@ def compute_kda_ma(
     return kernel_data
 
 
-def compute_ale_ma(mask, ijks, exp_idx, sample_sizes, kernels, use_dict):
+def compute_ale_ma(mask, ijks, kernels, exp_idx=None, sample_sizes=None, use_dict=False):
     """Generate ALE modeled activation (MA) maps.
 
     Replaces the values around each focus in ijk with the contrast-specific

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -429,9 +429,9 @@ def compute_ale_ma(mask, ijks, exp_idx, sample_sizes, kernels, use_dict):
     n_studies = len(exp_idx_uniq)
 
     kernel_shape = (n_studies,) + shape
+    all_exp = []
     all_coords = []
     all_data = []
-    all_exp = []
     for i_exp, _ in enumerate(exp_idx_uniq):
 
         # Index peaks by experiment
@@ -451,7 +451,6 @@ def compute_ale_ma(mask, ijks, exp_idx, sample_sizes, kernels, use_dict):
 
         mid = int(np.floor(kernel.shape[0] / 2.0))
         mid1 = mid + 1
-        exp_coords = []
         ma_values = np.zeros(shape)
         for j_peak in range(ijk.shape[0]):
             i, j, k = ijk[j_peak, :]
@@ -489,21 +488,15 @@ def compute_ale_ma(mask, ijks, exp_idx, sample_sizes, kernels, use_dict):
 
         nonzero_idx = np.nonzero(ma_values)
 
-        exp_data = ma_values[nonzero_idx]
-        all_data.append(exp_data)
+        all_exp.append(np.full(nonzero_idx[0].shape[0], i_exp))
+        all_coords.append(np.vstack(nonzero_idx))
+        all_data.append(ma_values[nonzero_idx])
 
-        exp_coords = np.vstack(nonzero_idx)
-        all_coords.append(exp_coords)
-
-        all_exp.append(np.full(exp_coords.shape[1], i_exp))
-
-    xyz_coords = np.hstack(all_coords)
     exp = np.hstack(all_exp)
+    coords = np.vstack((exp.flatten(), np.hstack(all_coords)))
+    data = np.hstack(all_data).flatten()
 
-    coords = np.vstack((exp.flatten(), xyz_coords))
-
-    data = np.hstack(all_data)
-    kernel_data = sparse.COO(coords, data.flatten(), shape=kernel_shape)
+    kernel_data = sparse.COO(coords, data, shape=kernel_shape)
 
     return kernel_data
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -459,7 +459,7 @@ def compute_ale_ma(mask, ijks, kernels=None, exp_idx=None, sample_sizes=None, us
         if kernels is not None:
             warnings.warn("The kernels provided will be replace by an empty dictionary.")
         kernels = {}  # retain kernels in dictionary to speed things up
-        if not isinstance(sample_sizes, list):
+        if not isinstance(sample_sizes, np.ndarray):
             raise ValueError("To use a kernel dictionary sample_sizes must be a list.")
     elif sample_sizes is not None:
         if not isinstance(sample_sizes, int):

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -429,7 +429,7 @@ def compute_ale_ma(mask, ijks, kernel=None, exp_idx=None, sample_sizes=None, use
 
     .. versionchanged:: 0.0.12
 
-        * This function now Return 4D sparse array.
+        * This function now returns a 4D sparse array.
         * `shape` parameter has been removed. That information is now extracted
           from the new parameter `mask`.
         * Replace `ijk` with `ijks`.

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -397,7 +397,7 @@ def compute_kda_ma(
     return kernel_data
 
 
-def compute_ale_ma(mask, ijks, kernels, exp_idx=None, sample_sizes=None, use_dict=False):
+def compute_ale_ma(mask, ijks, kernels=None, exp_idx=None, sample_sizes=None, use_dict=False):
     """Generate ALE modeled activation (MA) maps.
 
     Replaces the values around each focus in ijk with the contrast-specific
@@ -446,6 +446,8 @@ def compute_ale_ma(mask, ijks, kernels, exp_idx=None, sample_sizes=None, use_dic
                 kernels[sample_size] = kernel
             else:
                 kernel = kernels[sample_size]
+        elif sample_sizes is not None:
+            _, kernel = get_ale_kernel(mask, sample_size=sample_sizes)
         else:
             kernel = kernels
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -291,6 +291,8 @@ def compute_kda_ma(
 
         * Remove low-memory option in favor of sparse arrays.
         * Return 4D sparse array.
+        * `shape` and `vox_dims` parameters have been removed. That information is now extracted
+          from the new parameter `mask`.
 
     .. versionadded:: 0.0.4
 
@@ -424,6 +426,14 @@ def compute_ale_ma(mask, ijks, kernel=None, exp_idx=None, sample_sizes=None, use
     kernel. Takes the element-wise maximum when looping through foci, which
     accounts for foci which are near to one another and may have overlapping
     kernels.
+
+    .. versionchanged:: 0.0.12
+
+        * This function now Return 4D sparse array.
+        * `shape` parameter has been removed. That information is now extracted
+          from the new parameter `mask`.
+        * Remove `ijk` in favor of `ijks`.
+        *  New parameters: `exp_idx`, `sample_sizes`, and `use_dict`.
 
     Parameters
     ----------

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -429,7 +429,7 @@ def compute_ale_ma(mask, ijks, kernels=None, exp_idx=None, sample_sizes=None, us
     ----------
     mask : img_like
         Mask to extract the MA maps shape (typically (91, 109, 91)) and voxel dimension.
-        The mask is applied the data coordinated before creating the kernel_data.
+        The mask is applied to the coordinates before creating the kernel_data.
     ijks : array-like
         Indices of foci. Each row is a coordinate, with the three columns
         corresponding to index in each of three dimensions.

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -417,7 +417,7 @@ def compute_kda_ma(
     return kernel_data
 
 
-def compute_ale_ma(mask, ijks, kernels=None, exp_idx=None, sample_sizes=None, use_dict=False):
+def compute_ale_ma(mask, ijks, kernel=None, exp_idx=None, sample_sizes=None, use_dict=False):
     """Generate ALE modeled activation (MA) maps.
 
     Replaces the values around each focus in ijk with the contrast-specific
@@ -433,7 +433,7 @@ def compute_ale_ma(mask, ijks, kernels=None, exp_idx=None, sample_sizes=None, us
     ijks : array-like
         Indices of foci. Each row is a coordinate, with the three columns
         corresponding to index in each of three dimensions.
-    kernels : array-like, or None, optional
+    kernel : array-like, or None, optional
         3D array of smoothing kernel. Typically of shape (30, 30, 30).
     exp_idx : array_like
         Optional indices of experiments. If passed, must be of same length as
@@ -456,8 +456,8 @@ def compute_ale_ma(mask, ijks, kernels=None, exp_idx=None, sample_sizes=None, us
         unique experiments, and the remaining 3 dimensions are equal to `shape`.
     """
     if use_dict:
-        if kernels is not None:
-            warnings.warn("The kernels provided will be replace by an empty dictionary.")
+        if kernel is not None:
+            warnings.warn("The kernel provided will be replace by an empty dictionary.")
         kernels = {}  # retain kernels in dictionary to speed things up
         if not isinstance(sample_sizes, np.ndarray):
             raise ValueError("To use a kernel dictionary sample_sizes must be a list.")
@@ -465,7 +465,7 @@ def compute_ale_ma(mask, ijks, kernels=None, exp_idx=None, sample_sizes=None, us
         if not isinstance(sample_sizes, int):
             raise ValueError("If use_dict is False, sample_sizes provided must be integer.")
     else:
-        if kernels is None:
+        if kernel is None:
             raise ValueError("3D array of smoothing kernel must be provided.")
 
     if exp_idx is None:
@@ -497,8 +497,6 @@ def compute_ale_ma(mask, ijks, kernels=None, exp_idx=None, sample_sizes=None, us
                 kernel = kernels[sample_size]
         elif sample_sizes is not None:
             _, kernel = get_ale_kernel(mask, sample_size=sample_sizes)
-        else:
-            kernel = kernels
 
         mid = int(np.floor(kernel.shape[0] / 2.0))
         mid1 = mid + 1

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -381,10 +381,12 @@ def compute_kda_ma(
 
         if sum_overlap:
             # if sum_overlap, counts=list
-            all_spheres, counts = unique_rows(all_spheres, value, return_counts=True)
+            all_spheres, counts = unique_rows(all_spheres, return_counts=True)
+            counts = counts * value
         else:
             # if not sum_overlap, counts=value
-            all_spheres, counts = unique_rows(all_spheres, value)
+            all_spheres = unique_rows(all_spheres)
+            counts = value
 
         # Mask coordinates beyond space
         idx = np.all(

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -6,10 +6,12 @@ import pickle
 import nibabel as nib
 import numpy as np
 import pytest
+from nilearn.input_data import NiftiLabelsMasker
 
 import nimare
 from nimare.correct import FDRCorrector, FWECorrector
 from nimare.meta import ale
+from nimare.tests.utils import get_test_data_path
 from nimare.utils import vox2mm
 
 
@@ -300,3 +302,16 @@ def test_SCALE_smoke(testdata_cbma, tmp_path_factory):
 
     meta.save(out_file)
     assert os.path.isfile(out_file)
+
+
+def test_ALE_non_nifti_masker(testdata_cbma):
+    """Unit test for ALE with non-NiftiMasker.
+
+    CBMA estimators don't work with non-NiftiMasker (e.g., a NiftiLabelsMasker).
+    """
+    atlas = os.path.join(get_test_data_path(), "test_pain_dataset", "atlas.nii.gz")
+    masker = NiftiLabelsMasker(atlas)
+    meta = ale.ALE(mask=masker, n_iters=10)
+
+    with pytest.raises(ValueError):
+        meta.fit(testdata_cbma)

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -45,13 +45,6 @@ def test_ALE_ma_map_reuse(testdata_cbma, tmp_path_factory, caplog):
         meta.fit(dset)
     assert "Loading pre-generated MA maps" in caplog.text
 
-    # If there is a memory limit along with pre-generated images, then we should still see the
-    # logger message.
-    meta = ale.ALE(kernel__sample_size=20)
-    with caplog.at_level(logging.DEBUG, logger="nimare.meta.cbma.base"):
-        meta.fit(dset)
-    assert "Loading pre-generated MA maps" in caplog.text
-
 
 def test_ALESubtraction_ma_map_reuse(testdata_cbma, tmp_path_factory, caplog):
     """Test that MA maps are re-used when appropriate."""

--- a/nimare/tests/utils.py
+++ b/nimare/tests/utils.py
@@ -41,7 +41,6 @@ def _create_signal_mask(ground_truth_foci_ijks, mask):
         Binary image representing regions not expected
         to be significant within the brain.
     """
-
     # area where I'm reasonably certain there are significant results
     sig_prob_map = compute_kda_ma(mask, ground_truth_foci_ijks, r=2, value=1, sum_overlap=False)
     sig_prob_map = sig_prob_map[0].todense()

--- a/nimare/tests/utils.py
+++ b/nimare/tests/utils.py
@@ -41,18 +41,14 @@ def _create_signal_mask(ground_truth_foci_ijks, mask):
         Binary image representing regions not expected
         to be significant within the brain.
     """
-    dims = mask.shape
-    vox_dims = mask.header.get_zooms()
 
     # area where I'm reasonably certain there are significant results
-    sig_prob_map = compute_kda_ma(
-        dims, vox_dims, ground_truth_foci_ijks, r=2, value=1, sum_overlap=False
-    )
+    sig_prob_map = compute_kda_ma(mask, ground_truth_foci_ijks, r=2, value=1, sum_overlap=False)
     sig_prob_map = sig_prob_map[0].todense()
 
     # area where I'm reasonably certain there are not significant results
     nonsig_prob_map = compute_kda_ma(
-        dims, vox_dims, ground_truth_foci_ijks, r=14, value=1, sum_overlap=False
+        mask, ground_truth_foci_ijks, r=14, value=1, sum_overlap=False
     )
     nonsig_prob_map = nonsig_prob_map[0].todense()
 

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -993,11 +993,16 @@ def unique_rows(ar, return_counts=False):
     ----------
     ar : 2-D ndarray
         The input array.
+    return_counts : :obj:`bool`, optional
+        If True, also return the number of times each unique item appears in ar.
 
     Returns
     -------
     ar_out : 2-D ndarray
         A copy of the input array with repeated rows removed.
+    unique_counts : :obj:`np.ndarray`, optional
+        The number of times each of the unique values comes up in the original array.
+        Only provided if return_counts is True.
 
     Raises
     ------

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -983,7 +983,7 @@ def tqdm_joblib(tqdm_object):
         tqdm_object.close()
 
 
-def unique_rows(ar):
+def unique_rows(ar, return_counts=False):
     """Remove repeated rows from a 2D array.
 
     In particular, if given an array of coordinates of shape
@@ -1031,6 +1031,13 @@ def unique_rows(ar):
     # see each row as a single item, we create a view of each row as a
     # byte string of length itemsize times number of columns in `ar`
     ar_row_view = ar.view("|S%d" % (ar.itemsize * ar.shape[1]))
-    _, unique_row_indices = np.unique(ar_row_view, return_index=True)
+    counts = 1
+    if return_counts:
+        _, unique_row_indices, counts = np.unique(
+            ar_row_view, return_index=True, return_counts=True
+        )
+    else:
+        _, unique_row_indices = np.unique(ar_row_view, return_index=True)
+
     ar_out = ar[unique_row_indices]
-    return ar_out
+    return ar_out, counts

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -983,7 +983,7 @@ def tqdm_joblib(tqdm_object):
         tqdm_object.close()
 
 
-def unique_rows(ar, value, return_counts=False):
+def unique_rows(ar, return_counts=False):
     """Remove repeated rows from a 2D array.
 
     In particular, if given an array of coordinates of shape
@@ -1035,10 +1035,9 @@ def unique_rows(ar, value, return_counts=False):
         _, unique_row_indices, counts = np.unique(
             ar_row_view, return_index=True, return_counts=True
         )
-        counts = counts * counts
+
+        return ar[unique_row_indices], counts
     else:
         _, unique_row_indices = np.unique(ar_row_view, return_index=True)
-        counts = value
 
-    ar_out = ar[unique_row_indices]
-    return ar_out, counts
+        return ar[unique_row_indices]

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -983,7 +983,7 @@ def tqdm_joblib(tqdm_object):
         tqdm_object.close()
 
 
-def unique_rows(ar, return_counts=False):
+def unique_rows(ar, value, return_counts=False):
     """Remove repeated rows from a 2D array.
 
     In particular, if given an array of coordinates of shape
@@ -1031,13 +1031,14 @@ def unique_rows(ar, return_counts=False):
     # see each row as a single item, we create a view of each row as a
     # byte string of length itemsize times number of columns in `ar`
     ar_row_view = ar.view("|S%d" % (ar.itemsize * ar.shape[1]))
-    counts = 1
     if return_counts:
         _, unique_row_indices, counts = np.unique(
             ar_row_view, return_index=True, return_counts=True
         )
+        counts = counts * counts
     else:
         _, unique_row_indices = np.unique(ar_row_view, return_index=True)
+        counts = value
 
     ar_out = ar[unique_row_indices]
     return ar_out, counts


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #692.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Create the MA maps for all studies in `compute_ale_ma` and return a 4D sparse array.
- Return sparse array by `ALEKernel._transform` and `KernelTransformer.transform`.
- Add support for `ma_maps` 4D sparse array in `ALE` and `CBMAEstimator`. This will involve adding support for sparse array in `ALE._compute_summarystat_est`, `ALE._determine_histogram_bins`, and `ALE._compute_null_approximate`.
