### PR TITLE
[MAINT] limit version of nilearn to 0.10.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     joblib  # parallelization
     matplotlib>=3.5.2  # this is for nilearn, which doesn't include it in its reqs
     nibabel>=3.2.0  # I/O of niftis
-    nilearn>=0.10.1
+    nilearn>=0.10.1,<0.10.3 # until https://github.com/nilearn/nilearn/pull/4256 is resolved
     numba>=0.57.0 # used by sparse
     numpy>=1.22 # numba needs NumPy 1.22 or greater
     pandas>=2.0.0


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #Failing tests related to cmap .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- limit version of nilearn to 0.10.2 until this is merged and released: https://github.com/nilearn/nilearn/pull/4256
