### PR TITLE
Compute correlation matrix in signal voxels

### DIFF
--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -127,7 +127,7 @@ class IBMAEstimator(Estimator):
                 temp_arr = masker.transform(img4d)
 
                 # To save memory, we only save the original image array and perform masking later
-                # in the stimator if self.aggressive_mask is True.
+                # in the estimator if self.aggressive_mask is True.
                 self.inputs_[name] = temp_arr
 
                 if self.aggressive_mask:

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -92,6 +92,9 @@ class IBMAEstimator(Estimator):
         if isinstance(mask_img, str):
             mask_img = nib.load(mask_img)
 
+        # Reserve the key for the correlation matrix
+        self.inputs_["corr_matrix"] = None
+
         if self.aggressive_mask:
             # Ensure that protected values are not included among _required_inputs
             assert (
@@ -123,24 +126,26 @@ class IBMAEstimator(Estimator):
                 # Mask required input images using either the dataset's mask or the estimator's.
                 temp_arr = masker.transform(img4d)
 
-                # To save memory, we only save the original image array and perform masking later.
+                # To save memory, we only save the original image array and perform masking later
+                # in the stimator if self.aggressive_mask is True.
                 self.inputs_[name] = temp_arr
-                if self.aggressive_mask:
-                    # An intermediate step to mask out bad voxels.
-                    # Can be dropped once PyMARE is able to handle masked arrays or missing data.
-                    nonzero_voxels_bool = np.all(temp_arr != 0, axis=0)
-                    nonnan_voxels_bool = np.all(~np.isnan(temp_arr), axis=0)
-                    good_voxels_bool = np.logical_and(nonzero_voxels_bool, nonnan_voxels_bool)
 
-                    if "aggressive_mask" not in self.inputs_.keys():
-                        self.inputs_["aggressive_mask"] = good_voxels_bool
-                    else:
-                        # Remove any voxels that are bad in any image-based inputs
-                        self.inputs_["aggressive_mask"] = np.logical_or(
-                            self.inputs_["aggressive_mask"],
-                            good_voxels_bool,
-                        )
+                # Regardless of the masking strategy, we need to determine the good voxels here
+                # to mask the bad ones later when calculating the correlation matrix.
+                nonzero_voxels_bool = np.all(temp_arr != 0, axis=0)
+                nonnan_voxels_bool = np.all(~np.isnan(temp_arr), axis=0)
+                good_voxels_bool = np.logical_and(nonzero_voxels_bool, nonnan_voxels_bool)
+
+                if "aggressive_mask" not in self.inputs_.keys():
+                    self.inputs_["aggressive_mask"] = good_voxels_bool
                 else:
+                    # Remove any voxels that are bad in any image-based inputs
+                    self.inputs_["aggressive_mask"] = np.logical_or(
+                        self.inputs_["aggressive_mask"],
+                        good_voxels_bool,
+                    )
+
+                if not self.aggressive_mask:
                     data_bags = zip(*_apply_liberal_mask(temp_arr))
 
                     keys = ["values", "voxel_mask", "study_mask"]
@@ -148,14 +153,11 @@ class IBMAEstimator(Estimator):
 
         # Further reduce image-based inputs to remove "bad" voxels
         # (voxels with zeros or NaNs in any studies)
-        if "aggressive_mask" in self.inputs_.keys():
+        if self.aggressive_mask:
             if n_bad_voxels := (
                 self.inputs_["aggressive_mask"].size - self.inputs_["aggressive_mask"].sum()
             ):
-                LGR.warning(
-                    f"Masking out {n_bad_voxels} additional voxels. "
-                    "The updated masker is available in the Estimator.masker attribute."
-                )
+                LGR.warning(f"Masking out {n_bad_voxels} additional voxels.")
 
 
 class Fishers(IBMAEstimator):
@@ -396,6 +398,14 @@ class Stouffers(IBMAEstimator):
         self.inputs_["contrast_names"] = np.array([label_to_int[label] for label in labels])
         self.inputs_["num_contrasts"] = np.array([label_counts[label] for label in labels])
 
+        if self.inputs_["contrast_names"].size != np.unique(self.inputs_["contrast_names"]).size:
+            # If all studies are not unique, we will need to correct for multiple contrasts
+            # Calculate correlation matrix on valid voxels
+            self.inputs_["corr_matrix"] = np.corrcoef(
+                self.inputs_["z_maps"][:, self.inputs_["aggressive_mask"]],
+                rowvar=True,
+            )
+
     def _generate_description(self):
         description = (
             f"An image-based meta-analysis was performed with NiMARE {__version__} "
@@ -464,17 +474,12 @@ class Stouffers(IBMAEstimator):
                 "will produce invalid results."
             )
 
-        corr = None
-        if self.inputs_["contrast_names"].size != np.unique(self.inputs_["contrast_names"]).size:
-            # If all studies are not unique, we will need to correct for multiple contrasts
-            corr = np.corrcoef(self.inputs_["z_maps"], rowvar=True)
-
         if self.aggressive_mask:
             voxel_mask = self.inputs_["aggressive_mask"]
 
             result_maps = self._fit_model(
                 self.inputs_["z_maps"][:, voxel_mask],
-                corr=corr,
+                corr=self.inputs_["corr_matrix"],
             )
 
             z_map, p_map, dof_map = tuple(
@@ -490,7 +495,9 @@ class Stouffers(IBMAEstimator):
                     z_map[bag["voxel_mask"]],
                     p_map[bag["voxel_mask"]],
                     dof_map[bag["voxel_mask"]],
-                ) = self._fit_model(bag["values"], bag["study_mask"], corr=corr)
+                ) = self._fit_model(
+                    bag["values"], bag["study_mask"], corr=self.inputs_["corr_matrix"]
+                )
 
         maps = {"z": z_map, "p": p_map, "dof": dof_map}
         description = self._generate_description()

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -219,9 +219,10 @@ def test_ibma_resampling(testdata_ibma_resample, resample_kwargs):
     assert isinstance(results, nimare.results.MetaResult)
 
 
-def test_stouffers_multiple_contrasts(testdata_ibma_multiple_contrasts):
+@pytest.mark.parametrize("aggressive_mask", [True, False], ids=["aggressive", "liberal"])
+def test_stouffers_multiple_contrasts(testdata_ibma_multiple_contrasts, aggressive_mask):
     """Test Stouffer's correction with multiple contrasts."""
-    meta = ibma.Stouffers()
+    meta = ibma.Stouffers(aggressive_mask=aggressive_mask)
     results = meta.fit(testdata_ibma_multiple_contrasts)
 
     assert isinstance(results, nimare.results.MetaResult)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #888.

As documented in the issue, the correlation matrix for calculating the inflation reduction term in Stouffers, and the same matrix for showing the similarity between IBMA studies in the report, should be calculated in signal voxels.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Here, we calculate that matrix in the Stouffers._preprocess_input method and use the same in the report if it exists. 
