### PR TITLE
Fix the use correlation matrix from the results object when available for Reports

### DIFF
--- a/nimare/reports/base.py
+++ b/nimare/reports/base.py
@@ -540,7 +540,7 @@ class Report:
                             rowvar=True,
                         )
                 else:
-                    corr = self.inputs_["corr_matrix"]
+                    corr = self.results.estimator.inputs_["corr_matrix"]
 
                 similarity_table = pd.DataFrame(
                     index=ids_,

--- a/nimare/tests/test_reports.py
+++ b/nimare/tests/test_reports.py
@@ -108,3 +108,25 @@ def test_reports_ibma_smoke(tmp_path_factory, testdata_ibma, aggressive_mask):
     filename = "report.html"
     outpath = op.join(hedges_dir, filename)
     assert op.isfile(outpath)
+
+
+def test_reports_ibma_multiple_contrasts_smoke(tmp_path_factory, testdata_ibma_multiple_contrasts):
+    """Smoke test for IBMA reports for multiple contrasts."""
+    tmpdir = tmp_path_factory.mktemp("test_reports_ibma_smoke")
+
+    # Generate a report with z maps as inputs
+    stouffers_dir = op.join(tmpdir, "stouffers")
+    workflow = IBMAWorkflow(
+        estimator=Stouffers(aggressive_mask=True),
+        corrector="fdr",
+        diagnostics="jackknife",
+        voxel_thresh=3.2,
+        output_dir=stouffers_dir,
+    )
+    results = workflow.fit(testdata_ibma_multiple_contrasts)
+
+    run_reports(results, stouffers_dir)
+
+    filename = "report.html"
+    outpath = op.join(stouffers_dir, filename)
+    assert op.isfile(outpath)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Fix the use correlation matrix from the results object when available, when generating reports
-

## Summary by Sourcery

Bug Fixes:
- Fixed correlation matrix sourcing in report generation by using the results object's estimator inputs