### PR TITLE
Set `n_iters` and `n_cores` defaults only for estimators with `null_method="montecarlo"`

### DIFF
--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -125,8 +125,8 @@ class ALE(CBMAEstimator):
         self,
         kernel_transformer=ALEKernel,
         null_method="approximate",
-        n_iters=10000,
-        n_cores=1,
+        n_iters=None,
+        n_cores=None,
         **kwargs,
     ):
         if not (isinstance(kernel_transformer, ALEKernel) or kernel_transformer == ALEKernel):
@@ -139,8 +139,8 @@ class ALE(CBMAEstimator):
         # Add kernel transformer attribute and process keyword arguments
         super().__init__(kernel_transformer=kernel_transformer, **kwargs)
         self.null_method = null_method
-        self.n_iters = n_iters
-        self.n_cores = _check_ncores(n_cores)
+        self.n_iters = None if null_method == "approximate" else n_iters or 10000
+        self.n_cores = None if null_method == "approximate" else _check_ncores(n_cores) or 1
         self.dataset = None
 
     def _generate_description(self):

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -125,8 +125,8 @@ class MKDADensity(CBMAEstimator):
         self,
         kernel_transformer=MKDAKernel,
         null_method="approximate",
-        n_iters=10000,
-        n_cores=1,
+        n_iters=None,
+        n_cores=None,
         **kwargs,
     ):
         if not (isinstance(kernel_transformer, MKDAKernel) or kernel_transformer == MKDAKernel):
@@ -139,8 +139,8 @@ class MKDADensity(CBMAEstimator):
         # Add kernel transformer attribute and process keyword arguments
         super().__init__(kernel_transformer=kernel_transformer, **kwargs)
         self.null_method = null_method
-        self.n_iters = n_iters
-        self.n_cores = _check_ncores(n_cores)
+        self.n_iters = None if null_method == "approximate" else n_iters or 10000
+        self.n_cores = None if null_method == "approximate" else _check_ncores(n_cores) or 1
         self.dataset = None
 
     def _generate_description(self):
@@ -1112,8 +1112,8 @@ class KDA(CBMAEstimator):
         self,
         kernel_transformer=KDAKernel,
         null_method="approximate",
-        n_iters=10000,
-        n_cores=1,
+        n_iters=None,
+        n_cores=None,
         **kwargs,
     ):
         LGR.warning(
@@ -1132,8 +1132,8 @@ class KDA(CBMAEstimator):
         # Add kernel transformer attribute and process keyword arguments
         super().__init__(kernel_transformer=kernel_transformer, **kwargs)
         self.null_method = null_method
-        self.n_iters = n_iters
-        self.n_cores = _check_ncores(n_cores)
+        self.n_iters = None if null_method == "approximate" else n_iters or 10000
+        self.n_cores = None if null_method == "approximate" else _check_ncores(n_cores) or 1
         self.dataset = None
 
     def _generate_description(self):


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #801 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Set `n_iters` and `n_cores` defaults only for estimators with `null_method="montecarlo"`.
