### PR TITLE
[FIX] reduce memory/time for running reports

### DIFF
--- a/nimare/reports/base.py
+++ b/nimare/reports/base.py
@@ -288,7 +288,9 @@ def _gen_figures(results, img_key, diag_name, threshold, fig_dir):
     # Plot brain images if not empty
     if (results.maps[img_key] > threshold).any():
         img = results.get_map(img_key)
-        plot_interactive_brain(img, fig_dir / "corrector_figure-interactive.html", threshold, quality="low")
+        plot_interactive_brain(
+            img, fig_dir / "corrector_figure-interactive.html", threshold, quality="low"
+        )
         plot_static_brain(img, fig_dir / "corrector_figure-static.png", threshold)
     else:
         _no_maps_found(fig_dir / "corrector_figure-non.html")

--- a/nimare/reports/base.py
+++ b/nimare/reports/base.py
@@ -288,7 +288,7 @@ def _gen_figures(results, img_key, diag_name, threshold, fig_dir):
     # Plot brain images if not empty
     if (results.maps[img_key] > threshold).any():
         img = results.get_map(img_key)
-        plot_interactive_brain(img, fig_dir / "corrector_figure-interactive.html", threshold)
+        plot_interactive_brain(img, fig_dir / "corrector_figure-interactive.html", threshold, quality="low")
         plot_static_brain(img, fig_dir / "corrector_figure-static.png", threshold)
     else:
         _no_maps_found(fig_dir / "corrector_figure-non.html")

--- a/nimare/reports/figures.py
+++ b/nimare/reports/figures.py
@@ -297,7 +297,7 @@ def plot_interactive_brain(img, out_filename, threshold=1e-06, quality="medium")
         magically by analysis of the image. Default=1e-6.
     quality: str, optional
         Quality setting for the visualization. Options are:
-        - 'low': Uses 3mm resolution template, best for memory efficiency
+        - 'low': Uses 4mm resolution template, best for memory efficiency
         - 'medium': Uses 2mm resolution template
         - 'high': Uses 1mm resolution template (memory intensive)
         Default is 'low' for memory efficiency.

--- a/nimare/reports/figures.py
+++ b/nimare/reports/figures.py
@@ -217,7 +217,7 @@ def plot_coordinates(
         Valid extensions are '.png', '.pdf', '.svg'.
     max_coordinates : :obj:`int`, optional
         Maximum number of coordinates to plot. If there are more coordinates,
-        they will be randomly sampled. Default is 5000.
+        they will be randomly sampled. Default is 2000.
     """
     _check_extention(out_static_filename, [".png", ".pdf", ".svg"])
     _check_extention(out_interactive_filename, [".html"])

--- a/nimare/reports/figures.py
+++ b/nimare/reports/figures.py
@@ -228,13 +228,11 @@ def plot_coordinates(
         coordinates_df = coordinates_df.sample(n=max_coordinates, random_state=42)
 
     # Generate categorical colors for each study
-    unq_ids = coordinates_df[
-        "study_id"
-    ].unique() 
+    unq_ids = coordinates_df["study_id"].unique()
     n_studies = len(unq_ids)
 
     # Use tab20 colormap with modulo for studies > 20
-    cmap = plt.colormaps["tab20"].resampled(20)  
+    cmap = plt.colormaps["tab20"].resampled(20)
     colors = [cmap(i % 20) for i in range(n_studies)]
     colors_dict = {id_: mcolors.to_hex(color) for id_, color in zip(unq_ids, colors)}
 

--- a/nimare/reports/figures.py
+++ b/nimare/reports/figures.py
@@ -251,7 +251,7 @@ def plot_coordinates(
     html_view.save_as_html(out_interactive_filename)
 
 
-def plot_interactive_brain(img, out_filename, threshold=1e-06):
+def plot_interactive_brain(img, out_filename, threshold=1e-06, quality="low"):
     """Plot interactive brain image.
 
     .. versionadded:: 0.1.0
@@ -267,18 +267,33 @@ def plot_interactive_brain(img, out_filename, threshold=1e-06):
         used to threshold the image: values below the threshold (in absolute value)
         are plotted as transparent. If 'auto' is given, the threshold is determined
         magically by analysis of the image. Default=1e-6.
+    quality: str, optional
+        Quality setting for the visualization. Options are:
+        - 'low': Uses 3mm resolution template, best for memory efficiency
+        - 'medium': Uses 2mm resolution template
+        - 'high': Uses 1mm resolution template (memory intensive)
+        Default is 'low' for memory efficiency.
     """
     _check_extention(out_filename, [".html"])
 
-    template = datasets.load_mni152_template(resolution=1)
-    html_view = view_img(
-        img,
-        bg_img=template,
-        black_bg=False,
-        threshold=threshold,
-        symmetric_cmap=True,
-    )
-    html_view.save_as_html(out_filename)
+    # Set template resolution based on quality
+    resolution_map = {"low": 4, "medium": 2, "high": 1}
+    resolution = resolution_map.get(quality, 4)  # Default to low if invalid quality
+
+    try:
+        template = datasets.load_mni152_template(resolution=resolution)
+        html_view = view_img(
+            img,
+            bg_img=template,
+            black_bg=False,
+            threshold=threshold,
+            symmetric_cmap=True,
+        )
+        html_view.save_as_html(out_filename)
+    finally:
+        # Cleanup resources
+        if 'html_view' in locals():
+            del html_view
 
 
 def plot_heatmap(

--- a/nimare/reports/figures.py
+++ b/nimare/reports/figures.py
@@ -13,8 +13,8 @@ from nilearn.plotting import (
     plot_img,
     plot_roi,
     plot_stat_map,
-    view_markers,
     view_img,
+    view_markers,
 )
 from ridgeplot import ridgeplot
 from scipy import stats

--- a/nimare/reports/figures.py
+++ b/nimare/reports/figures.py
@@ -196,7 +196,7 @@ def plot_coordinates(
     out_static_filename,
     out_interactive_filename,
     out_legend_filename,
-    max_coordinates=2000,  # Add parameter to limit number of coordinates
+    max_coordinates=2000,
 ):
     """Plot static and interactive coordinates.
 
@@ -230,12 +230,12 @@ def plot_coordinates(
     # Generate categorical colors for each study
     unq_ids = coordinates_df[
         "study_id"
-    ].unique()  # pandas unique() is faster than np.unique for strings
+    ].unique() 
     n_studies = len(unq_ids)
 
     # Use tab20 colormap with modulo for studies > 20
-    cmap = plt.colormaps["tab20"].resampled(20)  # tab20 has 20 distinct colors
-    colors = [cmap(i % 20) for i in range(n_studies)]  # Cycle colors if more than 20 studies
+    cmap = plt.colormaps["tab20"].resampled(20)  
+    colors = [cmap(i % 20) for i in range(n_studies)]
     colors_dict = {id_: mcolors.to_hex(color) for id_, color in zip(unq_ids, colors)}
 
     # Create glass brain plot


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #879  .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Enable control over interactive brain plot resolution and reduce memory usage by adding a quality parameter, implementing resolution mapping and resource cleanup, and updating report calls to default to low quality.

New Features:
- Add `quality` parameter to `plot_interactive_brain` for adjustable template resolution (low/medium/high)

Enhancements:
- Map quality levels to 3mm/2mm/1mm MNI templates with default low resolution for memory efficiency
- Wrap interactive brain view rendering in a try/finally block to delete `html_view` and free resources
- Update report generator to pass `quality="low"` by default when plotting interactive brains