### PR TITLE
[FIX] vfwe only param

### DIFF
--- a/nimare/reports/base.py
+++ b/nimare/reports/base.py
@@ -79,6 +79,7 @@ PARAMETERS_DICT = {
     "varcope": "Variance of the parameter estimate",
     "t": "T-statistic",
     "z": "Z-statistic",
+    "vfwe_only": "Voxel-level FWE only",
 }
 
 PNG_SNIPPET = """\
@@ -172,7 +173,7 @@ def _get_ibma_summary(dset, sel_ids):
     ]
 
     maptype_text = ["<li>Available maps: ", "<ul>"]
-    maptype_text.extend(f"<li>{PARAMETERS_DICT[m]} ({m})</li>" for m in map_type)
+    maptype_text.extend(f"<li>{PARAMETERS_DICT.get(m, m)} ({m})</li>" for m in map_type)
     maptype_text.extend(["</ul>", "</li>"])
 
     ibma_text.extend(maptype_text)
@@ -201,7 +202,7 @@ def _get_kernel_summary(params_dict):
     kernel_transformer = str(params_dict["kernel_transformer"])
     ker_params = {k: v for k, v in params_dict.items() if k.startswith("kernel_transformer__")}
     ker_params_text = ["<ul>"]
-    ker_params_text.extend(f"<li>{PARAMETERS_DICT[k]}: {v}</li>" for k, v in ker_params.items())
+    ker_params_text.extend(f"<li>{PARAMETERS_DICT.get(k, k)}: {v}</li>" for k, v in ker_params.items())
     ker_params_text.append("</ul>")
     ker_params_text = "".join(ker_params_text)
 
@@ -216,7 +217,7 @@ def _gen_est_summary(obj, out_filename):
     ker_text = _get_kernel_summary(params_dict) if isinstance(obj, CBMAEstimator) else ""
 
     est_params = {k: v for k, v in params_dict.items() if not k.startswith("kernel_transformer")}
-    est_params_text = [f"<li>{PARAMETERS_DICT[k]}: {v}</li>" for k, v in est_params.items()]
+    est_params_text = [f"<li>{PARAMETERS_DICT.get(k, k)}: {v}</li>" for k, v in est_params.items()]
     est_params_text = "".join(est_params_text)
 
     est_name = obj.__class__.__name__
@@ -233,12 +234,12 @@ def _gen_cor_summary(obj, out_filename):
     """Generate html with parameter use in obj (e.g., corrector)."""
     params_dict = obj.get_params()
 
-    cor_params_text = [f"<li>{PARAMETERS_DICT[k]}: {v}</li>" for k, v in params_dict.items()]
+    cor_params_text = [f"<li>{PARAMETERS_DICT.get(k, k)}: {v}</li>" for k, v in params_dict.items()]
     cor_params_text = "".join(cor_params_text)
 
     ext_params_text = ["<ul>"]
     ext_params_text.extend(
-        f"<li>{PARAMETERS_DICT[k]}: {v}</li>" for k, v in obj.parameters.items()
+        f"<li>{PARAMETERS_DICT.get(k, k)}: {v}</li>" for k, v in obj.parameters.items()
     )
     ext_params_text.append("</ul>")
     ext_params_text = "".join(ext_params_text)

--- a/nimare/reports/base.py
+++ b/nimare/reports/base.py
@@ -202,7 +202,9 @@ def _get_kernel_summary(params_dict):
     kernel_transformer = str(params_dict["kernel_transformer"])
     ker_params = {k: v for k, v in params_dict.items() if k.startswith("kernel_transformer__")}
     ker_params_text = ["<ul>"]
-    ker_params_text.extend(f"<li>{PARAMETERS_DICT.get(k, k)}: {v}</li>" for k, v in ker_params.items())
+    ker_params_text.extend(
+        f"<li>{PARAMETERS_DICT.get(k, k)}: {v}</li>" for k, v in ker_params.items()
+    )
     ker_params_text.append("</ul>")
     ker_params_text = "".join(ker_params_text)
 
@@ -234,7 +236,9 @@ def _gen_cor_summary(obj, out_filename):
     """Generate html with parameter use in obj (e.g., corrector)."""
     params_dict = obj.get_params()
 
-    cor_params_text = [f"<li>{PARAMETERS_DICT.get(k, k)}: {v}</li>" for k, v in params_dict.items()]
+    cor_params_text = [
+        f"<li>{PARAMETERS_DICT.get(k, k)}: {v}</li>" for k, v in params_dict.items()
+    ]
     cor_params_text = "".join(cor_params_text)
 
     ext_params_text = ["<ul>"]

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -207,7 +207,7 @@ def mm2vox(xyz, affine):
     From here:
     http://blog.chrisgorgolewski.org/2014/12/how-to-convert-between-voxel-and-mm.html
     """
-    with np.errstate(invalid='ignore'):
+    with np.errstate(invalid="ignore"):
         ijk = nib.affines.apply_affine(np.linalg.inv(affine), xyz).astype(int)
     return ijk
 

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -207,7 +207,8 @@ def mm2vox(xyz, affine):
     From here:
     http://blog.chrisgorgolewski.org/2014/12/how-to-convert-between-voxel-and-mm.html
     """
-    ijk = nib.affines.apply_affine(np.linalg.inv(affine), xyz).astype(int)
+    with np.errstate(invalid='ignore'):
+        ijk = nib.affines.apply_affine(np.linalg.inv(affine), xyz).astype(int)
     return ijk
 
 


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #935 

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Add missing label for "vfwe_only" parameter and prevent KeyErrors in report generation by using safe dictionary lookups.

Bug Fixes:
- Use PARAMETERS_DICT.get with fallback to key itself to avoid KeyErrors when rendering parameter summaries

Enhancements:
- Add human-readable label for "vfwe_only" in PARAMETERS_DICT