### PR TITLE
ensure cluster label files are named correctly

### DIFF
--- a/nimare/tests/test_diagnostics.py
+++ b/nimare/tests/test_diagnostics.py
@@ -1,5 +1,6 @@
 """Tests for the nimare.diagnostics module."""
 
+import logging
 import os.path as op
 
 import nibabel as nib
@@ -130,6 +131,61 @@ def test_focuscounter_negative_tail_label_map_naming(testdata_cbma_full):
     assert results.maps["label_tail-negative"] is not None
     assert "label_tail-positive" not in results.maps
     assert "z_diag-FocusCounter_tab-counts_tail-negative" in results.tables
+
+
+def test_focuscounter_positive_tail_label_map_naming(testdata_cbma_full):
+    """Ensure single-tail positive clusters are labeled as positive."""
+    dset = testdata_cbma_full.slice(testdata_cbma_full.ids[:5])
+    meta = cbma.ALE()
+    res = meta.fit(dset)
+
+    masker = res.estimator.masker
+    mask_img = masker.mask_img_
+    mask_data = mask_img.get_fdata().astype(bool)
+
+    pos_data = np.zeros(mask_img.shape, dtype=float)
+    ijk = np.column_stack(np.where(mask_data))[0]
+    pos_data[tuple(ijk)] = 5.0
+    pos_img = nib.Nifti1Image(pos_data, mask_img.affine)
+    res.maps["z"] = np.squeeze(masker.transform(pos_img))
+
+    counter = diagnostics.FocusCounter(target_image="z", voxel_thresh=1.0)
+    results = counter.transform(res)
+
+    assert "label_tail-positive" in results.maps
+    assert results.maps["label_tail-positive"] is not None
+    assert "label_tail-negative" not in results.maps
+    assert "z_diag-FocusCounter_tab-counts_tail-positive" in results.tables
+
+
+def test_focuscounter_single_tail_mixed_sign_warning(testdata_cbma_full, monkeypatch, caplog):
+    """Ensure mixed-sign single-tail path warns and defaults to positive."""
+    dset = testdata_cbma_full.slice(testdata_cbma_full.ids[:5])
+    meta = cbma.ALE()
+    res = meta.fit(dset)
+
+    masker = res.estimator.masker
+    mask_img = masker.mask_img_
+    mask_data = mask_img.get_fdata().astype(bool)
+
+    pos_data = np.zeros(mask_img.shape, dtype=float)
+    ijk = np.column_stack(np.where(mask_data))[0]
+    pos_data[tuple(ijk)] = 5.0
+    pos_img = nib.Nifti1Image(pos_data, mask_img.affine)
+    res.maps["z"] = np.squeeze(masker.transform(pos_img))
+
+    def _fake_infer(_label_maps, _clusters_table, _n_clusters):
+        return ["positive"], "positive", True
+
+    monkeypatch.setattr(diagnostics, "_infer_label_map_tails", _fake_infer)
+    caplog.set_level(logging.WARNING, logger="nimare.diagnostics")
+
+    counter = diagnostics.FocusCounter(target_image="z", voxel_thresh=1.0)
+    results = counter.transform(res)
+
+    assert any("Mixed-sign clusters detected" in r.message for r in caplog.records)
+    assert "label_tail-positive" in results.maps
+    assert "label_tail-negative" not in results.maps
 
 
 def test_focuscounter_pairwise_negative_tail_uses_group2(testdata_cbma_full):


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #970 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Ensure diagnostic label maps and contribution tables use correct positive/negative tail naming and study IDs across CBMA and pairwise estimators.

Bug Fixes:
- Correct label map naming when only a single negative- or positive-tail cluster map is returned.
- Fix mapping of tails to study ID groups for pairwise estimators so negative tails use the second group as appropriate.
- Align contribution table tail names with the actual tail signs used in diagnostics.

Tests:
- Add regression tests for single-tail negative cluster label map naming.
- Add regression tests verifying pairwise negative-tail diagnostics use group2 study identifiers.