### PR TITLE
Fix the aspect ratio and size of the heatmap in Reports

### DIFF
--- a/nimare/reports/base.py
+++ b/nimare/reports/base.py
@@ -60,8 +60,9 @@ SVG_SNIPPET = [
 ]
 
 IFRAME_SNIPPET = """\
-<iframe id="igraph" scrolling="no" style="border:none;" seamless="seamless" \
-src="./{0}" height="800" width="100%"></iframe>
+<div class="igraph-container">
+    <iframe class="igraph" src="./{0}"></iframe>
+</div>
 """
 
 PARAMETERS_DICT = {

--- a/nimare/reports/default.yml
+++ b/nimare/reports/default.yml
@@ -49,6 +49,7 @@ sections:
   - bids: {value: preliminary, suffix: figure-legend}
   - bids: {value: preliminary, suffix: figure-interactive}
     title: Explorer
+    iframe: True
 - name: Meta-Analysis
   reportlets:
   - bids: {value: estimator, suffix: summary}
@@ -77,9 +78,7 @@ sections:
     subtitle: FocusCounter
     caption: *heatmap_text
     description: *focuscounter_text
-    iframe: True
   - bids: {value: diagnostics, diag: Jackknife, tab: counts, suffix: figure}
     subtitle: Jackknife
     caption: *heatmap_text
     description: *jackknife_text
-    iframe: True

--- a/nimare/reports/figures.py
+++ b/nimare/reports/figures.py
@@ -285,10 +285,12 @@ def plot_heatmap(contribution_table, out_filename):
     )
     new_df = pd.DataFrame(new_mat, columns=new_col_labels, index=new_row_labels)
 
-    fig = px.imshow(new_df, color_continuous_scale="Reds", aspect="auto")
-    width, height = len(new_col_labels) * 50, len(new_row_labels) * 50
-    fig.update_layout(autosize=False, width=width, height=height)
+    pxs_per_sqr = 50  # Number of pixels per square in the heatmap
+    plot2bar_space = 2  # Number of pixels between the heatmap and the barplot
+    width, height = (len(col_labels) + plot2bar_space) * pxs_per_sqr, len(row_labels) * pxs_per_sqr
 
+    fig = px.imshow(new_df, color_continuous_scale="Reds", aspect="auto")
+    fig.update_layout(autosize=False, width=width, height=height)
     fig.write_html(out_filename, full_html=True, include_plotlyjs=True)
 
 

--- a/nimare/reports/figures.py
+++ b/nimare/reports/figures.py
@@ -285,12 +285,10 @@ def plot_heatmap(contribution_table, out_filename):
     )
     new_df = pd.DataFrame(new_mat, columns=new_col_labels, index=new_row_labels)
 
-    fig = px.imshow(new_df, color_continuous_scale="Reds")
-    fig.update_layout(
-        autosize=False,
-        width=800,
-        height=800,
-    )
+    fig = px.imshow(new_df, color_continuous_scale="Reds", aspect="auto")
+    width, height = len(new_col_labels) * 50, len(new_row_labels) * 50
+    fig.update_layout(autosize=False, width=width, height=height)
+
     fig.write_html(out_filename, full_html=True, include_plotlyjs=True)
 
 

--- a/nimare/reports/report.tpl
+++ b/nimare/reports/report.tpl
@@ -36,6 +36,23 @@ body {
     padding: 65px 10px 10px;
 }
 
+.igraph-container {
+  position: relative;
+  overflow: hidden;
+  width: 100%;
+  padding-top: 50%;
+}
+.igraph {
+  position: absolute;
+  border: none;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .boiler-html {
     font-family: "Bitstream Charter", "Georgia", Times;
     margin: 20px 25px;


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #814.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Use iframes for Connectomes instead, given that its aspect ratio is fixed. 
- Keep the size of the heatmap fixed by including the str in the HTML directly.
- Set the size of the heatmap proportional to the number of rows (number of studies) and columns (number of clusters).
