### PR TITLE
Support surface data

### DIFF
--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -21,6 +21,10 @@ def compute_kda_ma(
 ):
     """Compute (M)KDA modeled activation (MA) map.
 
+    .. versionchanged:: 0.2.x
+
+        * Suport surface-based data.
+
     .. versionchanged:: 0.0.12
 
         * Remove low-memory option in favor of sparse arrays.


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->

In this PR, I will start drafting some of the things we need to implement to support surface data in NiMARE.
 

- [ ] Support 2D coordinates of vertices in Kernel transformers: `ALEKernel`, and `KDAKernel`.
- [ ] Support 2D arrays in `compute_kda_ma` and `compute_ale_ma` to compute MA maps on the surface.
- Note: For these cases, we won't need sparse arrays.
- [ ] Return 2D kernels from `get_ale_kernel` when requested.
- [ ] Add `vertex2voxel` and `voxel2vertex` functions
- Use registration fusion (Wu et al., 2018) for `voxel2vertex`. See [neuromaps.transforms._regfusion_project](https://github.com/netneurolab/neuromaps/blob/abc085acdc96223a4848b331951afd4aab529a20/neuromaps/transforms.py#L88) for MNI to vertices.
- Check [mne.vertex_to_mni](https://github.com/mne-tools/mne-python/blob/main/mne/_freesurfer.py#L340-L384) for vertices to voxels.
- [ ] For the kernel transformer, get the geodesic distance between all vertices on the surface. See [get_surface_distance](https://github.com/netneurolab/neuromaps/blob/abc085acdc96223a4848b331951afd4aab529a20/neuromaps/points.py#L326).
- [ ] Masker:
- In this case, we won't need a masker, but a function that converts gifti to a numpy array. See [_gifti_to_array](https://github.com/netneurolab/neuromaps/blob/abc085acdc96223a4848b331951afd4aab529a20/neuromaps/parcellate.py#L19) in neuromaps.
- Remove the medial wall from each hemisphere and stack the two arrays: https://github.com/JulioAPeraza/gradec/blob/c2cae635132c2b42b47c36b237fb393eb6ebc158/gradec/utils.py#L121