### PR TITLE
[MAINT] make indexed_gzip install optional

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,6 @@ python_requires = >= 3.6
 install_requires =
     cognitiveatlas  # nimare.annotate.cogat
     fuzzywuzzy  # nimare.annotate
-    indexed_gzip>=1.4.0  # working with gzipped niftis
     joblib  # parallelization
     matplotlib>=3.3  # this is for nilearn, which doesn't include it in its reqs
     nibabel>=3.0.0  # I/O of niftis
@@ -60,6 +59,8 @@ packages = find:
 include_package_data = False
 
 [options.extras_require]
+gzip = 
+    indexed_gzip>=1.4.0  # working with gzipped niftis
 doc =
     m2r
     matplotlib
@@ -82,7 +83,6 @@ tests =
     pytest
     pytest-cov
 minimum =
-    indexed_gzip==1.4
     matplotlib==3.3.4
     nibabel==3.0
     nilearn==0.9.2


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

removing indexed_gzip makes NiMARE a pure python package (and therefore usable by pyodide/jupyterlite, etc)
<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- make indexed_gzip installable via `[gzip]`
-
