### PR TITLE
Optimize compute_kda_ma for memory and speed

### DIFF
--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -205,7 +205,7 @@ class CBMAEstimator(Estimator):
         """
         return None
 
-    def _collect_ma_maps(self, coords_key="coordinates", maps_key="ma_maps"):
+    def _collect_ma_maps(self, coords_key="coordinates", maps_key="ma_maps", return_type="sparse"):
         """Collect modeled activation maps from Estimator inputs.
 
         Parameters
@@ -231,7 +231,7 @@ class CBMAEstimator(Estimator):
         ma_maps = self.kernel_transformer.transform(
             self.inputs_[coords_key],
             masker=self.masker,
-            return_type="sparse",
+            return_type=return_type,
         )
 
         return ma_maps

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -122,9 +122,7 @@ def compute_kda_ma(
             all_spheres = unique_rows(all_spheres)
 
         # Mask coordinates beyond space
-        idx = np.all(
-            np.logical_and(all_spheres >= 0, np.less(all_spheres, shape)), axis=1
-        )
+        idx = np.all(np.logical_and(all_spheres >= 0, np.less(all_spheres, shape)), axis=1)
 
         all_spheres = all_spheres[idx, :]
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -7,7 +7,7 @@ from numba import jit
 from scipy import ndimage
 
 from nimare.utils import unique_rows
-
+@profile
 def compute_kda_ma(
     mask,
     ijks,
@@ -125,7 +125,7 @@ def compute_kda_ma(
         all_spheres = all_spheres[idx, :]
 
         sphere_idx_inside_mask = np.where(mask_data[tuple(all_spheres.T)])[0]
-        sphere_idx_filtered = all_spheres[sphere_idx_inside_mask, :].T
+        sphere_idx_filtered = all_spheres[sphere_idx_inside_mask, :]
 
         if sum_overlap:
             nonzero_to_append = counts[idx][sphere_idx_inside_mask]
@@ -133,13 +133,11 @@ def compute_kda_ma(
             nonzero_to_append = np.ones((len(sphere_idx_inside_mask),)) * value
 
         # Combine experiment id with coordinates
-        exp_coords = np.vstack(
-            [np.full(sphere_idx_filtered.shape[1], i_exp), sphere_idx_filtered])
-
+        exp_coords = np.insert(sphere_idx_filtered, 0, i_exp, axis=1)
         all_coords.append(exp_coords)
         all_data.append(nonzero_to_append)
 
-    coords = np.hstack(all_coords)
+    coords = np.vstack(all_coords).T
     data = np.hstack(all_data).flatten().astype(np.int32)
     kernel_data = sparse.COO(coords, data, shape=kernel_shape)
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -8,7 +8,6 @@ from scipy import ndimage
 
 from nimare.utils import unique_rows
 
-
 def compute_kda_ma(
     mask,
     ijks,
@@ -128,19 +127,20 @@ def compute_kda_ma(
 
         sphere_idx_inside_mask = np.where(mask_data[tuple(all_spheres.T)])[0]
         sphere_idx_filtered = all_spheres[sphere_idx_inside_mask, :].T
-        nonzero_idx = tuple(sphere_idx_filtered)
 
         if sum_overlap:
             nonzero_to_append = counts[idx][sphere_idx_inside_mask]
         else:
             nonzero_to_append = np.ones((len(sphere_idx_inside_mask),)) * value
 
-        all_exp.append(np.full(nonzero_idx[0].shape[0], i_exp))
-        all_coords.append(np.vstack(nonzero_idx))
+        # Combine experiment id with coordinates
+        exp_coords = np.vstack(
+            [np.full(sphere_idx_filtered.shape[1], i_exp), sphere_idx_filtered])
+
+        all_coords.append(exp_coords)
         all_data.append(nonzero_to_append)
 
-    exp = np.hstack(all_exp)
-    coords = np.vstack((exp.flatten(), np.hstack(all_coords)))
+    coords = np.vstack(np.hstack(all_coords))
 
     data = np.hstack(all_data).flatten().astype(np.int32)
     kernel_data = sparse.COO(coords, data, shape=kernel_shape)
@@ -152,7 +152,7 @@ def compute_ale_ma(mask, ijks, kernel=None, exp_idx=None, sample_sizes=None, use
     """Generate ALE modeled activation (MA) maps.
 
     Replaces the values around each focus in ijk with the contrast-specific
-    kernel. Takes the element-wise maximum when looping through foci, which
+    kernel. Tmask_datakes the element-wise maximum when looping through foci, which
     accounts for foci which are near to one another and may have overlapping
     kernels.
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -145,7 +145,7 @@ def compute_kda_ma(
     all_coords = np.vstack(all_coords).T
     all_coords = np.insert(all_coords, 0, exp_indicator, axis=0)
 
-    kernel_data = sparse.COO(all_coords, data=1, has_duplicates=sum_overlap, shape=kernel_shape)
+    kernel_data = sparse.COO(all_coords, data=value, has_duplicates=sum_overlap, shape=kernel_shape)
 
     return kernel_data
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -102,7 +102,6 @@ def compute_kda_ma(
         return sphere_coords
 
     all_coords = []
-    all_exp = []
     all_data = []
     # Loop over experiments
     for i_exp, _ in enumerate(exp_idx_uniq):
@@ -140,8 +139,7 @@ def compute_kda_ma(
         all_coords.append(exp_coords)
         all_data.append(nonzero_to_append)
 
-    coords = np.vstack(np.hstack(all_coords))
-
+    coords = np.hstack(all_coords)
     data = np.hstack(all_data).flatten().astype(np.int32)
     kernel_data = sparse.COO(coords, data, shape=kernel_shape)
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -49,7 +49,7 @@ def _convolve_sphere(kernel, ijks, index, max_shape):
 
     return sphere_coords[idx, :]
 
-@profile
+
 def compute_kda_ma(
     mask,
     ijks,

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -7,7 +7,7 @@ from numba import jit
 from scipy import ndimage
 
 from nimare.utils import unique_rows
-@profile
+
 def compute_kda_ma(
     mask,
     ijks,

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -153,7 +153,7 @@ def compute_kda_ma(
         all_coords = []
         # Loop over experiments
         for i_exp, _ in enumerate(exp_idx_uniq):
-            # Index peaks by experiment
+            curr_exp_idx = exp_idx == i_exp
             # Convolve with sphere
             all_spheres = _convolve_sphere(kernel, ijks, curr_exp_idx, np.array(shape))
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -103,10 +103,8 @@ def compute_kda_ma(
         unique experiments, and the remaining 3 dimensions are equal to `shape`.
     """
     if sum_overlap and sum_across_studies:
-        raise NotImplementedError(
-            "sum_overlap and sum_across_studies cannot both be True."
-        )
-        
+        raise NotImplementedError("sum_overlap and sum_across_studies cannot both be True.")
+
     # recast ijks to int32 to reduce memory footprint
     ijks = ijks.astype(np.int32)
     shape = mask.shape

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -152,7 +152,7 @@ def compute_ale_ma(mask, ijks, kernel=None, exp_idx=None, sample_sizes=None, use
     """Generate ALE modeled activation (MA) maps.
 
     Replaces the values around each focus in ijk with the contrast-specific
-    kernel. Tmask_datakes the element-wise maximum when looping through foci, which
+    kernel. Takes the element-wise maximum when looping through foci, which
     accounts for foci which are near to one another and may have overlapping
     kernels.
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -102,6 +102,11 @@ def compute_kda_ma(
         is returned, where the first dimension has size equal to the number of
         unique experiments, and the remaining 3 dimensions are equal to `shape`.
     """
+    if sum_overlap and sum_across_studies:
+        raise NotImplementedError(
+            "sum_overlap and sum_across_studies cannot both be True."
+        )
+        
     # recast ijks to int32 to reduce memory footprint
     ijks = ijks.astype(np.int32)
     shape = mask.shape
@@ -135,13 +140,7 @@ def compute_kda_ma(
 
             # preallocate array for current study
             study_values = np.zeros(shape, dtype=np.int32)
-
-            if sum_overlap:
-                study_values[
-                    sphere_coords[:, 0], sphere_coords[:, 1], sphere_coords[:, 2]
-                ] += value
-            else:
-                study_values[sphere_coords[:, 0], sphere_coords[:, 1], sphere_coords[:, 2]] = value
+            study_values[sphere_coords[:, 0], sphere_coords[:, 1], sphere_coords[:, 2]] = value
 
             # Sum across studies
             all_values += study_values

--- a/nimare/reports/base.py
+++ b/nimare/reports/base.py
@@ -51,6 +51,7 @@ PARAMETERS_DICT = {
     "kernel_transformer__value": "Value for sphere",
     "kernel_transformer__memory": "Memory",
     "kernel_transformer__memory_level": "Memory level",
+    "kernel_transformer__sum_across_studies": "Sum Across Studies",
     "memory": "Memory",
     "memory_level": "Memory level",
     "null_method": "Null method",

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,13 +90,14 @@ tests =
     pytest-cov
 minimum =
     matplotlib==3.5.2
-    nibabel==3.2.0
+    nibabel==4.0.0
     nilearn==0.10.1
-    numpy==1.22
+    numpy==1.24
     pandas==2.0.0
     pymare==0.0.4rc2
     scikit-learn==1.0.0
     scipy==1.6.0
+    seaborn==0.13.0
 all =
     %(gzip)s
     %(cbmr)s

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,7 @@ minimum =
     matplotlib==3.5.2
     nibabel==4.0.0
     nilearn==0.10.1
-    numpy==1.24
+    numpy==1.24.1
     pandas==2.0.0
     pymare==0.0.4rc2
     scikit-learn==1.0.0


### PR DESCRIPTION
- Implement "summary_array" return type for `MKDAKernel`, which convolves kernels to coordinates in a 3D dense volume, summing counts in place, saving substantial memory and compute. 
- Using numba to speed up sphere kernel convolution
- @jdkent set types to int to reduce memory usage
- Minor improvements throughout

For large-scale `MKDAChi2` (i.e. using Neurosynth dataset), memory footprint is reduced ~18-20x (25GB to 1.2GB), and computation is sped up ~3.2x. 