### PR TITLE
Add support for IBMA estimators with t-statistic images in Reports

### DIFF
--- a/nimare/reports/base.py
+++ b/nimare/reports/base.py
@@ -70,6 +70,7 @@ PARAMETERS_DICT = {
     "method": "Method",
     "alpha": "Alpha",
     "prior": "Prior",
+    "tau2": "Between-study variance",
     "use_sample_size": "Use sample size for weights",
     "normalize_contrast_weights": "Normalize by the number of contrasts",
     "two_sided": "Two-sided test",
@@ -483,10 +484,18 @@ class Report:
                 )
             elif meta_type == "IBMA":
                 # Use "z_maps", for Fishers, and Stouffers; otherwise use "beta_maps".
-                key_maps = "z_maps" if "z_maps" in self.results.estimator.inputs_ else "beta_maps"
+                if "z_maps" in self.results.estimator.inputs_:
+                    key_maps = "z_maps"
+                    x_label = "Z"
+                elif "t_maps" in self.results.estimator.inputs_:
+                    key_maps = "t_maps"
+                    x_label = "T"
+                else:
+                    key_maps = "beta_maps"
+                    x_label = "Beta"
+
                 maps_arr = self.results.estimator.inputs_[key_maps]
                 ids_ = self.results.estimator.inputs_["id"]
-                x_label = "Z" if key_maps == "z_maps" else "Beta"
 
                 if self.results.estimator.aggressive_mask:
                     _plot_relcov_map(
@@ -526,12 +535,12 @@ class Report:
                     if self.results.estimator.aggressive_mask:
                         voxel_mask = self.results.estimator.inputs_["aggressive_mask"]
                         corr = np.corrcoef(
-                            self.results.estimator.inputs_["z_maps"][:, voxel_mask],
+                            self.results.estimator.inputs_[key_maps][:, voxel_mask],
                             rowvar=True,
                         )
                     else:
                         corr = np.zeros((n_studies, n_studies), dtype=float)
-                        for bag in self.results.estimator.inputs_["data_bags"]["z_maps"]:
+                        for bag in self.results.estimator.inputs_["data_bags"][key_maps]:
                             study_bag = bag["study_mask"]
                             corr[np.ix_(study_bag, study_bag)] = np.corrcoef(
                                 bag["values"],

--- a/nimare/reports/base.py
+++ b/nimare/reports/base.py
@@ -484,12 +484,12 @@ class Report:
                 )
             elif meta_type == "IBMA":
                 # Use "z_maps", for Fishers, and Stouffers; otherwise use "beta_maps".
-INPUT_TYPE_LABELS = {'z_maps': 'Z', 't_maps': 'T', 'beta_maps': 'Beta'}
-for key_maps, x_label in INPUT_TYPE_LABELS.items():
-    if key_maps in self.results.estimator.inputs_:
-        break
-else:
-    key_maps, x_label = 'beta_maps', 'Beta'
+                INPUT_TYPE_LABELS = {'z_maps': 'Z', 't_maps': 'T', 'beta_maps': 'Beta'}
+                for key_maps, x_label in INPUT_TYPE_LABELS.items():
+                    if key_maps in self.results.estimator.inputs_:
+                        break
+                else:
+                    key_maps, x_label = 'beta_maps', 'Beta'
 
                 maps_arr = self.results.estimator.inputs_[key_maps]
                 ids_ = self.results.estimator.inputs_["id"]

--- a/nimare/reports/base.py
+++ b/nimare/reports/base.py
@@ -484,12 +484,12 @@ class Report:
                 )
             elif meta_type == "IBMA":
                 # Use "z_maps", for Fishers, and Stouffers; otherwise use "beta_maps".
-                INPUT_TYPE_LABELS = {'z_maps': 'Z', 't_maps': 'T', 'beta_maps': 'Beta'}
+                INPUT_TYPE_LABELS = {"z_maps": "Z", "t_maps": "T", "beta_maps": "Beta"}
                 for key_maps, x_label in INPUT_TYPE_LABELS.items():
                     if key_maps in self.results.estimator.inputs_:
                         break
                 else:
