### PR TITLE
Add parallelization option to `CorrelationDecoder` and `CorrelationDistributionDecoder`

### DIFF
--- a/examples/01_datasets/02_download_neurosynth.py
+++ b/examples/01_datasets/02_download_neurosynth.py
@@ -86,7 +86,7 @@ files = fetch_neuroquery(
     version="1",
     overwrite=False,
     source="combined",
-    vocab="neuroquery7547",
+    vocab="neuroquery6308",
     type="tfidf",
 )
 # Note that the files are saved to a new folder within "out_dir" named "neuroquery".

--- a/nimare/decode/base.py
+++ b/nimare/decode/base.py
@@ -77,7 +77,7 @@ class Decoder(NiMAREBase):
         if not len(features):
             raise Exception("No features identified in Dataset!")
         elif len(features) < n_features_orig:
-            LGR.info(f"Retaining {len(features)}/({n_features_orig} features.")
+            LGR.info(f"Retaining {len(features)}/{n_features_orig} features.")
 
         self.features_ = features
 

--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -190,16 +190,18 @@ class CorrelationDecoder(Decoder):
         self.masker = dataset.masker
 
         n_features = len(self.features_)
-        images_ = [[]] * n_features
         with tqdm_joblib(tqdm(total=n_features)):
-            Parallel(n_jobs=self.n_cores)(
-                delayed(self._run_fit)(i_feature, feature, dataset, images_)
-                for i_feature, feature in enumerate(self.features_)
+            images_, feature_idx = zip(
+                *Parallel(n_jobs=self.n_cores)(
+                    delayed(self._run_fit)(i_feature, feature, dataset)
+                    for i_feature, feature in enumerate(self.features_)
+                )
             )
+        # Convert to an array and sort the images_ array based on the feature index.
+        images_ = np.array(images_)[np.array(feature_idx)]
+        self.images_ = images_
 
-        self.images_ = np.vstack(images_)
-
-    def _run_fit(self, i_feature, feature, dataset, images_):
+    def _run_fit(self, i_feature, feature, dataset):
         feature_ids = dataset.get_studies_by_label(
             labels=[feature],
             label_threshold=self.frequency_threshold,
@@ -224,7 +226,7 @@ class CorrelationDecoder(Decoder):
             return_type="array",
         )
 
-        images_[i_feature] = feature_data
+        return feature_data, i_feature
 
     def transform(self, img):
         """Correlate target image with each feature-specific meta-analytic map.
@@ -313,17 +315,18 @@ class CorrelationDistributionDecoder(Decoder):
         self.masker = dataset.masker
 
         n_features = len(self.features_)
-        images_ = {}
         with tqdm_joblib(tqdm(total=n_features)):
-            Parallel(n_jobs=self.n_cores)(
-                delayed(self._run_fit)(feature, dataset, images_) for feature in self.features_
+            images_ = dict(
+                Parallel(n_jobs=self.n_cores)(
+                    delayed(self._run_fit)(feature, dataset) for feature in self.features_
+                )
             )
 
         # reduce features again
         self.features_ = [f for f in self.features_ if f in images_.keys()]
         self.images_ = images_
 
-    def _run_fit(self, feature, dataset, images_):
+    def _run_fit(self, feature, dataset):
         feature_ids = dataset.get_studies_by_label(
             labels=[feature], label_threshold=self.frequency_threshold
         )
@@ -340,7 +343,7 @@ class CorrelationDistributionDecoder(Decoder):
                 self.masker,
                 memfile=None,
             )
-            images_[feature] = feature_arr
+            return feature, feature_arr
         else:
             LGR.info(f"Skipping feature '{feature}'. No images found.")
 

--- a/nimare/tests/utils.py
+++ b/nimare/tests/utils.py
@@ -23,7 +23,8 @@ def get_test_data_path():
 
 
 def _create_signal_mask(ground_truth_foci_ijks, mask):
-    """Create complementary binary images to identify areas of likely significance and nonsignificance.
+    """Create complementary binary images to identify areas of likely significance and
+    nonsignificance.
 
     Parameters
     ----------

--- a/nimare/tests/utils.py
+++ b/nimare/tests/utils.py
@@ -23,7 +23,7 @@ def get_test_data_path():
 
 
 def _create_signal_mask(ground_truth_foci_ijks, mask):
-    """Create complementary binary images to identify areas of likely significance and nonsignificance.
+    """Create binary images to identify areas of likely significance and nonsignificance.
 
     Parameters
     ----------

--- a/nimare/tests/utils.py
+++ b/nimare/tests/utils.py
@@ -23,8 +23,7 @@ def get_test_data_path():
 
 
 def _create_signal_mask(ground_truth_foci_ijks, mask):
-    """Create complementary binary images to identify areas of likely significance and
-    nonsignificance.
+    """Create complementary binary images to identify areas of likely significance and nonsignificance.
 
     Parameters
     ----------


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->

Currently, `CorrelationDecoder` takes a long time to be trained. Depending on the number of studies per feature, it takes around 13 min per feature (i.e., per iteration). For large databases like Neurosynth, which has 3228 features, it will take ~29 days. Adding the parallelization option reduces the computation time by a factor of `n_cores`. 

Changes proposed in this pull request:

- Add `n_cores` parameter to use for parallelization.
