### PR TITLE
Replace `pandas.DataFrame.append` with `pandas.concat`

### DIFF
--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -328,7 +328,7 @@ class Dataset(NiMAREBase):
         for attribute in ("annotations", "coordinates", "images", "metadata", "texts"):
             df1 = getattr(self, attribute)
             df2 = getattr(right, attribute)
-            new_df = df1.append(df2, ignore_index=True, sort=False)
+            new_df = pd.concat([df1, df2], ignore_index=True, sort=False)
             new_df.sort_values(by="id", inplace=True)
             new_df.reset_index(drop=True, inplace=True)
             new_df = new_df.where(~new_df.isna(), None)

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -448,7 +448,7 @@ class ImagesToCoordinates(NiMAREBase):
         if self.merge_strategy != "demolish":
             original_idxs = ~dataset.coordinates["id"].isin(coordinates_df["id"])
             old_coordinates_df = dataset.coordinates[original_idxs]
-            coordinates_df = coordinates_df.append(old_coordinates_df, ignore_index=True)
+            coordinates_df = pd.concat([coordinates_df, old_coordinates_df], ignore_index=True)
 
             # specify original coordinates
             original_ids = set(old_coordinates_df["id"])


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:
`pandas.DataFrame.append` is deprecated and will be removed in a future version of [pandas](https://pandas.pydata.org/docs/whatsnew/v1.4.0.html#whatsnew-140-deprecations-frame-series-append).
- Replace `pandas.DataFrame.append` with `pandas.concat`.
