### PR TITLE
[FIX] do not check id columns for image extensions

### DIFF
--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -510,10 +510,10 @@ def _validate_images_df(image_df):
         DataFrame with updated paths and columns.
     """
     valid_suffixes = [".brik", ".head", ".nii", ".img", ".hed"]
-
+    id_columns = set(["id", "study_id", "contrast_id"])
     # Find columns in the DataFrame with images
     file_cols = []
-    for col in image_df.columns:
+    for col in set(image_df.columns) - id_columns:
         vals = [v for v in image_df[col].values if isinstance(v, str)]
         fc = any([any([vs in v for vs in valid_suffixes]) for v in vals])
         if fc:


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- the neurovault collections are a bit messy and sometimes contrast names are the names of the images themselves (and not a reference to their relative path)
- this pull request makes sure the id columns are not checked to contain valid image extensions (since some of them currently do).
