### PR TITLE
Raise deprecation warnings with Python 3.6 and 3.7

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -36,7 +36,7 @@ jobs:
         fail-fast: false
         matrix:
             os: ["ubuntu-latest"]
-            python-version: ["3.7"]
+            python-version: ["3.8"]
     name: Style check
     defaults:
       run:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,13 +39,14 @@ jobs:
         matrix:
             os: ["ubuntu-20.04", "ubuntu-latest", "macos-latest"]
             python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
-            exclude:
+            include:
               # ubuntu-20.04 is used only to test python 3.6
               - os: "ubuntu-20.04"
-                python-version: ["3.7", "3.8", "3.9", "3.10"]
+                python-version: "3.6"
+            exclude:
               # ubuntu-latest does not support python 3.6
               - os: "ubuntu-latest"
-                python-version: ["3.6"]
+                python-version: "3.6"
 
     defaults:
       run:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-20.04", "ubuntu-latest", "macos-latest"]
+            os: ["ubuntu-latest", "macos-latest"]
             python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
             include:
               # ubuntu-20.04 is used only to test python 3.6

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -79,7 +79,7 @@ jobs:
         fail-fast: false
         matrix:
             os: ["ubuntu-latest"]
-            python-version: ["3.6"]
+            python-version: ["3.8"]
     defaults:
       run:
         shell: bash
@@ -88,7 +88,7 @@ jobs:
       - name: 'Set up python'
         uses: actions/setup-python@v2
         with:
-            python-version: 3.6
+            python-version: 3.8
       - name: 'Install NiMARE'
         shell: bash {0}
         run: pip install -e .[minimum,tests,peaks2maps-cpu]
@@ -111,7 +111,7 @@ jobs:
         fail-fast: false
         matrix:
             os: ["ubuntu-latest"]
-            python-version: ["3.7"]
+            python-version: ["3.8"]
     defaults:
       run:
         shell: bash
@@ -143,7 +143,7 @@ jobs:
         fail-fast: false
         matrix:
             os: ["ubuntu-latest"]
-            python-version: ["3.7"]
+            python-version: ["3.8"]
     defaults:
       run:
         shell: bash
@@ -175,7 +175,7 @@ jobs:
         fail-fast: false
         matrix:
             os: ["ubuntu-latest"]
-            python-version: ["3.7"]
+            python-version: ["3.8"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -37,8 +37,16 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-            os: ["ubuntu-latest", "macos-latest"]
+            os: ["ubuntu-20.04", "ubuntu-latest", "macos-latest"]
             python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+            exclude:
+              # ubuntu-20.04 is used only to test python 3.6
+              - os: "ubuntu-20.04"
+                python-version: ["3.7", "3.8", "3.9", "3.10"]
+              # ubuntu-latest does not support python 3.6
+              - os: "ubuntu-latest"
+                python-version: ["3.6"]
+
     defaults:
       run:
         shell: bash

--- a/nimare/__init__.py
+++ b/nimare/__init__.py
@@ -1,5 +1,6 @@
 """NiMARE: Neuroimaging Meta-Analysis Research Environment."""
 import logging
+import sys
 import warnings
 
 from ._version import get_versions
@@ -40,3 +41,34 @@ with warnings.catch_warnings(record=True) as w:
     ]
 
 del get_versions
+
+
+def _py367_deprecation_warning():
+    """Deprecation warnings message.
+
+    Notes
+    -----
+    Adapted from Nilearn.
+    """
+    py36_warning = (
+        "Python 3.6 and 3.7 support is deprecated and will be removed in release 0.1.0 of NiMARE. "
+        "Consider switching to Python 3.8, 3.9 or 3.10."
+    )
+    warnings.filterwarnings("once", message=py36_warning)
+    warnings.warn(message=py36_warning, category=FutureWarning, stacklevel=3)
+
+
+def _python_deprecation_warnings():
+    """Raise deprecation warnings.
+
+    Notes
+    -----
+    Adapted from Nilearn.
+    """
+    if sys.version_info.major == 3 and (
+        sys.version_info.minor == 6 or sys.version_info.minor == 7
+    ):
+        _py367_deprecation_warning()
+
+
+_python_deprecation_warnings()

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,6 +120,6 @@ parentdir_prefix =
 max-line-length = 99
 exclude = *build/,_version.py
 putty-ignore =
-    */__init__.py : +F401
+    */__init__.py : +F401,D401
 ignore = E203,E402,E722,W503
 docstring-convention = numpy

--- a/setup.cfg
+++ b/setup.cfg
@@ -120,6 +120,8 @@ parentdir_prefix =
 max-line-length = 99
 exclude = *build/,_version.py
 putty-ignore =
-    */__init__.py : +F401,D401
+    */__init__.py : +F401
+per-file-ignores =
+    */__init__.py:D401
 ignore = E203,E402,E722,W503
 docstring-convention = numpy


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add deprecation warnings when running NiMARE on Python 3.6 or 3.7.
- Run Unit Tests of python 3.6 on ubuntu-20.04, since ubuntu-latest does not support python 3.6.
