### PR TITLE
[FIX] do not initialize kernel object

### DIFF
--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -389,7 +389,7 @@ class MKDAChi2(PairwiseCBMAEstimator):
 
     def __init__(
         self,
-        kernel_transformer=MKDAKernel(),
+        kernel_transformer=MKDAKernel,
         prior=0.5,
         memory=Memory(location=None, verbose=0),
         memory_level=0,


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #906 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- do not initialize the kernel transformer so arguments can be passed to it upon initialization
-

## Summary by Sourcery

Bug Fixes:
- Fix the initialization of the kernel transformer in the MKDAChi2 class to allow arguments to be passed upon initialization.