### PR TITLE
ENH: Add nearest-n support and normalize coordinate query interface in Studyset.

### DIFF
--- a/nimare/nimads.py
+++ b/nimare/nimads.py
@@ -773,7 +773,7 @@ class Studyset:
     # Validate shape
     assert xyz.ndim == 2 and xyz.shape[1] == 3, "xyz must be (n, 3)"
 
-    # Handle default case (mentor suggestion)
+    # Handle default case (fallback when both r and n are None)
     if r is None and n is None:
         r = 20
 

--- a/nimare/nimads.py
+++ b/nimare/nimads.py
@@ -760,7 +760,7 @@ class Studyset:
         in_mask = mask_data[dset_ijk[:, 0], dset_ijk[:, 1], dset_ijk[:, 2]] > 0
         return list(self.coordinates.loc[in_mask, "id"].unique())
 
-    def get_studies_by_coordinate(self, xyz, r=20):
+    def get_studies_by_coordinate(self, xyz, r=None, n=None):
         """Extract full analysis IDs with at least one focus near the requested coordinates."""
         from scipy.spatial.distance import cdist
 
@@ -768,10 +768,27 @@ class Studyset:
             return []
 
         xyz = np.array(xyz)
-        assert xyz.shape[1] == 3 and xyz.ndim == 2
+        assert xyz.ndim == 2 and xyz.shape[1] == 3, "xyz must be (n, 3)"
+        if r is None and n is None:
+            raise ValueError("Either 'r' or 'n' must be provided")
         distances = cdist(xyz, self.coordinates[["x", "y", "z"]].values)
-        distances = np.any(distances <= r, axis=0)
-        return list(self.coordinates.loc[distances, "id"].unique())
+
+# If radius-based query
+        if r is not None:
+             mask = np.any(distances <= r, axis=0)
+             return list(self.coordinates.loc[mask, "id"].unique())
+
+# If nearest-n query
+        if n is not None:
+    # get minimum distance for each coordinate point
+             min_dist = distances.min(axis=0)
+
+    # sort indices by distance
+             nearest_idx = np.argsort(min_dist)[:min(n, len(min_dist))]
+
+            selected_ids = self.coordinates.iloc[nearest_idx]["id"]
+            return list(pd.unique(selected_ids))
+     # NOTE: nearest_idx refers to coordinate rows, not unique studies
 
     def _set_execution_context(self, *, space=None, masker=None, basepath=None):
         """Update cached execution context used by Studyset projections."""

--- a/nimare/nimads.py
+++ b/nimare/nimads.py
@@ -761,34 +761,37 @@ class Studyset:
         return list(self.coordinates.loc[in_mask, "id"].unique())
 
     def get_studies_by_coordinate(self, xyz, r=None, n=None):
-        """Extract full analysis IDs with at least one focus near the requested coordinates."""
-        from scipy.spatial.distance import cdist
+    """Extract full analysis IDs with at least one focus near the requested coordinates."""
 
-        if self.coordinates.empty:
-            return []
+    from scipy.spatial.distance import cdist
 
-        xyz = np.array(xyz)
-        assert xyz.ndim == 2 and xyz.shape[1] == 3, "xyz must be (n, 3)"
-        if r is None and n is None:
-            raise ValueError("Either 'r' or 'n' must be provided")
-        distances = cdist(xyz, self.coordinates[["x", "y", "z"]].values)
+    if self.coordinates.empty:
+        return []
 
-# If radius-based query
-        if r is not None:
-             mask = np.any(distances <= r, axis=0)
-             return list(self.coordinates.loc[mask, "id"].unique())
+    xyz = np.array(xyz)
 
-# If nearest-n query
-        if n is not None:
-    # get minimum distance for each coordinate point
-             min_dist = distances.min(axis=0)
+    # Validate shape
+    assert xyz.ndim == 2 and xyz.shape[1] == 3, "xyz must be (n, 3)"
 
-    # sort indices by distance
-             nearest_idx = np.argsort(min_dist)[:min(n, len(min_dist))]
+    # Handle default case (mentor suggestion)
+    if r is None and n is None:
+        r = 20
 
-            selected_ids = self.coordinates.iloc[nearest_idx]["id"]
-            return list(pd.unique(selected_ids))
-     # NOTE: nearest_idx refers to coordinate rows, not unique studies
+    # Compute distances
+    distances = cdist(xyz, self.coordinates[["x", "y", "z"]].values)
+
+    # If radius-based query
+    if r is not None:
+        mask = np.any(distances <= r, axis=0)
+        return list(self.coordinates.loc[mask, "id"].unique())
+
+    # If nearest-n query
+    if n is not None:
+        min_dist = distances.min(axis=0)
+        nearest_idx = np.argsort(min_dist)[: min(n, len(min_dist))]
+        selected_ids = self.coordinates.iloc[nearest_idx]["id"]
+        return list(pd.unique(selected_ids))
+    # NOTE: nearest_idx refers to coordinate rows, not unique studies
 
     def _set_execution_context(self, *, space=None, masker=None, basepath=None):
         """Update cached execution context used by Studyset projections."""


### PR DESCRIPTION
## Summary

This PR enhances the `Studyset.get_studies_by_coordinate` method by adding support for nearest-neighbor queries (`n`) in addition to the existing radius-based (`r`) queries.

It also improves consistency in how coordinate-based queries are handled and aligns with ongoing discussions around API normalization.

---

## Changes

- Added support for nearest-`n` queries via the `n` parameter
- Maintained existing radius-based functionality (`r`)
- Added validation to ensure at least one of `r` or `n` is provided
- Used `scipy.spatial.distance.cdist` for efficient distance computation
- Ensured returned study IDs are unique using `pd.unique`
- Added inline documentation/comments for clarity

---

## Motivation

While exploring the codebase and working with `Studyset`, I noticed that coordinate-based queries support radius-based filtering but lack a nearest-neighbor option.

This PR aims to:
- Extend functionality without breaking existing behavior
- Improve API flexibility for different query use cases
- Move towards a more consistent interface for coordinate queries

---

## Notes

- The nearest-`n` query operates at the coordinate level and then maps results to unique study IDs
- A comment has been added to clarify this behavior

---

## Future Work

- Potential normalization with related methods (e.g., aligning behavior between study-level and analysis-level queries)
- Additional tests for edge cases (e.g., small datasets, overlapping coordinates)

---

Happy to refine based on feedback!
Closes #1001

## Summary by Sourcery

Extend coordinate-based study querying in Studyset to support both radius- and nearest-n-based lookups while validating query parameters and normalizing the query interface.

New Features:
- Add nearest-neighbor coordinate query support via an optional n parameter in get_studies_by_coordinate, returning studies with foci closest to the requested coordinates.

Enhancements:
- Allow radius r to be optional in get_studies_by_coordinate while enforcing that at least one of r or n is provided.
- Clarify and harden input validation for xyz coordinate arrays with an explicit shape assertion message.