### PR TITLE
Support pre-generated maps in `CorrelationDecoder`

### DIFF
--- a/nimare/decode/base.py
+++ b/nimare/decode/base.py
@@ -83,6 +83,7 @@ class Decoder(NiMAREBase):
 
     def fit(self, dataset, drop_invalid=True):
         """Fit Decoder to Dataset.
+
         Parameters
         ----------
         dataset : :obj:`~nimare.dataset.Dataset`
@@ -90,16 +91,19 @@ class Decoder(NiMAREBase):
         drop_invalid : :obj:`bool`, optional
             Whether to automatically ignore any studies without the required data or not.
             Default is True.
+
         Returns
         -------
         :obj:`~nimare.results.MetaResult`
             Results of Decoder fitting.
+
         Notes
         -----
         The `fit` method is a light wrapper that runs input validation and
         preprocessing before fitting the actual model. Decoders' individual
         "fitting" methods are implemented as `_fit`, although users should
         call `fit`.
+
         Selection of features based on requested features and feature group is performed in
         `Decoder._preprocess_input`.
         """

--- a/nimare/decode/base.py
+++ b/nimare/decode/base.py
@@ -3,6 +3,8 @@ import logging
 from abc import abstractmethod
 
 from nimare.base import NiMAREBase
+from nimare.dataset import Dataset
+from nimare.decode.continuous import CorrelationDecoder
 
 LGR = logging.getLogger(__name__)
 
@@ -86,10 +88,11 @@ class Decoder(NiMAREBase):
 
         Parameters
         ----------
-        dataset : :obj:`~nimare.dataset.Dataset`
-            Dataset object to analyze.
+        dataset : :obj:`~nimare.dataset.Dataset` or :obj:`dict`
+            Dataset or dict object to train the Decoder on.
         drop_invalid : :obj:`bool`, optional
             Whether to automatically ignore any studies without the required data or not.
+            This parameter is not used if dataset is a dictionary.
             Default is True.
 
 
@@ -108,8 +111,20 @@ class Decoder(NiMAREBase):
         Selection of features based on requested features and feature group is performed in
         `Decoder._preprocess_input`.
         """
-        self._collect_inputs(dataset, drop_invalid=drop_invalid)
-        self._preprocess_input(dataset)
+        if issubclass(type(dataset), Dataset):
+            self._collect_inputs(dataset, drop_invalid=drop_invalid)
+            self._preprocess_input(dataset)
+        elif isinstance(dataset, dict) and not issubclass(type(self), CorrelationDecoder):
+            raise ValueError(
+                f"Argument 'dataset' of type dictionary is only supported for "
+                f"CorrelationDecoder, not {type(self)}."
+            )
+        elif not isinstance(dataset, dict):
+            raise ValueError(
+                f"Argument 'dataset' must be a valid Dataset object or a dictionary "
+                f"with path to pregenerated map, not a {type(dataset)}."
+            )
+
         self._fit(dataset)
 
     @abstractmethod

--- a/nimare/decode/base.py
+++ b/nimare/decode/base.py
@@ -95,7 +95,7 @@ class Decoder(NiMAREBase):
         Returns
         -------
         :obj:`~nimare.results.MetaResult`
-            Results of Decoder fitting.
+            Results of Decoder fitting. Returned if a ``self.results`` was set in ``_fit``.
 
         Notes
         -----
@@ -110,6 +110,8 @@ class Decoder(NiMAREBase):
         self._collect_inputs(dataset, drop_invalid=drop_invalid)
         self._preprocess_input(dataset)
         self._fit(dataset)
+
+        return self.results if hasattr(self, "results") else None
 
     @abstractmethod
     def _fit(self, dataset):

--- a/nimare/decode/base.py
+++ b/nimare/decode/base.py
@@ -4,7 +4,6 @@ from abc import abstractmethod
 
 from nimare.base import NiMAREBase
 from nimare.dataset import Dataset
-from nimare.decode.continuous import CorrelationDecoder
 
 LGR = logging.getLogger(__name__)
 
@@ -114,11 +113,6 @@ class Decoder(NiMAREBase):
         if issubclass(type(dataset), Dataset):
             self._collect_inputs(dataset, drop_invalid=drop_invalid)
             self._preprocess_input(dataset)
-        elif isinstance(dataset, dict) and not issubclass(type(self), CorrelationDecoder):
-            raise ValueError(
-                f"Argument 'dataset' of type dictionary is only supported for "
-                f"CorrelationDecoder, not {type(self)}."
-            )
         elif not isinstance(dataset, dict):
             raise ValueError(
                 f"Argument 'dataset' must be a valid Dataset object or a dictionary "

--- a/nimare/decode/base.py
+++ b/nimare/decode/base.py
@@ -92,11 +92,6 @@ class Decoder(NiMAREBase):
             Whether to automatically ignore any studies without the required data or not.
             Default is True.
 
-        Returns
-        -------
-        :obj:`~nimare.results.MetaResult`
-            Results of Decoder fitting. Returned if a ``self.results`` was set in ``_fit``.
-
         Notes
         -----
         The `fit` method is a light wrapper that runs input validation and
@@ -110,8 +105,6 @@ class Decoder(NiMAREBase):
         self._collect_inputs(dataset, drop_invalid=drop_invalid)
         self._preprocess_input(dataset)
         self._fit(dataset)
-
-        return self.results if hasattr(self, "results") else None
 
     @abstractmethod
     def _fit(self, dataset):

--- a/nimare/decode/base.py
+++ b/nimare/decode/base.py
@@ -3,7 +3,6 @@ import logging
 from abc import abstractmethod
 
 from nimare.base import NiMAREBase
-from nimare.dataset import Dataset
 
 LGR = logging.getLogger(__name__)
 
@@ -84,41 +83,28 @@ class Decoder(NiMAREBase):
 
     def fit(self, dataset, drop_invalid=True):
         """Fit Decoder to Dataset.
