### PR TITLE
Unpin numpy version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     nibabel>=3.0.0  # I/O of niftis
     nilearn>=0.9.2
     numba  # used by sparse
-    numpy<1.24,>=1.18 # for compatibility with numba https://github.com/numba/numba/issues/8615
+    numpy>=1.18
     pandas>=1.1.0
     pymare~=0.0.4rc2  # nimare.meta.ibma and stats
     requests  # nimare.extract


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->

This is an attempt to unpin the maximum version of numpy, given that this issue `https://github.com/numba/numba/issues/8615` was closed. 
Hopefully, this will address one of the issues we have with installing nimare in a pyodide kernel: https://github.com/neurostuff/NiMARE/pull/785#issuecomment-1528079272.