-                    key_maps, x_label = 'beta_maps', 'Beta'
+                    key_maps, x_label = "beta_maps", "Beta"
 
                 maps_arr = self.results.estimator.inputs_[key_maps]
                 ids_ = self.results.estimator.inputs_["id"]

--- a/nimare/reports/base.py
+++ b/nimare/reports/base.py
@@ -484,15 +484,12 @@ class Report:
                 )
             elif meta_type == "IBMA":
                 # Use "z_maps", for Fishers, and Stouffers; otherwise use "beta_maps".
-                if "z_maps" in self.results.estimator.inputs_:
-                    key_maps = "z_maps"
-                    x_label = "Z"
-                elif "t_maps" in self.results.estimator.inputs_:
-                    key_maps = "t_maps"
-                    x_label = "T"
-                else:
-                    key_maps = "beta_maps"
-                    x_label = "Beta"
+INPUT_TYPE_LABELS = {'z_maps': 'Z', 't_maps': 'T', 'beta_maps': 'Beta'}
+for key_maps, x_label in INPUT_TYPE_LABELS.items():
+    if key_maps in self.results.estimator.inputs_:
+        break
+else:
+    key_maps, x_label = 'beta_maps', 'Beta'
 
                 maps_arr = self.results.estimator.inputs_[key_maps]
                 ids_ = self.results.estimator.inputs_["id"]

--- a/nimare/tests/test_reports.py
+++ b/nimare/tests/test_reports.py
@@ -7,7 +7,7 @@ import pytest
 from nimare.correct import FWECorrector
 from nimare.diagnostics import FocusCounter, Jackknife
 from nimare.meta.cbma import ALESubtraction
-from nimare.meta.ibma import Stouffers
+from nimare.meta.ibma import FixedEffectsHedges, Stouffers
 from nimare.reports.base import run_reports
 from nimare.workflows import CBMAWorkflow, IBMAWorkflow, PairwiseCBMAWorkflow
 
@@ -75,17 +75,36 @@ def test_reports_ibma_smoke(tmp_path_factory, testdata_ibma, aggressive_mask):
     """Smoke test for IBMA reports."""
     tmpdir = tmp_path_factory.mktemp("test_reports_ibma_smoke")
 
+    # Generate a report with z maps as inputs
+    stouffers_dir = op.join(tmpdir, "stouffers")
     workflow = IBMAWorkflow(
         estimator=Stouffers(aggressive_mask=aggressive_mask),
         corrector="fdr",
         diagnostics="jackknife",
         voxel_thresh=3.2,
-        output_dir=tmpdir,
+        output_dir=stouffers_dir,
     )
     results = workflow.fit(testdata_ibma)
 
-    run_reports(results, tmpdir)
+    run_reports(results, stouffers_dir)
 
     filename = "report.html"
-    outpath = op.join(tmpdir, filename)
+    outpath = op.join(stouffers_dir, filename)
+    assert op.isfile(outpath)
+
+    # Generate a report with t maps as inputs
+    hedges_dir = op.join(tmpdir, "hedges")
+    workflow = IBMAWorkflow(
+        estimator=FixedEffectsHedges(aggressive_mask=aggressive_mask),
+        corrector="fdr",
+        diagnostics="jackknife",
+        voxel_thresh=3.2,
+        output_dir=hedges_dir,
+    )
+    results = workflow.fit(testdata_ibma)
+
+    run_reports(results, hedges_dir)
+
+    filename = "report.html"
+    outpath = op.join(hedges_dir, filename)
     assert op.isfile(outpath)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add support for IBMA estimators with t-statistic images in Reports

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add support for IBMA estimators with t-statistic images in report generation and update the report generation logic to handle different types of input maps. Extend smoke tests to cover the new functionality.

New Features:
- Add support for IBMA estimators with t-statistic images in report generation.

Enhancements:
- Update report generation logic to handle different types of input maps (z_maps, t_maps, beta_maps) for IBMA estimators.

Tests:
- Extend smoke tests to include report generation with t-statistic images for IBMA estimators.

<!-- Generated by sourcery-ai[bot]: end summary -->