### PR TITLE
Add `sum_across_studies` to kda

### DIFF
--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -205,7 +205,7 @@ class CBMAEstimator(Estimator):
         """
         return None
 
-    def _collect_ma_maps(self, coords_key="coordinates", maps_key="ma_maps"):
+    def _collect_ma_maps(self, coords_key="coordinates", maps_key="ma_maps", return_type="sparse"):
         """Collect modeled activation maps from Estimator inputs.
 
         Parameters
@@ -231,7 +231,7 @@ class CBMAEstimator(Estimator):
         ma_maps = self.kernel_transformer.transform(
             self.inputs_[coords_key],
             masker=self.masker,
-            return_type="sparse",
+            return_type=return_type,
         )
 
         return ma_maps

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -571,22 +571,17 @@ class MKDAChi2(PairwiseCBMAEstimator):
         iter_df2[["x", "y", "z"]] = iter_xyz2
 
         # Generate MA maps and calculate count variables for first dataset
-        temp_ma_maps1 = self.kernel_transformer.transform(
+        n_selected_active_voxels = self.kernel_transformer.transform(
             iter_df1, self.masker, return_type="sparse"
         )
-        n_selected = temp_ma_maps1.shape[0]
-        n_selected_active_voxels = self._load_ma_maps(temp_ma_maps1)
 
-        del temp_ma_maps1
+        n_selected = self.dataset1.coordinates["id"].unique().shape[0]
 
         # Generate MA maps and calculate count variables for second dataset
-        temp_ma_maps2 = self.kernel_transformer.transform(
+        n_unselected_active_voxels = self.kernel_transformer.transform(
             iter_df2, self.masker, return_type="sparse"
         )
-        n_unselected = temp_ma_maps2.shape[0]
-        n_unselected_active_voxels = self._load_ma_maps(temp_ma_maps2)
-
-        del temp_ma_maps2
+        n_unselected = self.dataset2.coordinates["id"].unique().shape[0]
 
         # Currently unused conditional probabilities
         # pAgF = n_selected_active_voxels / n_selected

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -388,7 +388,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
 
     def __init__(
         self,
-        kernel_transformer=MKDAKernel,
+        kernel_transformer=MKDAKernel(sum_across_studies=True),
         prior=0.5,
         memory=Memory(location=None, verbose=0),
         memory_level=0,

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -388,7 +388,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
 
     def __init__(
         self,
-        kernel_transformer=MKDAKernel(sum_across_studies=True),
+        kernel_transformer=MKDAKernel(),
         prior=0.5,
         memory=Memory(location=None, verbose=0),
         memory_level=0,
@@ -441,6 +441,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
         n_selected_active_voxels = self._collect_ma_maps(
             maps_key="ma_maps1",
             coords_key="coordinates1",
+            return_type="summary_array",
         )
 
         n_selected = self.dataset1.coordinates["id"].unique().shape[0]
@@ -449,6 +450,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
         n_unselected_active_voxels = self._collect_ma_maps(
             maps_key="ma_maps2",
             coords_key="coordinates2",
+            return_type="summary_array",
         )
         n_unselected = self.dataset2.coordinates["id"].unique().shape[0]
 
@@ -572,14 +574,14 @@ class MKDAChi2(PairwiseCBMAEstimator):
 
         # Generate MA maps and calculate count variables for first dataset
         n_selected_active_voxels = self.kernel_transformer.transform(
-            iter_df1, self.masker, return_type="sparse"
+            iter_df1, self.masker, return_type="summary_array"
         )
 
         n_selected = self.dataset1.coordinates["id"].unique().shape[0]
 
         # Generate MA maps and calculate count variables for second dataset
         n_unselected_active_voxels = self.kernel_transformer.transform(
-            iter_df2, self.masker, return_type="sparse"
+            iter_df2, self.masker, return_type="summary_array"
         )
         n_unselected = self.dataset2.coordinates["id"].unique().shape[0]
 

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -184,7 +184,7 @@ class KernelTransformer(NiMAREBase):
                 imgs.append(img)
             elif return_type == "image":
                 kernel_data *= mask_data
-                img = nib.Nifti1Image(kernel_data, mask.affine)
+                img = nib.Nifti1Image(kernel_data, mask.affine, dtype=kernel_data.dtype)
                 imgs.append(img)
 
         del kernel_data, transformed_maps

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -382,7 +382,7 @@ class KDAKernel(KernelTransformer):
         value=1,
         memory=Memory(location=None, verbose=0),
         memory_level=0,
-        sum_across_studies=False
+        sum_across_studies=False,
     ):
         self.r = float(r)
         self.value = value

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -371,7 +371,7 @@ class KDAKernel(KernelTransformer):
     """
 
     _sum_overlap = True
-    _mean_across_studies = False
+    _sum_across_studies = False
 
     def __init__(
         self,
@@ -394,7 +394,7 @@ class KDAKernel(KernelTransformer):
             self.value,
             exp_idx,
             sum_overlap=self._sum_overlap,
-            mean_across_studies=self._mean_across_studies,
+            sum_across_studies=self._sum_across_studies,
         )
         exp_ids = np.unique(exp_idx)
         return transformed, exp_ids
@@ -447,7 +447,7 @@ class MKDAKernel(KDAKernel):
     """
 
     _sum_overlap = False
-    _mean_across_studies = True
+    _sum_across_studies = True
 
     def _generate_description(self):
         """Generate a description of the fitted KernelTransformer.

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -344,6 +344,10 @@ class ALEKernel(KernelTransformer):
 class KDAKernel(KernelTransformer):
     """Generate KDA modeled activation images from coordinates.
 
+    .. versionchanged:: 0.2.1
+
+        - Add new parameter ``sum_across_studies`` to sum across studies in KDA.
+
     .. versionchanged:: 0.0.13
 
         - Add new parameter ``memory`` to cache modeled activation (MA) maps.
@@ -371,7 +375,6 @@ class KDAKernel(KernelTransformer):
     """
 
     _sum_overlap = True
-    _sum_across_studies = False
 
     def __init__(
         self,
@@ -379,9 +382,11 @@ class KDAKernel(KernelTransformer):
         value=1,
         memory=Memory(location=None, verbose=0),
         memory_level=0,
+        sum_across_studies=False
     ):
         self.r = float(r)
         self.value = value
+        self.sum_across_studies = sum_across_studies
         super().__init__(memory=memory, memory_level=memory_level)
 
     def _transform(self, mask, coordinates):
@@ -394,7 +399,7 @@ class KDAKernel(KernelTransformer):
             self.value,
             exp_idx,
             sum_overlap=self._sum_overlap,
-            sum_across_studies=self._sum_across_studies,
+            sum_across_studies=self.sum_across_studies,
         )
         exp_ids = np.unique(exp_idx)
         return transformed, exp_ids
@@ -447,7 +452,6 @@ class MKDAKernel(KDAKernel):
     """
 
     _sum_overlap = False
-    _sum_across_studies = True
 
     def _generate_description(self):
         """Generate a description of the fitted KernelTransformer.

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -371,6 +371,7 @@ class KDAKernel(KernelTransformer):
     """
 
     _sum_overlap = True
+    _mean_across_studies = False
 
     def __init__(
         self,
@@ -393,6 +394,7 @@ class KDAKernel(KernelTransformer):
             self.value,
             exp_idx,
             sum_overlap=self._sum_overlap,
+            mean_across_studies=self._mean_across_studies,
         )
         exp_ids = np.unique(exp_idx)
         return transformed, exp_ids
@@ -445,6 +447,7 @@ class MKDAKernel(KDAKernel):
     """
 
     _sum_overlap = False
+    _mean_across_studies = True
 
     def _generate_description(self):
         """Generate a description of the fitted KernelTransformer.

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -48,7 +48,6 @@ def _convolve_sphere(kernel, peaks, max_shape):
     
     return sphere_coords[idx, :]
 
-@profile
 def compute_kda_ma(
     mask,
     ijks,

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -45,8 +45,9 @@ def _convolve_sphere(kernel, peaks, max_shape):
 
     # Mask coordinates beyond space
     idx = np_all_axis1(np.logical_and(sphere_coords >= 0, np.less(sphere_coords, max_shape)))
-    
+
     return sphere_coords[idx, :]
+
 
 def compute_kda_ma(
     mask,
@@ -143,7 +144,7 @@ def compute_kda_ma(
 
             # Sum across studies
             all_values += study_values
-        
+
         # Set voxel outside the mask to zero.
         all_values[~mask_data] = 0
 
@@ -171,7 +172,7 @@ def compute_kda_ma(
 
             if not sum_overlap:
                 all_spheres = unique_rows(all_spheres)
-            
+
             # Combine experiment id with coordinates
             all_coords.append(all_spheres)
 
@@ -182,7 +183,9 @@ def compute_kda_ma(
         all_coords = np.vstack(all_coords).T
         all_coords = np.insert(all_coords, 0, exp_indicator, axis=0)
 
-        kernel_data = sparse.COO(all_coords, data=value, has_duplicates=sum_overlap, shape=kernel_shape)
+        kernel_data = sparse.COO(
+            all_coords, data=value, has_duplicates=sum_overlap, shape=kernel_shape
+        )
 
     return kernel_data
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -145,19 +145,9 @@ def compute_kda_ma(
             # Sum across studies
             all_values += study_values
 
-        # Set voxel outside the mask to zero.
-        all_values[~mask_data] = 0
-
-        # Go from dense to sparse
-        nonzero_idx = np.where(all_values > 0)
-        all_coords = np.vstack(nonzero_idx)
-        value = all_values[nonzero_idx]
-
-        # Add dummy indicator to return 4D sparse array
-        exp_indicator = np.zeros(all_coords.shape[1])
-        all_coords = np.insert(all_coords, 0, exp_indicator, axis=0)
-
-        kernel_data = sparse.COO(all_coords, data=value, has_duplicates=False, shape=kernel_shape)
+        # Only return values within the mask
+        all_values = all_values.reshape(-1)
+        kernel_data = all_values[mask_data.reshape(-1)]
 
     else:
         all_coords = []

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -138,7 +138,7 @@ def compute_kda_ma(
             study_values = np.zeros(shape, dtype=np.int32)
 
             if sum_overlap:
-                sphere_coords = unique_rows(sphere_coords)
+                study_values[sphere_coords[:, 0], sphere_coords[:, 1], sphere_coords[:, 2]] += value
             else:
                 study_values[sphere_coords[:, 0], sphere_coords[:, 1], sphere_coords[:, 2]] = value
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -164,8 +164,11 @@ def compute_kda_ma(
 
             if not sum_overlap:
                 all_spheres = unique_rows(all_spheres)
-        sphere_idx_inside_mask = np.where(mask_data[tuple(all_spheres.T)])[0]
-        all_spheres = all_spheres[sphere_idx_inside_mask, :]
+
+            # Apply mask
+            sphere_idx_inside_mask = np.where(mask_data[tuple(all_spheres.T)])[0]
+            all_spheres = all_spheres[sphere_idx_inside_mask, :]
+
             # Combine experiment id with coordinates
             all_coords.append(all_spheres)
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -164,7 +164,8 @@ def compute_kda_ma(
 
             if not sum_overlap:
                 all_spheres = unique_rows(all_spheres)
-
+        sphere_idx_inside_mask = np.where(mask_data[tuple(all_spheres.T)])[0]
+        all_spheres = all_spheres[sphere_idx_inside_mask, :]
             # Combine experiment id with coordinates
             all_coords.append(all_spheres)
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -134,7 +134,7 @@ def compute_kda_ma(
 
             sphere_coords = _convolve_sphere(kernel, peaks, np.array(shape))
 
-            # Go from sparse to dense
+            # preallocate array for current study
             study_values = np.zeros(shape, dtype=np.int32)
 
             if sum_overlap:

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -48,6 +48,7 @@ def _convolve_sphere(kernel, peaks, max_shape):
     
     return sphere_coords[idx, :]
 
+@profile
 def compute_kda_ma(
     mask,
     ijks,
@@ -55,6 +56,7 @@ def compute_kda_ma(
     value=1.0,
     exp_idx=None,
     sum_overlap=False,
+    sum_across_studies=False,
 ):
     """Compute (M)KDA modeled activation (MA) map.
 
@@ -88,6 +90,8 @@ def compute_kda_ma(
         come from the same experiment.
     sum_overlap : :obj:`bool`
         Whether to sum voxel values in overlapping spheres.
+    sum_across_studies : :obj:`bool`
+        Whether to sum voxel values across studies.
 
     Returns
     -------
@@ -119,33 +123,67 @@ def compute_kda_ma(
     )
     kernel = cube[:, np.sum(np.dot(np.diag(vox_dims), cube) ** 2, 0) ** 0.5 <= r]
 
-    all_coords = []
-    # Loop over experiments
-    for i_exp, _ in enumerate(exp_idx_uniq):
-        # Index peaks by experiment
-        curr_exp_idx = exp_idx == i_exp
-        peaks = ijks[curr_exp_idx]
+    if sum_across_studies:
+        all_values = np.zeros(shape, dtype=np.int32)
 
-        # Convolve with sphere
-        all_spheres = _convolve_sphere(kernel, peaks, np.array(shape))
+        # Loop over experiments
+        for i_exp, _ in enumerate(exp_idx_uniq):
+            # Index peaks by experiment
+            curr_exp_idx = exp_idx == i_exp
+            peaks = ijks[curr_exp_idx]
 
-        if not sum_overlap:
-            all_spheres = unique_rows(all_spheres)
+            sphere_coords = _convolve_sphere(kernel, peaks, np.array(shape))
 
-        sphere_idx_inside_mask = np.where(mask_data[tuple(all_spheres.T)])[0]
-        all_spheres = all_spheres[sphere_idx_inside_mask, :]
+            # Go from sparse to dense
+            study_values = np.zeros(shape, dtype=np.int32)
+
+            if sum_overlap:
+                sphere_coords = unique_rows(sphere_coords)
+            else:
+                study_values[sphere_coords[:, 0], sphere_coords[:, 1], sphere_coords[:, 2]] = value
+
+            # Sum across studies
+            all_values += study_values
         
-        # Combine experiment id with coordinates
-        all_coords.append(all_spheres)
+        # Set voxel outside the mask to zero.
+        all_values[~mask_data] = 0
 
-    # Add exp_idx to coordinates
-    exp_shapes = [coords.shape[0] for coords in all_coords]
-    exp_indicator = np.repeat(np.arange(len(exp_shapes)), exp_shapes)
+        # Go from dense to sparse
+        nonzero_idx = np.where(all_values > 0)
+        all_coords = np.vstack(nonzero_idx)
+        value = all_values[nonzero_idx]
 
-    all_coords = np.vstack(all_coords).T
-    all_coords = np.insert(all_coords, 0, exp_indicator, axis=0)
+        # Add dummy indicator to return 4D sparse array
+        exp_indicator = np.zeros(all_coords.shape[1])
+        all_coords = np.insert(all_coords, 0, exp_indicator, axis=0)
 
-    kernel_data = sparse.COO(all_coords, data=value, has_duplicates=sum_overlap, shape=kernel_shape)
+        kernel_data = sparse.COO(all_coords, data=value, has_duplicates=False, shape=kernel_shape)
+
+    else:
+        all_coords = []
+        # Loop over experiments
+        for i_exp, _ in enumerate(exp_idx_uniq):
+            # Index peaks by experiment
+            curr_exp_idx = exp_idx == i_exp
+            peaks = ijks[curr_exp_idx]
+
+            # Convolve with sphere
+            all_spheres = _convolve_sphere(kernel, peaks, np.array(shape))
+
+            if not sum_overlap:
+                all_spheres = unique_rows(all_spheres)
+            
+            # Combine experiment id with coordinates
+            all_coords.append(all_spheres)
+
+        # Add exp_idx to coordinates
+        exp_shapes = [coords.shape[0] for coords in all_coords]
+        exp_indicator = np.repeat(np.arange(len(exp_shapes)), exp_shapes)
+
+        all_coords = np.vstack(all_coords).T
+        all_coords = np.insert(all_coords, 0, exp_indicator, axis=0)
+
+        kernel_data = sparse.COO(all_coords, data=value, has_duplicates=sum_overlap, shape=kernel_shape)
 
     return kernel_data
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -138,7 +138,9 @@ def compute_kda_ma(
             study_values = np.zeros(shape, dtype=np.int32)
 
             if sum_overlap:
-                study_values[sphere_coords[:, 0], sphere_coords[:, 1], sphere_coords[:, 2]] += value
+                study_values[
+                    sphere_coords[:, 0], sphere_coords[:, 1], sphere_coords[:, 2]
+                ] += value
             else:
                 study_values[sphere_coords[:, 0], sphere_coords[:, 1], sphere_coords[:, 2]] = value
 

--- a/nimare/reports/base.py
+++ b/nimare/reports/base.py
@@ -51,6 +51,7 @@ PARAMETERS_DICT = {
     "kernel_transformer__value": "Value for sphere",
     "kernel_transformer__memory": "Memory",
     "kernel_transformer__memory_level": "Memory level",
+    "kernel_transformer__sum_across_studies": "Sum Across Studies",
     "memory": "Memory",
     "memory_level": "Memory level",
     "null_method": "Null method",

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,9 +90,9 @@ tests =
     pytest-cov
 minimum =
     matplotlib==3.5.2
-    nibabel==3.2.0
+    nibabel==4.0.0
     nilearn==0.10.1
-    numpy==1.22
+    numpy==1.24
     pandas==2.0.0
     pymare==0.0.4rc2
     scikit-learn==1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,6 +97,7 @@ minimum =
     pymare==0.0.4rc2
     scikit-learn==1.0.0
     scipy==1.6.0
+    seaborn==0.13.0
 all =
     %(gzip)s
     %(cbmr)s


### PR DESCRIPTION
`sum_across_studies` returns an array where study counts are sequentially added to a single dense matrix, rather than compiling an exhaustive matrix containg all study-level count data. 

This is much more effecient memory and compute wise, enabling MKDA Chi squared with Neurosynth as reference, using <1GB of memory. 