### PR TITLE
Remove upper bound for matplotlib version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     fuzzywuzzy  # nimare.annotate
     indexed_gzip>=1.4.0  # working with gzipped niftis
     joblib  # parallelization
-    matplotlib<3.5  # this is for nilearn, which doesn't include it in its reqs
+    matplotlib>=3.0  # this is for nilearn, which doesn't include it in its reqs
     nibabel>=3.0.0  # I/O of niftis
     nilearn>=0.7.1
     numba  # used by sparse
@@ -84,6 +84,7 @@ tests =
     pytest-cov
 minimum =
     indexed_gzip==1.4
+    matplotlib==3.3.4
     nibabel==3.0
     nilearn==0.7.1
     numpy==1.18


### PR DESCRIPTION
Since version 0.9.1, `nilearn` declares extra dependencies for its plotting capabilities.

~This PR drops the explicit dependency on a bounded version of `matplotlib` and let it be installed transitively through `nilearn`. Another benefit is to allow projects depending on `NiMARE` explicitly or transitively to install more recent versions of matplotlib which provides wheels for Python 3.10+.~

This PR drops the upper bound of the matplotlib requirement to allow install of more recent versions which provides wheels for Python 3.10+.