-
         Parameters
         ----------
-        dataset : :obj:`~nimare.dataset.Dataset` or :obj:`dict`
-            Dataset or dict object to train the Decoder on.
+        dataset : :obj:`~nimare.dataset.Dataset`
+            Dataset object to analyze.
         drop_invalid : :obj:`bool`, optional
             Whether to automatically ignore any studies without the required data or not.
-            This parameter is not used if dataset is a dictionary.
             Default is True.
-
-
         Returns
         -------
         :obj:`~nimare.results.MetaResult`
             Results of Decoder fitting.
-
         Notes
         -----
         The `fit` method is a light wrapper that runs input validation and
         preprocessing before fitting the actual model. Decoders' individual
         "fitting" methods are implemented as `_fit`, although users should
         call `fit`.
-
         Selection of features based on requested features and feature group is performed in
         `Decoder._preprocess_input`.
         """
-        if issubclass(type(dataset), Dataset):
-            self._collect_inputs(dataset, drop_invalid=drop_invalid)
-            self._preprocess_input(dataset)
-        elif not isinstance(dataset, dict):
-            raise ValueError(
-                f"Argument 'dataset' must be a valid Dataset object or a dictionary "
-                f"with path to pregenerated map, not a {type(dataset)}."
-            )
-
+        self._collect_inputs(dataset, drop_invalid=drop_invalid)
+        self._preprocess_input(dataset)
         self._fit(dataset)
 
     @abstractmethod

--- a/nimare/decode/base.py
+++ b/nimare/decode/base.py
@@ -119,4 +119,3 @@ class Decoder(NiMAREBase):
 
         Must return a DataFrame, with one row for each feature.
         """
-        pass

--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -164,7 +164,6 @@ class CorrelationDecoder(Decoder):
         frequency_threshold=0.001,
         meta_estimator=None,
         target_image="z_desc-specificity",
-        mask=None,
         n_cores=1,
     ):
         if meta_estimator is None:
@@ -177,7 +176,6 @@ class CorrelationDecoder(Decoder):
         self.frequency_threshold = frequency_threshold
         self.meta_estimator = meta_estimator
         self.target_image = target_image
-
         self.n_cores = _check_ncores(n_cores)
 
     def _fit(self, dataset):

