### PR TITLE
[FIX] bump matplotlib version and update usage of get_cmap

### DIFF
--- a/nimare/reports/figures.py
+++ b/nimare/reports/figures.py
@@ -211,7 +211,7 @@ def plot_coordinates(
     # Generate dictionary and array of colors for each unique ID
     ids = coordinates_df["study_id"].to_list()
     unq_ids = np.unique(ids)
-    cmap = plt.cm.get_cmap("tab20", len(unq_ids))
+    cmap = plt.colormaps["tab20"].resampled(len(unq_ids))
     colors_dict = {unq_id: mcolors.to_hex(cmap(i)) for i, unq_id in enumerate(unq_ids)}
     colors = [colors_dict[id_] for id_ in ids]
 
@@ -386,7 +386,7 @@ def plot_clusters(img, out_filename):
 
     # Define cmap depending on the number of clusters
     clust_ids = list(np.unique(img.get_fdata())[1:])
-    cmap = plt.cm.get_cmap("tab20", len(clust_ids))
+    cmap = plt.colormaps["tab20"].resampled(len(clust_ids))
 
     fig = plot_roi(
         img,

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     fuzzywuzzy  # nimare.annotate
     jinja2 # nimare.reports
     joblib>=1.3.0  # parallelization
-    matplotlib>=3.5.2  # this is for nilearn, which doesn't include it in its reqs
+    matplotlib>=3.6.0  # this is for nilearn, which doesn't include it in its reqs
     nibabel>=3.2.0  # I/O of niftis
     nilearn>=0.10.1,!=0.10.3 # https://github.com/nilearn/nilearn/pull/4256 0.10.3 is broken
     numba>=0.57.0 # used by sparse
@@ -89,7 +89,7 @@ tests =
     pytest
     pytest-cov
 minimum =
-    matplotlib==3.5.2
+    matplotlib==3.6.0
     nibabel==4.0.0
     nilearn==0.10.1
     numpy==1.22


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #886  .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- colormaps API changed: https://github.com/matplotlib/matplotlib/issues/20853
