### PR TITLE
Add robust inverse of a FI matrix in CBMR inference

### DIFF
--- a/nimare/meta/cbmr.py
+++ b/nimare/meta/cbmr.py
@@ -20,7 +20,13 @@ from nimare import _version
 from nimare.diagnostics import FocusFilter
 from nimare.estimator import Estimator
 from nimare.meta import models
-from nimare.utils import b_spline_bases, dummy_encoding_moderators, robust_inverse, get_masker, mm2vox
+from nimare.utils import (
+    b_spline_bases,
+    dummy_encoding_moderators,
+    get_masker,
+    mm2vox,
+    robust_inverse,
+)
 
 LGR = logging.getLogger(__name__)
 __version__ = _version.get_versions()["version"]

--- a/nimare/meta/cbmr.py
+++ b/nimare/meta/cbmr.py
@@ -20,7 +20,7 @@ from nimare import _version
 from nimare.diagnostics import FocusFilter
 from nimare.estimator import Estimator
 from nimare.meta import models
-from nimare.utils import b_spline_bases, dummy_encoding_moderators, get_masker, mm2vox
+from nimare.utils import b_spline_bases, dummy_encoding_moderators, robust_inverse, get_masker, mm2vox
 
 LGR = logging.getLogger(__name__)
 __version__ = _version.get_versions()["version"]
@@ -106,6 +106,8 @@ class CBMREstimator(Estimator):
 
     Notes
     -----
+    The CBMR framework was developed in :footcite:t:`yu2024neuroimaging`,
+
     Available correction methods: :meth:`~nimare.meta.cbmr.CBMRInference`.
     """
 
@@ -751,7 +753,7 @@ class CBMRInference(object):
                 self.estimator.inputs_["foci_per_voxel"],
                 self.estimator.inputs_["foci_per_study"],
             )
-            cov_spatial_coef = np.linalg.inv(f_spatial_coef)
+            cov_spatial_coef = robust_inverse(f_spatial_coef)
             # compute numerator: contrast vector * group-wise log spatial intensity
             involved_log_intensity_per_voxel = list()
             for group in con_group_involved:
@@ -925,8 +927,7 @@ class CBMRInference(object):
                 self.estimator.inputs_["foci_per_voxel"],
                 self.estimator.inputs_["foci_per_study"],
             )
-
-            cov_moderator_coef = np.linalg.inv(f_moderator_coef)
+            cov_moderator_coef = robust_inverse(f_moderator_coef)
             if m_con_moderator == 1:  # a single contrast vector, use Wald test
                 var_moderator_coef = np.diag(cov_moderator_coef)
                 involved_var_moderator_coef = con_moderator**2 @ var_moderator_coef

--- a/nimare/tests/conftest.py
+++ b/nimare/tests/conftest.py
@@ -77,7 +77,7 @@ def testdata_cbmr_simulated():
     """Simulate coordinate-based dataset for tests."""
     # simulate
     ground_truth_foci, dset = create_coordinate_dataset(
-        foci=10, sample_size=(20, 40), n_studies=1000, seed=100
+        foci=10, sample_size=(20, 40), n_studies=500, seed=100
     )
     # set up group columns: diagnosis & drug_status
     n_rows = dset.annotations.shape[0]

--- a/nimare/tests/test_meta_cbmr.py
+++ b/nimare/tests/test_meta_cbmr.py
@@ -262,6 +262,7 @@ def test_StandardizeField(testdata_cbmr_simulated):
 
 
 @pytest.mark.cbmr_importerror
+@pytest.mark.skipif(TORCH_INSTALLED, reason="Torch is installed, ImportError test not applicable")
 def test_cbmr_importerror():
     """Test that ImportErrors are raised when torch is not installed."""
     with pytest.raises(ImportError):

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -1390,10 +1390,15 @@ def robust_inverse(FI, eps=1e-8):
     FI_inv : :obj:`numpy.ndarray`
         The robust inverse of the Fisher information matrix.
     """
+    # Improve numerical stability of FI by symmetrizing it
     FI = (FI + FI.T) / 2
