### PR TITLE
Link to NeuroStars software support category instead of neuro questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Usage question
-    url: https://neurostars.org/tag/nimare
+    url: https://neurostars.org/tags/c/software-support/234/nimare
     about: Please ask questions about using NiMARE on NeuroStars.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ As stated in the code, severe or repeated violations by community members may re
 
 ## Asking questions about using NiMARE
 
-Please direct usage-related questions to [NeuroStars][link_neurostars], with the ["nimare" tag][link_neurostars_nimare].
+Please direct usage-related questions to [NeuroStars][link_neurostars], with [the "Software Support" category and the "nimare" tag][link_neurostars_nimare].
 The ``NiMARE`` developers follow NeuroStars, and will be able to answer your question there.
 
 ## Labels
@@ -114,7 +114,7 @@ You're awesome.
 [link_labels]: https://github.com/neurostuff/NiMARE/labels
 [link_discussingissues]: https://help.github.com/articles/discussing-projects-in-issues-and-pull-requests
 [link_neurostars]: https://neurostars.org
-[link_neurostars_nimare]: https://neurostars.org/tag/nimare
+[link_neurostars_nimare]: https://neurostars.org/tags/c/software-support/234/nimare
 
 [link_pullrequest]: https://help.github.com/articles/creating-a-pull-request/
 [link_fork]: https://help.github.com/articles/fork-a-repo/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ A Python library for coordinate- and image-based meta-analysis.
 
 [![Latest Version](https://img.shields.io/pypi/v/nimare.svg)](https://pypi.python.org/pypi/nimare/)
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/nimare.svg)](https://pypi.python.org/pypi/nimare/)
+[![GitHub Repository](https://img.shields.io/badge/Source%20Code-neurostuff%2Fnimare-purple)](https://github.com/neurostuff/NiMARE)
 [![DOI](https://zenodo.org/badge/117724523.svg)](https://zenodo.org/badge/latestdoi/117724523)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Test Status](https://github.com/neurostuff/NiMARE/actions/workflows/testing.yml/badge.svg)](https://github.com/neurostuff/NiMARE/actions/workflows/testing.yml)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,7 +174,7 @@ intersphinx_mapping = {
     "matplotlib": ("https://matplotlib.org/", (None, "https://matplotlib.org/objects.inv")),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "nibabel": ("https://nipy.org/nibabel/", None),
-    "nilearn": ("http://nilearn.github.io/", None),
+    "nilearn": ("http://nilearn.github.io/stable/", None),
     "pymare": ("https://pymare.readthedocs.io/en/latest/", None),
     "skimage": ("https://scikit-image.org/docs/stable/", None),
 }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,10 @@ To install NiMARE check out our `installation guide`_.
    :target: https://pypi.python.org/pypi/nimare/
    :alt: PyPI - Python Version
 
+.. image:: https://img.shields.io/badge/Source%20Code-neurostuff%2Fnimare-purple
+   :target: https://github.com/neurostuff/NiMARE
+   :alt: GitHub Repository
+
 .. image:: https://zenodo.org/badge/117724523.svg
    :target: https://zenodo.org/badge/latestdoi/117724523
    :alt: DOI


### PR DESCRIPTION
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Link to NeuroStars software support category instead of the general category (which defaults new posts to "Neuro Questions").
- Add badges to link to the GitHub repo, so it's easier to go from the RTD site to the code.
- Fix Nilearn intersphinx link.
