### PR TITLE
Fix the two sided test on IBMA Fishers and Stouffers estimators

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -120,7 +120,7 @@ jobs:
         shell: bash {0}
         run: make test_performance_estimators
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: performance_estimator
           path: coverage.xml
@@ -152,7 +152,7 @@ jobs:
         shell: bash {0}
         run: make test_performance_correctors
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: performance_corrector
           path: coverage.xml
@@ -184,7 +184,7 @@ jobs:
         shell: bash {0}
         run: make test_performance_smoke
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: performance_smoke
           path: coverage.xml
@@ -216,7 +216,7 @@ jobs:
         shell: bash {0}
         run: make test_cbmr_importerror
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: cbmr_importerror
           path: coverage.xml

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -238,7 +238,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
       - name: Upload to CodeCov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -6,7 +6,7 @@ on:
       - "main"
   pull_request:
     branches:
-      - '*'
+      - "*"
 
 concurrency:
   group: testing-${{ github.ref }}
@@ -26,8 +26,8 @@ jobs:
       - id: result_step
         uses: mstachniuk/ci-skip@master
         with:
-          commit-filter: '[skip ci];[ci skip];[skip github]'
-          commit-filter-separator: ';'
+          commit-filter: "[skip ci];[ci skip];[skip github]"
+          commit-filter-separator: ";"
 
   run_unit_tests:
     name: Unit tests
@@ -35,28 +35,28 @@ jobs:
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: false
-        matrix:
-            os: ["ubuntu-latest", "macos-latest"]
-            python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     defaults:
       run:
         shell: bash
     steps:
       - uses: actions/checkout@v2
-      - name: 'Set up python'
+      - name: "Set up python"
         uses: actions/setup-python@v2
         with:
-            python-version: ${{ matrix.python-version }}
-      - name: 'Install NiMARE'
+          python-version: ${{ matrix.python-version }}
+      - name: "Install NiMARE"
         shell: bash {0}
         run: pip install -e .[tests,cbmr]
-      - name: 'Run tests'
+      - name: "Run tests"
         shell: bash {0}
         run: make unittest
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: unit_${{ matrix.os }}_${{ matrix.python-version }}
           path: coverage.xml
@@ -68,27 +68,27 @@ jobs:
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: false
-        matrix:
-            os: ["ubuntu-latest"]
-            python-version: ["3.8"]
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.8"]
     defaults:
       run:
         shell: bash
     steps:
       - uses: actions/checkout@v2
-      - name: 'Set up python'
+      - name: "Set up python"
         uses: actions/setup-python@v2
         with:
-            python-version: 3.8
-      - name: 'Install NiMARE'
+          python-version: 3.8
+      - name: "Install NiMARE"
         shell: bash {0}
         run: pip install -e .[minimum,tests,cbmr]
-      - name: 'Run tests'
+      - name: "Run tests"
         shell: bash {0}
         run: make unittest
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: unit_minimum
           path: coverage.xml
@@ -100,23 +100,23 @@ jobs:
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: false
-        matrix:
-            os: ["ubuntu-latest"]
-            python-version: ["3.8"]
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.8"]
     defaults:
       run:
         shell: bash
     steps:
       - uses: actions/checkout@v2
-      - name: 'Set up python'
+      - name: "Set up python"
         uses: actions/setup-python@v2
         with:
-            python-version: ${{ matrix.python-version }}
-      - name: 'Install NiMARE'
+          python-version: ${{ matrix.python-version }}
+      - name: "Install NiMARE"
         shell: bash {0}
         run: pip install -e .[tests,cbmr]
-      - name: 'Run tests'
+      - name: "Run tests"
         shell: bash {0}
         run: make test_performance_estimators
       - name: Upload artifacts
@@ -132,23 +132,23 @@ jobs:
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: false
-        matrix:
-            os: ["ubuntu-latest"]
-            python-version: ["3.8"]
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.8"]
     defaults:
       run:
         shell: bash
     steps:
       - uses: actions/checkout@v2
-      - name: 'Set up python'
+      - name: "Set up python"
         uses: actions/setup-python@v2
         with:
-            python-version: ${{ matrix.python-version }}
-      - name: 'Install NiMARE'
+          python-version: ${{ matrix.python-version }}
+      - name: "Install NiMARE"
         shell: bash {0}
         run: pip install -e .[tests,cbmr]
-      - name: 'Run tests'
+      - name: "Run tests"
         shell: bash {0}
         run: make test_performance_correctors
       - name: Upload artifacts
@@ -164,23 +164,23 @@ jobs:
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: false
-        matrix:
-            os: ["ubuntu-latest"]
-            python-version: ["3.8"]
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.8"]
     defaults:
       run:
         shell: bash
     steps:
       - uses: actions/checkout@v2
-      - name: 'Set up python'
+      - name: "Set up python"
         uses: actions/setup-python@v2
         with:
-            python-version: ${{ matrix.python-version }}
-      - name: 'Install NiMARE'
+          python-version: ${{ matrix.python-version }}
+      - name: "Install NiMARE"
         shell: bash {0}
         run: pip install -e .[tests,cbmr]
-      - name: 'Run tests'
+      - name: "Run tests"
         shell: bash {0}
         run: make test_performance_smoke
       - name: Upload artifacts
