### PR TITLE
[FIX] bump pymare version to fix z values

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     pandas>=2.0.0
     patsy  # for cbmr
     plotly  # nimare.reports
-    pymare>=0.0.7  # nimare.meta.ibma and stats
+    pymare>=0.0.8  # nimare.meta.ibma and stats
     pyyaml # nimare.reports
     requests  # nimare.extract
     ridgeplot  # nimare.reports
@@ -96,7 +96,7 @@ minimum =
     nilearn==0.10.1
     numpy==1.22
     pandas==2.0.0
-    pymare==0.0.7
+    pymare==0.0.8
     scikit-learn==1.0.0
     scipy==1.6.0
     seaborn==0.13.0


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Bump the pymare package version from 0.0.7 to 0.0.8 in the setup configuration to fix issues related to z values.

Bug Fixes:
- Update pymare dependency version to 0.0.8 to address issues with z values.

<!-- Generated by sourcery-ai[bot]: end summary -->