### PR TITLE
[TST] patch url calls to not fetch contents

### DIFF
--- a/nimare/tests/test_extract.py
+++ b/nimare/tests/test_extract.py
@@ -9,8 +9,17 @@ import nimare
 
 
 def mock_urlopen(url):
-    """Mock URL opener that returns fake data."""
-    mock_data = b"Mock file content"
+    """Mock URL opener that returns appropriate mock data based on file type."""
+    if "coordinates.tsv.gz" in url:
+        mock_data = b"x\ty\tz\n1\t2\t3\n4\t5\t6"
+    elif "metadata.tsv.gz" in url:
+        mock_data = b"id\ttitle\n1\tStudy 1\n2\tStudy 2"
+    elif "features.npz" in url:
+        mock_data = b"mock npz content"
+    elif "vocabulary.txt" in url:
+        mock_data = b"term1\nterm2\nterm3"
+    else:
+        mock_data = b"Mock file content"
     return BytesIO(mock_data)
 
 
@@ -28,12 +37,16 @@ def test_fetch_neurosynth(tmp_path_factory):
         source="abstract",
         vocab="terms",
     )
-    files = glob(os.path.join(tmpdir, "neurosynth", "*"))
-    assert len(files) == 4
-
-    # One set of files found
+    # Check data_files structure
     assert isinstance(data_files, list)
     assert len(data_files) == 1
+
+    # Verify expected files in data_files
+    files_dict = data_files[0]
+    assert "coordinates" in files_dict
+    assert "metadata" in files_dict
+    assert "features" in files_dict
+    assert len(files_dict["features"]) == 1
 
 
 @patch("nimare.extract.extract.urlopen", side_effect=mock_urlopen)

--- a/nimare/tests/test_extract.py
+++ b/nimare/tests/test_extract.py
@@ -2,10 +2,19 @@
 
 import os
 from glob import glob
+from io import BytesIO
+from unittest.mock import patch
 
 import nimare
 
 
+def mock_urlopen(url):
+    """Mock URL opener that returns fake data."""
+    mock_data = b"Mock file content"
+    return BytesIO(mock_data)
+
+
+@patch("nimare.extract.extract.urlopen", side_effect=mock_urlopen)
 def test_fetch_neurosynth(tmp_path_factory):
     """Smoke test for extract.fetch_neurosynth.
 
@@ -27,7 +36,8 @@ def test_fetch_neurosynth(tmp_path_factory):
     assert len(data_files) == 1
 
 
-def test_fetch_neuroquery(tmp_path_factory):
+@patch("nimare.extract.extract.urlopen", side_effect=mock_urlopen)
+def test_fetch_neuroquery(mock_url, tmp_path_factory):
     """Smoke test for extract.fetch_neuroquery."""
     tmpdir = tmp_path_factory.mktemp("test_fetch_neuroquery")
     data_files = nimare.extract.fetch_neuroquery(
@@ -44,3 +54,10 @@ def test_fetch_neuroquery(tmp_path_factory):
     # One set of files found
     assert isinstance(data_files, list)
     assert len(data_files) == 1
+
+    # Verify mock was called with expected URLs
+    assert mock_url.call_count > 0  # Should be called for each file download
+    for call in mock_url.call_args_list:
+        url = call[0][0]
+        assert "neuroquery/neuroquery_data/blob" in url
+        assert "?raw=true" in url


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
references https://github.com/neurostuff/NiMARE/pull/925#issuecomment-2867051811

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- patch URL requests to fetch_neuroquery/fetch_neurosynth
-

## Summary by Sourcery

Mock external URL calls in extract tests to avoid real network requests and verify URL parameters for fetch_neurosynth and fetch_neuroquery.

Tests:
- Introduce a mock_urlopen function that returns fake data via BytesIO.
- Apply unittest.mock.patch to intercept nimare.extract.extract.urlopen in fetch_neurosynth and fetch_neuroquery tests.
- Add assertions in test_fetch_neuroquery to check that urlopen is called and URLs contain expected path and raw parameters.