### PR TITLE
[FIX] do not try to set n_cores on initialized objects

### DIFF
--- a/nimare/workflows/base.py
+++ b/nimare/workflows/base.py
@@ -116,12 +116,10 @@ class Workflow(NiMAREBase):
             "voxel_thresh": self.voxel_thresh,
             "cluster_threshold": self.cluster_threshold,
         }
+        diag_kwargs["n_cores"] = self.n_cores
         if diagnostics is None:
-            diag_kwargs["n_cores"] = self.n_cores
             diagnostics = [self._diag_default(**diag_kwargs)]
         else:
-            # Pass n_cores for all non-initialized diagnostics
-            diag_kwargs["n_cores"] = self.n_cores
             diagnostics = [
                 _check_input(diagnostic, Diagnostics, self._diag_options, **diag_kwargs)
                 for diagnostic in diagnostics

--- a/nimare/workflows/base.py
+++ b/nimare/workflows/base.py
@@ -63,7 +63,12 @@ def _check_input(obj, clss, options, **kwargs):
         if obj == FWECorrector:
             kwargs["method"] = obj_str
 
-    return _check_type(obj, clss, **kwargs)
+    # Apply kwargs (including n_cores) when obj is a class or string
+    if isinstance(obj, (str, type)):
+        return _check_type(obj, clss, **kwargs)
+
+    # If object is already instantiated, return it as-is
+    return _check_type(obj, clss)
 
 
 class Workflow(NiMAREBase):
@@ -93,26 +98,30 @@ class Workflow(NiMAREBase):
             diagnostics = [diagnostics]
 
         # Check inputs and set defaults if input is None
-        estimator = (
-            self._estm_default(n_cores=self.n_cores)
-            if estimator is None
-            else _check_input(estimator, self._estm_base, self._estm_options, n_cores=self.n_cores)
-        )
+        if estimator is None:
+            estimator = self._estm_default(n_cores=self.n_cores)
+        else:
+            estimator = _check_input(
+                estimator, self._estm_base, self._estm_options, n_cores=self.n_cores
+            )
 
-        corrector = (
-            self._corr_default(method=self._mcc_method, n_cores=self.n_cores)
-            if corrector is None
-            else _check_input(corrector, Corrector, self._corr_options, n_cores=self.n_cores)
-        )
+        if corrector is None:
+            corrector = self._corr_default(method=self._mcc_method, n_cores=self.n_cores)
+        else:
+            corrector = _check_input(
+                corrector, Corrector, self._corr_options, n_cores=self.n_cores
+            )
 
         diag_kwargs = {
             "voxel_thresh": self.voxel_thresh,
             "cluster_threshold": self.cluster_threshold,
-            "n_cores": self.n_cores,
         }
         if diagnostics is None:
+            diag_kwargs["n_cores"] = self.n_cores
             diagnostics = [self._diag_default(**diag_kwargs)]
         else:
+            # Pass n_cores for all non-initialized diagnostics
+            diag_kwargs["n_cores"] = self.n_cores
             diagnostics = [
                 _check_input(diagnostic, Diagnostics, self._diag_options, **diag_kwargs)
                 for diagnostic in diagnostics


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # Feedback I received from a confused user in person

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- only inialize with arguments if objects have not already been initialized

## Summary by Sourcery

Prevent passing n_cores to already instantiated workflow components by applying parallelism settings only when creating new objects and clarify instantiation logic for estimators, correctors, and diagnostics.

Bug Fixes:
- Only apply n_cores keyword in _check_input when the component is a class or string to avoid resetting initialized objects.
- Correct diagnostic n_cores injection in Workflow._preprocess_input to only add parallelism parameter when instantiating diagnostics.

Enhancements:
- Refactor estimator and corrector initialization in Workflow._preprocess_input for clearer separation between default construction and input checking.