--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -12,7 +12,6 @@ from nilearn._utils import load_niimg
 from nilearn.masking import apply_mask
 from tqdm.auto import tqdm
 
-from nimare.dataset import Dataset
 from nimare.decode.base import Decoder
 from nimare.decode.utils import weight_priors
 from nimare.meta.cbma.base import CBMAEstimator
@@ -132,31 +131,19 @@ class CorrelationDecoder(Decoder):
     Parameters
     ----------
     feature_group : :obj:`str`, optional
-        Feature group.
-        This parameter is not used if the Decoder object is fit to a dictionary of pre-generated
-        maps.
+        Feature group
     features : :obj:`list`, optional
-        Features.
-        This parameter is not used if the Decoder object is fit to a dictionary of pre-generated
-        maps.
+        Features
     frequency_threshold : :obj:`float`, optional
-        Frequency threshold.
-        This parameter is not used if the Decoder object is fit to a dictionary of pre-generated
-        maps.
+        Frequency threshold
     meta_estimator : :class:`~nimare.base.CBMAEstimator`, optional
         Meta-analysis estimator. Default is :class:`~nimare.meta.mkda.MKDAChi2`.
-        This parameter is not used if the Decoder object is fit to a dictionary of pre-generated
-        maps.
     target_image : :obj:`str`, optional
         Name of meta-analysis results image to use for decoding.
-        This parameter is not used if the Decoder object is fit to a dictionary of pre-generated
-        maps.
     n_cores : :obj:`int`, optional
         Number of cores to use for parallelization.
         If <=0, defaults to using all available cores.
         Default is 1.
-        This parameter is not used if the Decoder object is fit to a dictionary of pre-generated
-        maps.
 
     Warnings
     --------
