### PR TITLE
Optimize compute_kda_ma

### DIFF
--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -116,13 +116,10 @@ def compute_kda_ma(
         all_spheres = _convolve_sphere(kernel, peaks)
 
         if sum_overlap:
-            # if sum_overlap, counts=list
             all_spheres, counts = unique_rows(all_spheres, return_counts=True)
             counts = counts * value
         else:
-            # if not sum_overlap, counts=value
             all_spheres = unique_rows(all_spheres)
-            counts = value
 
         # Mask coordinates beyond space
         idx = np.all(
@@ -131,17 +128,14 @@ def compute_kda_ma(
 
         all_spheres = all_spheres[idx, :]
 
-        if sum_overlap:
-            counts = counts[idx]
-
         sphere_idx_inside_mask = np.where(mask_data[tuple(all_spheres.T)])[0]
         sphere_idx_filtered = all_spheres[sphere_idx_inside_mask, :].T
         nonzero_idx = tuple(sphere_idx_filtered)
 
         if sum_overlap:
-            nonzero_to_append = counts[sphere_idx_inside_mask]
+            nonzero_to_append = counts[idx][sphere_idx_inside_mask]
         else:
-            nonzero_to_append = np.ones((len(sphere_idx_inside_mask),)) * counts
+            nonzero_to_append = np.ones((len(sphere_idx_inside_mask),)) * value
 
         all_exp.append(np.full(nonzero_idx[0].shape[0], i_exp))
         all_coords.append(np.vstack(nonzero_idx))

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -130,6 +130,7 @@ def compute_kda_ma(
         )
 
         all_spheres = all_spheres[idx, :]
+
         if sum_overlap:
             counts = counts[idx]
 
@@ -137,8 +138,8 @@ def compute_kda_ma(
         sphere_idx_filtered = all_spheres[sphere_idx_inside_mask, :].T
         nonzero_idx = tuple(sphere_idx_filtered)
 
-        if isinstance(counts, list):
-            nonzero_to_append = counts[sphere_idx_filtered]
+        if sum_overlap:
+            nonzero_to_append = counts[sphere_idx_inside_mask]
         else:
             nonzero_to_append = np.ones((len(sphere_idx_inside_mask),)) * counts
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -133,16 +133,18 @@ def compute_kda_ma(
         if sum_overlap:
             counts = counts[idx]
 
-        ma_values = np.zeros(shape)
-        ma_values[tuple(all_spheres.T)] = counts
-        # Set voxel outside the mask to zero.
-        ma_values[~mask_data] = 0
+        sphere_idx_inside_mask = np.where(mask_data[tuple(all_spheres.T)])[0]
+        sphere_idx_filtered = all_spheres[sphere_idx_inside_mask, :].T
+        nonzero_idx = tuple(sphere_idx_filtered)
 
-        nonzero_idx = np.where(ma_values > 0)
+        if isinstance(counts, list):
+            nonzero_to_append = counts[sphere_idx_filtered]
+        else:
+            nonzero_to_append = np.ones((len(sphere_idx_inside_mask),)) * counts
 
         all_exp.append(np.full(nonzero_idx[0].shape[0], i_exp))
         all_coords.append(np.vstack(nonzero_idx))
-        all_data.append(ma_values[nonzero_idx])
+        all_data.append(nonzero_to_append)
 
     exp = np.hstack(all_exp)
     coords = np.vstack((exp.flatten(), np.hstack(all_coords)))


### PR DESCRIPTION
Changes proposed in this pull request:

- Optimize `compute_kda_ma`

I was trying to speedup `MKDAChi2()` and made some changes to the matrix operations in `compute_kda_ma`, which could half the running time. Please feel free to make any revisions, as I could only test under my specific case.

- `nonzero_idx` is not sorted after the change, but I guess it's not an issue.
- I did not fully test against `sum_overlap=True`, in which `counts` could be a list.


I also found that parallelize this loop with joblib could speedup the process by another small percent. So, I was wondering if there is a way to pre-calculate `ma_maps` for all the files in a dataset and reuse them. I saw that many functions support using saved MA maps internally through `self.inputs_["ma_maps"]`, but I did not find a way to patch into the input.

Thank you.