### PR TITLE
Fix neurosyth download_abstracts example; inc biopython

### DIFF
--- a/examples/01_datasets/02_download_neurosynth.py
+++ b/examples/01_datasets/02_download_neurosynth.py
@@ -41,7 +41,7 @@ from nimare.io import convert_neurosynth_to_dataset
 
 # biopython is unnecessary here, but is required by download_abstracts
 # importing here only to document dependency and cause early failure if missing
-import Bio
+import Bio  # pip instlal biopython
 
 ###############################################################################
 # Download Neurosynth

--- a/examples/01_datasets/02_download_neurosynth.py
+++ b/examples/01_datasets/02_download_neurosynth.py
@@ -41,7 +41,7 @@ from nimare.io import convert_neurosynth_to_dataset
 
 # biopython is unnecessary here, but is required by download_abstracts.
 # We import it here only to document the dependency and cause an early failure if it's missing.
-import Bio  # pip instlal biopython
+import Bio  # pip install biopython
 
 ###############################################################################
 # Download Neurosynth

--- a/examples/01_datasets/02_download_neurosynth.py
+++ b/examples/01_datasets/02_download_neurosynth.py
@@ -41,7 +41,7 @@ from nimare.io import convert_neurosynth_to_dataset
 
 # biopython is unnecessary here, but is required by download_abstracts
 # importing here only to document dependency and cause early failure if missing
-import biopython
+import Bio
 
 ###############################################################################
 # Download Neurosynth

--- a/examples/01_datasets/02_download_neurosynth.py
+++ b/examples/01_datasets/02_download_neurosynth.py
@@ -39,8 +39,8 @@ from pprint import pprint
 from nimare.extract import download_abstracts, fetch_neuroquery, fetch_neurosynth
 from nimare.io import convert_neurosynth_to_dataset
 
-# biopython is unnecessary here, but is required by download_abstracts
-# importing here only to document dependency and cause early failure if missing
+# biopython is unnecessary here, but is required by download_abstracts.
+# We import it here only to document the dependency and cause an early failure if it's missing.
 import Bio  # pip instlal biopython
 
 ###############################################################################

--- a/examples/01_datasets/02_download_neurosynth.py
+++ b/examples/01_datasets/02_download_neurosynth.py
@@ -39,6 +39,10 @@ from pprint import pprint
 from nimare.extract import download_abstracts, fetch_neuroquery, fetch_neurosynth
 from nimare.io import convert_neurosynth_to_dataset
 
+# biopython is unnecessary here, but is required by download_abstracts
+# importing here only to document dependency and cause early failure if missing
+import biopython
+
 ###############################################################################
 # Download Neurosynth
 # -----------------------------------------------------------------------------
@@ -74,7 +78,7 @@ print(neurosynth_dset)
 # This is only possible because Neurosynth uses PMIDs as study IDs.
 #
 # Make sure you replace the example email address with your own.
-neurosynth_dset = extract.download_abstracts(neurosynth_dset, "example@example.edu")
+neurosynth_dset = download_abstracts(neurosynth_dset, "example@example.edu")
 neurosynth_dset.save(os.path.join(out_dir, "neurosynth_dataset_with_abstracts.pkl.gz"))
 
 ###############################################################################


### PR DESCRIPTION
small syntax issue in https://nimare.readthedocs.io/en/latest/auto_examples/01_datasets/02_download_neurosynth.html#sphx-glr-auto-examples-01-datasets-02-download-neurosynth-py. `download_abstracts` is directly imported instead of what might have earlier been `from nimare.extract as extract`

also wanted to indicate `biopython` is required for `download_abstracts` so error doesn't get buried among the prints for neurosynth-data download  