### PR TITLE
Add t-statistic images as valid targets in ImageTransformer

### DIFF
--- a/nimare/tests/test_transforms.py
+++ b/nimare/tests/test_transforms.py
@@ -30,6 +30,12 @@ def test_ImageTransformer(testdata_ibma):
     new_p_files = new_dset.images["p"].tolist()
     assert all([isinstance(pf, str) for pf in new_p_files])
 
+    t_files = dset.images["t"].tolist()
+    t_transformer = transforms.ImageTransformer(target="t")
+    new_dset = t_transformer.transform(dset)
+    new_t_files = new_dset.images["t"].tolist()
+    assert t_files[:-1] == new_t_files[:-1]
+
 
 def test_transform_images(testdata_ibma):
     """Smoke test on transforms.transform_images."""

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -110,7 +110,7 @@ def transform_images(images_df, target, masker, metadata_df=None, out_dir=None, 
     """
     new_images_df = images_df.copy()  # Work on a copy of the images_df
 
-    valid_targets = {"z", "p", "beta", "varcope"}
+    valid_targets = {"t", "z", "p", "beta", "varcope"}
     if target not in valid_targets:
         raise ValueError(
             f"Target type {target} not supported. Must be one of: {', '.join(valid_targets)}"


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add t-statistic images as valid targets in ImageTransformer

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add support for t-statistic images as valid targets in the ImageTransformer and include corresponding tests to ensure proper functionality.

New Features:
- Add support for t-statistic images as valid targets in the ImageTransformer.

Tests:
- Add tests to verify the transformation of t-statistic images in ImageTransformer.

<!-- Generated by sourcery-ai[bot]: end summary -->