### PR TITLE
fix an index error in diagnostics.py

### DIFF
--- a/nimare/diagnostics.py
+++ b/nimare/diagnostics.py
@@ -478,7 +478,8 @@ class FocusFilter(NiMAREBase):
         # Only retain coordinates inside the brain mask
         def check_coord(coord):
             try:
-                return masker_array[coord[0], coord[1], coord[2]] == 1
+                # index starts from 0, while coordinates start from 1
+                return masker_array[coord[0] - 1, coord[1] - 1, coord[2] - 1] == 1
             except IndexError:
                 return False
 

--- a/nimare/tests/test_diagnostics.py
+++ b/nimare/tests/test_diagnostics.py
@@ -163,5 +163,5 @@ def test_focusfilter(testdata_laird):
     filtered_dset = ffilter.transform(testdata_laird)
     n_coordinates_filtered = filtered_dset.coordinates.shape[0]
     assert n_coordinates_all == 1117
-    assert n_coordinates_filtered == 1101
+    assert n_coordinates_filtered == 1103
     assert n_coordinates_filtered <= n_coordinates_all


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- When checking if a foci coordinate falls within brain mask, index starts from 0 while coordinate starts from 1, so index should be [coord[0]-1, coord[1]-1, coord[2]-1].
-
