### PR TITLE
[REF] optimize `get_studies_by_mask`

### DIFF
--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -643,19 +643,20 @@ class Dataset(NiMAREBase):
         found_ids : :obj:`list`
             A list of IDs from the Dataset with at least one focus in the mask.
         """
-        from scipy.spatial.distance import cdist
-
         mask = load_niimg(mask)
-
         dset_mask = self.masker.mask_img
+
         if not np.array_equal(dset_mask.affine, mask.affine):
             LGR.warning("Mask affine does not match Dataset affine. Assuming same space.")
 
         dset_ijk = mm2vox(self.coordinates[["x", "y", "z"]].values, mask.affine)
-        mask_ijk = np.vstack(np.where(mask.get_fdata())).T
-        distances = cdist(mask_ijk, dset_ijk)
-        distances = np.any(distances == 0, axis=0)
-        found_ids = list(self.coordinates.loc[distances, "id"].unique())
+        mask_data = mask.get_fdata()
+        mask_coords = np.vstack(np.where(mask_data)).T
+
+        # Check for presence of coordinates in mask
+        in_mask = np.any(np.all(dset_ijk[:, None] == mask_coords[None, :], axis=-1), axis=-1)
+        found_ids = list(self.coordinates.loc[in_mask, "id"].unique())
+
         return found_ids
 
     def get_studies_by_coordinate(self, xyz, r=20):


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->
This comes from a user trying to use get_studies_by_mask, but kept running out of memory on their machine, this makes the function more efficient.
<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- 
-

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request optimizes the `get_studies_by_mask` function in `nimare/dataset.py` to improve memory efficiency, addressing issues where users experienced memory exhaustion.

- **Enhancements**:
    - Optimized the `get_studies_by_mask` function to improve memory efficiency by replacing the use of `cdist` with a more direct coordinate comparison approach.

<!-- Generated by sourcery-ai[bot]: end summary -->