+    # Perform Singular Value Decomposition
+    # and compute the inverse using a threshold on singular values
+    # to avoid division by zero or very small values
     U, S, VT = np.linalg.svd(FI, full_matrices=False)
     M = S > eps
     S_inv = S**-1
     U = ((U + VT.T) / 2) * M[None, :]
+    # Set small singular values to zero in the inverse
     FI_inv = U @ np.diag(S_inv) @ U.T
     return FI_inv

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -207,7 +207,7 @@ def mm2vox(xyz, affine):
     From here:
     http://blog.chrisgorgolewski.org/2014/12/how-to-convert-between-voxel-and-mm.html
     """
-    with np.errstate(invalid='ignore'):
+    with np.errstate(invalid="ignore"):
         ijk = nib.affines.apply_affine(np.linalg.inv(affine), xyz).astype(int)
     return ijk
 
@@ -1367,13 +1367,15 @@ def dummy_encoding_moderators(dataset_annotations, moderators):
             new_moderators.append(moderator)
     return dataset_annotations, new_moderators
 
+
 def robust_inverse(FI, eps=1e-8):
     """
     Compute the robust inverse of a Fisher information matrix.
+
     This function computes the inverse of a Fisher information matrix (FI) using
     Singular Value Decomposition (SVD) and a thresholding approach to handle
     small singular values, which can lead to numerical instability.
-    
+
     Parameters
     ----------
     FI : :obj:`numpy.ndarray`
@@ -1390,8 +1392,8 @@ def robust_inverse(FI, eps=1e-8):
     """
     FI = (FI + FI.T) / 2
     U, S, VT = np.linalg.svd(FI, full_matrices=False)
-    M = (S > eps)
-    S_inv = S ** -1
+    M = S > eps
+    S_inv = S**-1
     U = ((U + VT.T) / 2) * M[None, :]
     FI_inv = U @ np.diag(S_inv) @ U.T
     return FI_inv

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -1366,3 +1366,32 @@ def dummy_encoding_moderators(dataset_annotations, moderators):
         else:
             new_moderators.append(moderator)
     return dataset_annotations, new_moderators
+
+def robust_inverse(FI, eps=1e-8):
+    """
+    Compute the robust inverse of a Fisher information matrix.
+    This function computes the inverse of a Fisher information matrix (FI) using
+    Singular Value Decomposition (SVD) and a thresholding approach to handle
+    small singular values, which can lead to numerical instability.
+    
+    Parameters
+    ----------
+    FI : :obj:`numpy.ndarray`
+        The Fisher information matrix to be inverted.
+    eps : :obj:`float`, optional
+        A small value to threshold the singular values. Singular values below this
+        threshold will be set to zero in the inverse computation to avoid numerical
+        instability. Default is 1e-8.
+
+    Returns
+    -------
+    FI_inv : :obj:`numpy.ndarray`
+        The robust inverse of the Fisher information matrix.
+    """
+    FI = (FI + FI.T) / 2
+    U, S, VT = np.linalg.svd(FI, full_matrices=False)
+    M = (S > eps)
+    S_inv = S ** -1
+    U = ((U + VT.T) / 2) * M[None, :]
+    FI_inv = U @ np.diag(S_inv) @ U.T
+    return FI_inv


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- For CBMR inference, add robust inverse of a Fisher information matrix using SVD and a thresholding approach to ignore small singular values
-

## Summary by Sourcery

Add a robust inverse function for Fisher information matrices using SVD thresholding and integrate it into CBMR inference to replace direct matrix inversion for enhanced numerical stability, and update CBMR tests accordingly.

New Features:
- Introduce robust_inverse function in utils to compute Fisher information matrix inverses via SVD with thresholding.

Enhancements:
- Use robust_inverse in CBMR inference to replace np.linalg.inv for spatial and moderator coefficient covariance computations.

Documentation:
- Add documentation for the robust_inverse function detailing its parameters and behavior.

Tests:
- Skip CBMR import error test when Torch is installed to avoid false negatives.