@@ -196,23 +196,23 @@ jobs:
     if: ${{ needs.check_skip.outputs.skip == 'false' }}
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: false
-        matrix:
-            os: ["ubuntu-latest"]
-            python-version: ["3.8"]
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.8"]
     defaults:
       run:
         shell: bash
     steps:
       - uses: actions/checkout@v2
-      - name: 'Set up python'
+      - name: "Set up python"
         uses: actions/setup-python@v2
         with:
-            python-version: ${{ matrix.python-version }}
-      - name: 'Install NiMARE'
+          python-version: ${{ matrix.python-version }}
+      - name: "Install NiMARE"
         shell: bash {0}
         run: pip install -e .[tests]
-      - name: 'Run tests'
+      - name: "Run tests"
         shell: bash {0}
         run: make test_cbmr_importerror
       - name: Upload artifacts
@@ -224,7 +224,15 @@ jobs:
 
   upload_to_codecov:
     name: Upload coverage
-    needs: [run_unit_tests,run_unit_tests_with_minimum_dependencies,test_performance_estimators,test_performance_correctors,test_performance_smoke,test_cbmr_importerror]
+    needs:
+      [
+        run_unit_tests,
+        run_unit_tests_with_minimum_dependencies,
+        test_performance_estimators,
+        test_performance_correctors,
+        test_performance_smoke,
+        test_cbmr_importerror,
+      ]
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout

--- a/examples/02_meta-analyses/12_plot_ibma_workflow.py
+++ b/examples/02_meta-analyses/12_plot_ibma_workflow.py
@@ -78,7 +78,7 @@ result.tables["z_corr-FDR_method-indep_tab-clust"]
 ###############################################################################
 # Contribution table
 # ``````````````````````````````````````````````````````````````````````````````
-result.tables["z_corr-FDR_method-indep_diag-Jackknife_tab-counts_tail-positive"]
+result.tables["z_corr-FDR_method-indep_diag-Jackknife_tab-counts"]
 
 ###############################################################################
 # Report

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -481,6 +481,9 @@ class Stouffers(IBMAEstimator):
         pos_est.fit_dataset(pos_pymare_dset, corr=sub_corr)
         pos_est_summary = pos_est.summary()
 
+        z_map = pos_est_summary.z.squeeze()
+        p_map = pos_est_summary.p.squeeze()
+
         if self.two_sided:
             # Run Stouffers for left tail
             neg_est = pymare.estimators.StoufferCombinationTest(mode="directed")
@@ -489,17 +492,14 @@ class Stouffers(IBMAEstimator):
             neg_est_summary = neg_est.summary()
 
             # Find the minimum p-values
-            p_map = np.minimum(pos_est_summary.p.squeeze(), neg_est_summary.p.squeeze())
+            p_map = np.minimum(p_map, neg_est_summary.p.squeeze())
 
             # Create z_map based on which p-value is smaller
             z_map = np.where(
-                pos_est_summary.p.squeeze() <= neg_est_summary.p.squeeze(),
-                pos_est_summary.z.squeeze(),
+                p_map <= neg_est_summary.p.squeeze(),
+                z_map,
                 -neg_est_summary.z.squeeze(),
             )
-        else:
-            z_map = pos_est_summary.z.squeeze()
-            p_map = pos_est_summary.p.squeeze()
 
         dof_map = np.tile(n_studies - 1, n_voxels).astype(np.int32)
 

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -248,6 +248,9 @@ class Fishers(IBMAEstimator):
         pos_est.fit_dataset(pos_pymare_dset)
         pos_est_summary = pos_est.summary()
 
+        z_map = pos_est_summary.z.squeeze()
+        p_map = pos_est_summary.p.squeeze()
+
         if self.two_sided:
             # Run Stouffers for left tail
             neg_est = pymare.estimators.FisherCombinationTest(mode="directed")
@@ -256,17 +259,14 @@ class Fishers(IBMAEstimator):
             neg_est_summary = neg_est.summary()
 
             # Find the minimum p-values
-            p_map = np.minimum(pos_est_summary.p.squeeze(), neg_est_summary.p.squeeze())
+            p_map = np.minimum(p_map, neg_est_summary.p.squeeze())
 
             # Create z_map based on which p-value is smaller
             z_map = np.where(
-                pos_est_summary.p.squeeze() <= neg_est_summary.p.squeeze(),
-                pos_est_summary.z.squeeze(),
+                p_map <= neg_est_summary.p.squeeze(),
+                z_map,
                 -neg_est_summary.z.squeeze(),
             )
-        else:
-            z_map = pos_est_summary.z.squeeze()
-            p_map = pos_est_summary.p.squeeze()
 
         dof_map = np.tile(n_studies - 1, n_voxels).astype(np.int32)
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes None.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- As noticed in PyMARE, combination tests only take z-scores from one-sided p-values. Before, we were performing a concordant test, but that returned the values of the left tail to positive as well.
- To be able to handle both tails, we perform the test for each tail separately and take the values with minimum p-value as output.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the two-sided test implementation for IBMA Fishers and Stouffers estimators by running separate tests for each tail and using the minimum p-value to ensure correct handling of both tails.

Bug Fixes:
- Fix the two-sided test for IBMA Fishers and Stouffers estimators by separately handling each tail and selecting the minimum p-value.

<!-- Generated by sourcery-ai[bot]: end summary -->