@@ -195,10 +182,12 @@ class CorrelationDecoder(Decoder):
 
     def _fit(self, dataset):
         """Generate feature-specific meta-analytic maps for dataset.
+
         Parameters
         ----------
         dataset : :obj:`~nimare.dataset.Dataset`
             Dataset for which to run meta-analyses to generate maps.
+
         Attributes
         ----------
         masker : :class:`~nilearn.input_data.NiftiMasker` or similar

--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -234,8 +234,10 @@ class CorrelationDecoder(Decoder):
             images_ = []
             for feature in dataset:
                 img = nib.load(dataset[feature])
-                images_.append(self.masker.transform(img))
+                images_.append(np.squeeze(self.masker.transform(img)))
+
             self.features_ = list(dataset.keys())
+            images_ = np.array(images_)
 
         self.images_ = images_
 

--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -128,8 +128,6 @@ class CorrelationDecoder(Decoder):
         * New attribute: `results_`. MetaResult object containing masker, meta-analytic maps,
           and tables. This attribute replaces `masker`, `features_`, and `images_`.
 
-        * `transform` now return a MetaResult object instead of a DataFrame.
-
     .. versionchanged:: 0.0.13
 
         * New parameter: `n_cores`. Number of cores to use for parallelization.
@@ -299,8 +297,8 @@ class CorrelationDecoder(Decoder):
 
         Returns
         -------
-        result : :obj:`~nimare.results.MetaResult`
-            MetaResult with meta-analytic masker, maps, and tables added.
+        out_df : :obj:`pandas.DataFrame`
+            DataFrame with one row for each feature, an index named "feature", and one column: "r".
         """
         if not hasattr(self, "results_"):
             raise AttributeError(
@@ -318,13 +316,11 @@ class CorrelationDecoder(Decoder):
         out_df = pd.DataFrame(index=features, columns=["r"], data=corrs)
         out_df.index.name = "feature"
 
-        # DataFrame with one row for each feature, an index named "feature", and one column: "r".
+        # Update self.results_ to include the new table
         results.tables["correlation"] = out_df
-
-        # update self.results_ to include the new table
         self.results_ = results
 
-        return results
+        return out_df
 
 
 class CorrelationDistributionDecoder(Decoder):
@@ -334,8 +330,6 @@ class CorrelationDistributionDecoder(Decoder):
 
         * New attribute: `results_`. MetaResult object containing masker, meta-analytic maps,
           and tables. This attribute replaces `masker`, `features_`, and `images_`.
-
-        * `transform` now return a MetaResult object instead of a DataFrame.
 
     .. versionchanged:: 0.0.13
 
@@ -435,8 +429,9 @@ class CorrelationDistributionDecoder(Decoder):
 
         Returns
         -------
-        results : :obj:`~nimare.results.MetaResult`
-            MetaResult with meta-analytic masker, maps, and tables added.
+        out_df : :obj:`pandas.DataFrame`
+            DataFrame with one row for each feature, an index named "feature", and two columns:
+            "mean" and "std".
         """
         if not hasattr(self, "results_"):
             raise AttributeError(
@@ -459,11 +454,8 @@ class CorrelationDistributionDecoder(Decoder):
             out_df.loc[feature, "mean"] = np.mean(corrs_z)
             out_df.loc[feature, "std"] = np.std(corrs_z)
 
-        # DataFrame with one row for each feature, an index named "feature", and two columns:
-        # "mean" and "std".
+        # Update self.results_ to include the new table
         results.tables["correlation"] = out_df
-
-        # update self.results_ to include the new table
         self.results_ = results
 
-        return results
+        return out_df

--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -126,7 +126,10 @@ class CorrelationDecoder(Decoder):
         * New method: `load_imgs`. Load pre-generated meta-analytic maps for decoding.
 
         * New attribute: `results`. MetaResult object containing masker, meta-analytic maps,
-        and tables. This attribute replaces `masker`, `features_`, and `images_`.
+          and tables. This attribute replaces `masker`, `features_`, and `images_`.
+
+        * Braking-change: `transform` now require a MetaResult object in addition to the
+          image to decode.
 
     .. versionchanged:: 0.0.13
 
@@ -174,10 +177,9 @@ class CorrelationDecoder(Decoder):
         target_image="z_desc-specificity",
         n_cores=1,
     ):
-        if meta_estimator is None:
-            meta_estimator = MKDAChi2()
-        else:
-            meta_estimator = _check_type(meta_estimator, CBMAEstimator)
+        meta_estimator = (
+            MKDAChi2() if meta_estimator is None else _check_type(meta_estimator, CBMAEstimator)
+        )
 
         self.feature_group = feature_group
         self.features = features
@@ -321,7 +323,10 @@ class CorrelationDistributionDecoder(Decoder):
     .. versionchanged:: 0.1.0
 
         * New attribute: `results`. MetaResult object containing masker, meta-analytic maps,
-        and tables. This attribute replaces `masker`, `features_`, and `images_`.
+          and tables. This attribute replaces `masker`, `features_`, and `images_`.
+
+        * Braking-change: `transform` now require a MetaResult object in addition to the
+          image to decode.
 
     .. versionchanged:: 0.0.13
 

--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -128,6 +128,8 @@ class CorrelationDecoder(Decoder):
         * New attribute: `results_`. MetaResult object containing masker, meta-analytic maps,
           and tables. This attribute replaces `masker`, `features_`, and `images_`.
 
+        * `transform` now return a MetaResult object instead of a DataFrame.
+
     .. versionchanged:: 0.0.13
 
         * New parameter: `n_cores`. Number of cores to use for parallelization.
@@ -332,6 +334,8 @@ class CorrelationDistributionDecoder(Decoder):
 
         * New attribute: `results_`. MetaResult object containing masker, meta-analytic maps,
           and tables. This attribute replaces `masker`, `features_`, and `images_`.
+
+        * `transform` now return a MetaResult object instead of a DataFrame.
 
     .. versionchanged:: 0.0.13
 

--- a/nimare/tests/test_decode_continuous.py
+++ b/nimare/tests/test_decode_continuous.py
@@ -25,28 +25,28 @@ def test_CorrelationDecoder_smoke(testdata_laird, tmp_path_factory):
     # Test: train decoder with Dataset object
     decoder = continuous.CorrelationDecoder(features=features)
     decoder.fit(testdata_laird)
-    result = decoder.transform(img)
+    decoded_df = decoder.transform(img)
 
-    features = list(result.maps.keys())
-    images = np.array(list(result.maps.values()))
-    decoded_df = result.tables["correlation"]
     assert isinstance(decoded_df, pd.DataFrame)
+
+    # Get features and images to compare with other methods
+    features = list(decoder.results_.maps.keys())
+    images = np.array(list(decoder.results_.maps.values()))
 
     # Save images to disk to test load_imgs method
     tmpdir = tmp_path_factory.mktemp("test_CorrelationDecoder")
-    result.save_maps(tmpdir)
+    decoder.results_.save_maps(tmpdir)
 
     # Test: load pregenerated maps using a dictionary of feature names and paths
     img_dict = {feature: os.path.join(tmpdir, f"{feature}.nii.gz") for feature in features}
     decoder2 = continuous.CorrelationDecoder()
     decoder2.load_imgs(img_dict, mask=testdata_laird.masker)
-    result2 = decoder2.transform(img)
+    decoded2_df = decoder2.transform(img)
 
-    features2 = list(result2.maps.keys())
-    images2 = np.array(list(result2.maps.values()))
-    decoded2_df = result2.tables["correlation"]
+    features2 = list(decoder2.results_.maps.keys())
+    images2 = np.array(list(decoder2.results_.maps.values()))
+
     assert isinstance(decoded2_df, pd.DataFrame)
-
     assert np.array_equal(features, features2)
     assert np.array_equal(images, images2)
     assert decoded_df.equals(decoded2_df)
@@ -54,13 +54,12 @@ def test_CorrelationDecoder_smoke(testdata_laird, tmp_path_factory):
     # Test: load pregenerated maps from a directory
     decoder3 = continuous.CorrelationDecoder()
     decoder3.load_imgs(tmpdir.as_posix(), mask=testdata_laird.masker)
-    result3 = decoder3.transform(img)
+    decoded3_df = decoder3.transform(img)
 
-    features3 = list(result3.maps.keys())
-    images3 = np.array(list(result3.maps.values()))
-    decoded3_df = result3.tables["correlation"]
+    features3 = list(decoder3.results_.maps.keys())
+    images3 = np.array(list(decoder3.results_.maps.values()))
+
     assert isinstance(decoded3_df, pd.DataFrame)
-
     assert np.array_equal(features, features3)
     assert np.array_equal(images, images3)
     assert decoded_df.equals(decoded3_df)
@@ -122,9 +121,8 @@ def test_CorrelationDistributionDecoder_smoke(testdata_laird, tmp_path_factory):
     meta = mkda.KDA(null_method="approximate")
     res = meta.fit(testdata_laird)
     img = res.get_map("stat")
-    result = decoder.transform(img)
+    decoded_df = decoder.transform(img)
 
-    decoded_df = result.tables["correlation"]
     assert isinstance(decoded_df, pd.DataFrame)
 
     # Test: try transforming an image without fitting the decoder

--- a/nimare/tests/test_decode_continuous.py
+++ b/nimare/tests/test_decode_continuous.py
@@ -24,8 +24,8 @@ def test_CorrelationDecoder_smoke(testdata_laird, tmp_path_factory):
 
     # Test: train decoder with Dataset object
     decoder = continuous.CorrelationDecoder(features=features)
-    result = decoder.fit(testdata_laird)
-    result = decoder.transform(result, img)
+    decoder.fit(testdata_laird)
+    result = decoder.transform(img)
 
     features = list(result.maps.keys())
     images = np.array(list(result.maps.values()))
@@ -39,8 +39,8 @@ def test_CorrelationDecoder_smoke(testdata_laird, tmp_path_factory):
     # Test: load pregenerated maps using a dictionary of feature names and paths
     img_dict = {feature: os.path.join(tmpdir, f"{feature}.nii.gz") for feature in features}
     decoder2 = continuous.CorrelationDecoder()
-    result2 = decoder2.load_imgs(img_dict, mask=testdata_laird.masker)
-    result2 = decoder2.transform(result2, img)
+    decoder2.load_imgs(img_dict, mask=testdata_laird.masker)
+    result2 = decoder2.transform(img)
 
     features2 = list(result2.maps.keys())
     images2 = np.array(list(result2.maps.values()))
@@ -53,8 +53,8 @@ def test_CorrelationDecoder_smoke(testdata_laird, tmp_path_factory):
 
     # Test: load pregenerated maps from a directory
     decoder3 = continuous.CorrelationDecoder()
-    result3 = decoder3.load_imgs(tmpdir.as_posix(), mask=testdata_laird.masker)
-    result3 = decoder3.transform(result3, img)
+    decoder3.load_imgs(tmpdir.as_posix(), mask=testdata_laird.masker)
+    result3 = decoder3.transform(img)
 
     features3 = list(result3.maps.keys())
     images3 = np.array(list(result3.maps.values()))
@@ -74,6 +74,11 @@ def test_CorrelationDecoder_smoke(testdata_laird, tmp_path_factory):
     decoder5 = continuous.CorrelationDecoder()
     with pytest.raises(ValueError):
         decoder5.load_imgs(img_dict)
+
+    # Test: try transforming an image without fitting the decoder
+    decoder6 = continuous.CorrelationDecoder()
+    with pytest.raises(AttributeError):
+        decoder6.transform(img)
 
 
 def test_CorrelationDistributionDecoder_smoke(testdata_laird, tmp_path_factory):
@@ -111,13 +116,18 @@ def test_CorrelationDistributionDecoder_smoke(testdata_laird, tmp_path_factory):
         features=features,
         target_image=kern.image_type,
     )
-    result = decoder.fit(dset)
+    decoder.fit(dset)
 
     # Make an image to decode
     meta = mkda.KDA(null_method="approximate")
     res = meta.fit(testdata_laird)
     img = res.get_map("stat")
-    result = decoder.transform(result, img)
+    result = decoder.transform(img)
 
     decoded_df = result.tables["correlation"]
     assert isinstance(decoded_df, pd.DataFrame)
+
+    # Test: try transforming an image without fitting the decoder
+    decoder2 = decoder = continuous.CorrelationDistributionDecoder()
+    with pytest.raises(AttributeError):
+        decoder2.transform(img)

--- a/nimare/tests/test_decode_continuous.py
+++ b/nimare/tests/test_decode_continuous.py
@@ -70,6 +70,11 @@ def test_CorrelationDecoder_smoke(testdata_laird, tmp_path_factory):
     with pytest.raises(ValueError):
         decoder4.load_imgs(testdata_laird, mask=testdata_laird.masker)
 
+    # Test: try loading pregenerated maps without a masker
+    decoder5 = continuous.CorrelationDecoder()
+    with pytest.raises(ValueError):
+        decoder5.load_imgs(img_dict)
+
 
 def test_CorrelationDistributionDecoder_smoke(testdata_laird, tmp_path_factory):
     """Smoke test for continuous.CorrelationDistributionDecoder."""

--- a/nimare/tests/test_decode_continuous.py
+++ b/nimare/tests/test_decode_continuous.py
@@ -26,7 +26,7 @@ def test_CorrelationDecoder_smoke(testdata_laird, tmp_path_factory):
     decoded_df = decoder.transform(img)
     assert isinstance(decoded_df, pd.DataFrame)
 
-    # Save images to disk
+    # Save images to disk to use in load_imgs
     img_dict = {}
     tmpdir = tmp_path_factory.mktemp("test_CorrelationDecoder")
     for feature_i, feature in enumerate(features):
@@ -37,8 +37,8 @@ def test_CorrelationDecoder_smoke(testdata_laird, tmp_path_factory):
         img_dict[feature] = out_file
 
     # Train decoder with pregenerated maps
-    decoder2 = continuous.CorrelationDecoder(mask=testdata_laird.masker)
-    decoder2.fit(img_dict)
+    decoder2 = continuous.CorrelationDecoder()
+    decoder2.load_imgs(img_dict, mask=testdata_laird.masker)
     decoded2_df = decoder2.transform(img)
 
     assert np.array_equal(decoder.features_, decoder2.features_)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #781.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- New method: `load_imgs`. Load pre-generated meta-analytic maps for decoding.
- New attribute: `results_`. MetaResult object containing masker, meta-analytic maps, and tables. This attribute replaces `masker`, `features_`, and `images_`.
