### PR TITLE
[FIX] underflow (and overflow) issues

### DIFF
--- a/nimare/correct.py
+++ b/nimare/correct.py
@@ -10,7 +10,7 @@ from pymare.stats import bonferroni, fdr
 from nimare.base import NiMAREBase
 from nimare.results import MetaResult
 from nimare.transforms import p_to_z
-from nimare.utils import DEFAULT_FLOAT_DTYPE
+from nimare.utils import DEFAULT_FLOAT_DTYPE, _clip_logp_values, _clip_p_values
 
 LGR = logging.getLogger(__name__)
 
@@ -99,7 +99,8 @@ class Corrector(NiMAREBase):
 
     def _generate_secondary_maps(self, result, corr_maps, rm):
         """Generate corrected version of z and log-p maps if they exist."""
-        p = corr_maps[rm]
+        p = _clip_p_values(corr_maps[rm], dtype=DEFAULT_FLOAT_DTYPE)
+        corr_maps[rm] = p
 
         if rm == "p":
             z_map_name, logp_map_name = "z", "logp"
@@ -109,7 +110,10 @@ class Corrector(NiMAREBase):
             corr_maps[z_map_name] = p_to_z(p) * np.sign(result.maps[z_map_name])
 
         if logp_map_name in result.maps:
-            corr_maps[logp_map_name] = -np.log10(p)
+            corr_maps[logp_map_name] = _clip_logp_values(
+                -np.log10(p),
+                dtype=DEFAULT_FLOAT_DTYPE,
+            )
 
         return corr_maps
 

--- a/nimare/correct.py
+++ b/nimare/correct.py
@@ -10,7 +10,7 @@ from pymare.stats import bonferroni, fdr
 from nimare.base import NiMAREBase
 from nimare.results import MetaResult
 from nimare.transforms import p_to_z
-from nimare.utils import DEFAULT_FLOAT_DTYPE, _clip_logp_values, _clip_p_values
+from nimare.utils import DEFAULT_FLOAT_DTYPE, _clip_p_values, _p_to_logp_values
 
 LGR = logging.getLogger(__name__)
 
@@ -99,7 +99,7 @@ class Corrector(NiMAREBase):
 
     def _generate_secondary_maps(self, result, corr_maps, rm):
         """Generate corrected version of z and log-p maps if they exist."""
-        p = _clip_p_values(corr_maps[rm], dtype=DEFAULT_FLOAT_DTYPE)
+        p = _clip_p_values(corr_maps[rm], dtype=DEFAULT_FLOAT_DTYPE, copy=False)
         corr_maps[rm] = p
 
         if rm == "p":
@@ -110,10 +110,7 @@ class Corrector(NiMAREBase):
             corr_maps[z_map_name] = p_to_z(p) * np.sign(result.maps[z_map_name])
 
         if logp_map_name in result.maps:
-            corr_maps[logp_map_name] = _clip_logp_values(
-                -np.log10(p),
-                dtype=DEFAULT_FLOAT_DTYPE,
-            )
+            corr_maps[logp_map_name] = _p_to_logp_values(p, dtype=DEFAULT_FLOAT_DTYPE)
 
         return corr_maps
 

--- a/nimare/decode/discrete.py
+++ b/nimare/decode/discrete.py
@@ -12,7 +12,7 @@ from nimare.decode.utils import weight_priors
 from nimare.meta.kernel import KernelTransformer, MKDAKernel
 from nimare.stats import one_way, pearson, two_way
 from nimare.transforms import p_to_z
-from nimare.utils import _check_type, _mask_img_to_bool, get_masker
+from nimare.utils import _check_type, _clip_p_values, _mask_img_to_bool, get_masker
 
 
 def gclda_decode_roi(model, roi, topic_priors=None, prior_weight=1.0):
@@ -330,7 +330,8 @@ def brainmap_decode(
 
     # Significance testing
     # Forward inference significance is determined with a binomial distribution
-    p_fi = 1 - binom.cdf(k=n_selected_term, n=n_term_foci, p=p_selected)
+    p_fi = binom.sf(k=n_selected_term, n=n_term_foci, p=p_selected)
+    p_fi = _clip_p_values(p_fi, dtype=p_fi.dtype, copy=False)
     sign_fi = np.sign(
         n_selected_term - np.mean(n_selected_term)
     ).ravel()  # pylint: disable=no-member
@@ -344,6 +345,7 @@ def brainmap_decode(
     ).T
     chi2_ri = two_way(cells)
     p_ri = special.chdtrc(1, chi2_ri)
+    p_ri = _clip_p_values(p_ri, dtype=p_ri.dtype, copy=False)
     sign_ri = np.sign(p_selected_g_term - p_selected_g_noterm).ravel()  # pylint: disable=no-member
 
     # Ignore rare features
@@ -627,6 +629,7 @@ def neurosynth_decode(
     # One-way chi-square test for uniformity of term frequency across terms
     chi2_fi = one_way(n_selected_term, n_term)
     p_fi = special.chdtrc(1, chi2_fi)
+    p_fi = _clip_p_values(p_fi, dtype=p_fi.dtype, copy=False)
     sign_fi = np.sign(
         n_selected_term - np.mean(n_selected_term)
     ).ravel()  # pylint: disable=no-member
@@ -640,6 +643,7 @@ def neurosynth_decode(
     ).T
     chi2_ri = two_way(cells)
     p_ri = special.chdtrc(1, chi2_ri)
+    p_ri = _clip_p_values(p_ri, dtype=p_ri.dtype, copy=False)
     sign_ri = np.sign(p_selected_g_term - p_selected_g_noterm).ravel()  # pylint: disable=no-member
 
     # Multiple comparisons correction across terms. Separately done for FI and RI.

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -33,6 +33,7 @@ from nimare.transforms import p_to_z
 from nimare.utils import (
     DEFAULT_FLOAT_DTYPE,
     _check_ncores,
+    _p_to_logp_values,
     mm2vox,
     use_memmap,
 )
@@ -968,7 +969,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
                     iter_diff_values._mmap.close()
 
         z_arr = p_to_z(p_values, tail="two") * diff_signs
-        logp_arr = -np.log10(p_values)
+        logp_arr = _p_to_logp_values(p_values, dtype=DEFAULT_FLOAT_DTYPE)
 
         maps = {
             "stat_desc-group1MinusGroup2": diff_ale_values,
@@ -1277,7 +1278,6 @@ class ALESubtraction(PairwiseCBMAEstimator):
         stat_values = result.get_map("stat_desc-group1MinusGroup2", return_type="array")
         z_values = result.get_map("z_desc-group1MinusGroup2", return_type="array")
         sign = np.sign(z_values)
-        eps = np.spacing(1)
 
         if n_iters is None:
             n_iters = self.n_iters
@@ -1365,8 +1365,7 @@ class ALESubtraction(PairwiseCBMAEstimator):
         vfwe_null = self.null_distributions_["values_level-voxel_corr-fwe_method-montecarlo"]
         p_vfwe_vals = null_to_p(np.abs(stat_values), vfwe_null, tail="upper")
         z_vfwe_vals = p_to_z(p_vfwe_vals, tail="two") * sign
-        logp_vfwe_vals = -np.log10(p_vfwe_vals)
-        logp_vfwe_vals[np.isinf(logp_vfwe_vals)] = -np.log10(eps)
+        logp_vfwe_vals = _p_to_logp_values(p_vfwe_vals, dtype=DEFAULT_FLOAT_DTYPE)
 
         maps = {
             "p_desc-group1MinusGroup2_level-voxel": p_vfwe_vals,
@@ -1420,12 +1419,10 @@ class ALESubtraction(PairwiseCBMAEstimator):
             )
 
             z_cmfwe_vals = p_to_z(p_cmfwe_values, tail="two") * sign
-            logp_cmfwe_vals = -np.log10(p_cmfwe_values)
-            logp_cmfwe_vals[np.isinf(logp_cmfwe_vals)] = -np.log10(eps)
+            logp_cmfwe_vals = _p_to_logp_values(p_cmfwe_values, dtype=DEFAULT_FLOAT_DTYPE)
 
             z_csfwe_vals = p_to_z(p_csfwe_values, tail="two") * sign
-            logp_csfwe_vals = -np.log10(p_csfwe_values)
-            logp_csfwe_vals[np.isinf(logp_csfwe_vals)] = -np.log10(eps)
+            logp_csfwe_vals = _p_to_logp_values(p_csfwe_values, dtype=DEFAULT_FLOAT_DTYPE)
 
             maps.update(
                 {
@@ -1649,8 +1646,7 @@ class SCALE(CBMAEstimator):
 
         p_values, z_values = self._scale_to_p(stat_values, exceedance_counts)
 
-        logp_values = -np.log10(p_values)
-        logp_values[np.isinf(logp_values)] = -np.log10(np.finfo(float).eps)
+        logp_values = _p_to_logp_values(p_values, dtype=DEFAULT_FLOAT_DTYPE, copy=False)
 
         # Write out unthresholded value images
         maps = {"stat": stat_values, "logp": logp_values, "z": z_values}
@@ -1826,8 +1822,11 @@ class SCALE(CBMAEstimator):
 
         p_vfwe_values = null_to_p(stat_values, fwe_voxel_max, tail="upper")
         z_vfwe_values = p_to_z(p_vfwe_values, tail="one")
-        logp_vfwe_values = -np.log10(p_vfwe_values)
-        logp_vfwe_values[np.isinf(logp_vfwe_values)] = -np.log10(np.finfo(float).eps)
+        logp_vfwe_values = _p_to_logp_values(
+            p_vfwe_values,
+            dtype=DEFAULT_FLOAT_DTYPE,
+            copy=False,
+        )
 
         self.null_distributions_["values_level-voxel_corr-fwe_method-montecarlo"] = fwe_voxel_max
 

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -26,6 +26,7 @@ from nimare.utils import (
     _check_ncores,
     _check_type,
     _mask_img_to_bool,
+    _p_to_logp_values,
     get_masker,
     get_masker_mask_image,
     mm2vox,
@@ -912,8 +913,7 @@ class CBMAEstimator(Estimator):
                         nib.Nifti1Image(p_cmfwe_map, self.masker.mask_img.affine)
                     )
                 )
-                logp_cmfwe_values = -np.log10(p_cmfwe_values)
-                logp_cmfwe_values[np.isinf(logp_cmfwe_values)] = -np.log10(np.finfo(float).eps)
+                logp_cmfwe_values = _p_to_logp_values(p_cmfwe_values, dtype=DEFAULT_FLOAT_DTYPE)
                 z_cmfwe_values = p_to_z(p_cmfwe_values, tail="one")
 
                 # Cluster size-based inference
@@ -926,8 +926,7 @@ class CBMAEstimator(Estimator):
                         nib.Nifti1Image(p_csfwe_map, self.masker.mask_img.affine)
                     )
                 )
-                logp_csfwe_values = -np.log10(p_csfwe_values)
-                logp_csfwe_values[np.isinf(logp_csfwe_values)] = -np.log10(np.finfo(float).eps)
+                logp_csfwe_values = _p_to_logp_values(p_csfwe_values, dtype=DEFAULT_FLOAT_DTYPE)
                 z_csfwe_values = p_to_z(p_csfwe_values, tail="one")
 
                 self.null_distributions_[
@@ -945,8 +944,7 @@ class CBMAEstimator(Estimator):
             )
 
         z_vfwe_values = p_to_z(p_vfwe_values, tail="one")
-        logp_vfwe_values = -np.log10(p_vfwe_values)
-        logp_vfwe_values[np.isinf(logp_vfwe_values)] = -np.log10(np.finfo(float).eps)
+        logp_vfwe_values = _p_to_logp_values(p_vfwe_values, dtype=DEFAULT_FLOAT_DTYPE)
 
         if vfwe_only:
             # Return unthresholded value images

--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -19,7 +19,13 @@ from nimare.meta.kernel import KDAKernel, MKDAKernel
 from nimare.meta.utils import _calculate_cluster_measures
 from nimare.stats import null_to_p, one_way, two_way
 from nimare.transforms import p_to_z
-from nimare.utils import DEFAULT_FLOAT_DTYPE, _check_ncores, _mask_img_to_bool, vox2mm
+from nimare.utils import (
+    DEFAULT_FLOAT_DTYPE,
+    _check_ncores,
+    _mask_img_to_bool,
+    _p_to_logp_values,
+    vox2mm,
+)
 
 LGR = logging.getLogger(__name__)
 __version__ = _version.get_versions()["version"]
@@ -861,7 +867,6 @@ class MKDAChi2(PairwiseCBMAEstimator):
         rand_idx2 = np.random.choice(null_xyz.shape[0], size=(iter_df2.shape[0], n_iters))
         rand_xyz2 = null_xyz[rand_idx2, :]
         iter_xyzs2 = np.split(rand_xyz2, rand_xyz2.shape[1], axis=1)
-        eps = np.spacing(1)
 
         # Identify summary statistic corresponding to intensity threshold
         ss_thresh = chi2.isf(voxel_thresh, 1)
@@ -946,25 +951,19 @@ class MKDAChi2(PairwiseCBMAEstimator):
         # Convert p-values
         # pAgF
         pAgF_z_vfwe_vals = p_to_z(pAgF_p_vfwe_vals, tail="two") * pAgF_sign
-        pAgF_logp_vfwe_vals = -np.log10(pAgF_p_vfwe_vals)
-        pAgF_logp_vfwe_vals[np.isinf(pAgF_logp_vfwe_vals)] = -np.log10(eps)
+        pAgF_logp_vfwe_vals = _p_to_logp_values(pAgF_p_vfwe_vals, dtype=DEFAULT_FLOAT_DTYPE)
         pAgF_z_cmfwe_vals = p_to_z(pAgF_p_cmfwe_vals, tail="two") * pAgF_sign
-        pAgF_logp_cmfwe_vals = -np.log10(pAgF_p_cmfwe_vals)
-        pAgF_logp_cmfwe_vals[np.isinf(pAgF_logp_cmfwe_vals)] = -np.log10(eps)
+        pAgF_logp_cmfwe_vals = _p_to_logp_values(pAgF_p_cmfwe_vals, dtype=DEFAULT_FLOAT_DTYPE)
         pAgF_z_csfwe_vals = p_to_z(pAgF_p_csfwe_vals, tail="two") * pAgF_sign
-        pAgF_logp_csfwe_vals = -np.log10(pAgF_p_csfwe_vals)
-        pAgF_logp_csfwe_vals[np.isinf(pAgF_logp_csfwe_vals)] = -np.log10(eps)
+        pAgF_logp_csfwe_vals = _p_to_logp_values(pAgF_p_csfwe_vals, dtype=DEFAULT_FLOAT_DTYPE)
 
         # pFgA
         pFgA_z_vfwe_vals = p_to_z(pFgA_p_vfwe_vals, tail="two") * pFgA_sign
-        pFgA_logp_vfwe_vals = -np.log10(pFgA_p_vfwe_vals)
-        pFgA_logp_vfwe_vals[np.isinf(pFgA_logp_vfwe_vals)] = -np.log10(eps)
+        pFgA_logp_vfwe_vals = _p_to_logp_values(pFgA_p_vfwe_vals, dtype=DEFAULT_FLOAT_DTYPE)
         pFgA_z_cmfwe_vals = p_to_z(pFgA_p_cmfwe_vals, tail="two") * pFgA_sign
-        pFgA_logp_cmfwe_vals = -np.log10(pFgA_p_cmfwe_vals)
-        pFgA_logp_cmfwe_vals[np.isinf(pFgA_logp_cmfwe_vals)] = -np.log10(eps)
+        pFgA_logp_cmfwe_vals = _p_to_logp_values(pFgA_p_cmfwe_vals, dtype=DEFAULT_FLOAT_DTYPE)
         pFgA_z_csfwe_vals = p_to_z(pFgA_p_csfwe_vals, tail="two") * pFgA_sign
-        pFgA_logp_csfwe_vals = -np.log10(pFgA_p_csfwe_vals)
-        pFgA_logp_csfwe_vals[np.isinf(pFgA_logp_csfwe_vals)] = -np.log10(eps)
+        pFgA_logp_csfwe_vals = _p_to_logp_values(pFgA_p_csfwe_vals, dtype=DEFAULT_FLOAT_DTYPE)
 
         maps = {
             # uniformity analysis

--- a/nimare/meta/cbmr.py
+++ b/nimare/meta/cbmr.py
@@ -21,6 +21,9 @@ from nimare.estimator import Estimator
 from nimare.meta import models
 from nimare.results import MetaResult
 from nimare.utils import (
+    DEFAULT_FLOAT_DTYPE,
+    _clip_p_values,
+    _minimum_positive_float,
     b_spline_bases,
     dummy_encoding_moderators,
     get_masker,
@@ -1212,6 +1215,11 @@ class CBMRInference(object):
             p_vals_spatial = scipy.stats.norm.sf(z_stats_spatial)
         else:
             p_vals_spatial = scipy.stats.norm.sf(abs(z_stats_spatial)) * 2
+        p_vals_spatial = _clip_p_values(
+            p_vals_spatial,
+            dtype=DEFAULT_FLOAT_DTYPE,
+            copy=False,
+        )
         return z_stats_spatial, p_vals_spatial
 
     def _compute_group_glh_statistics(
@@ -1249,12 +1257,21 @@ class CBMRInference(object):
             cov_log_intensity,
             contrast_log_intensity,
         )
-        p_vals_spatial = 1 - scipy.stats.chi2.cdf(chi_sq_spatial, df=m)
+        p_vals_spatial = scipy.stats.chi2.sf(chi_sq_spatial, df=m)
+        p_vals_spatial = _clip_p_values(
+            p_vals_spatial,
+            dtype=DEFAULT_FLOAT_DTYPE,
+            copy=False,
+        )
         if is_homogeneity_test:
             z_stats_spatial = scipy.stats.norm.isf(p_vals_spatial)
             z_stats_spatial[z_stats_spatial < 0] = 0
         else:
-            z_stats_spatial = scipy.stats.norm.isf(p_vals_spatial / 2)
+            z_p_values = np.maximum(
+                p_vals_spatial,
+                2 * _minimum_positive_float(p_vals_spatial.dtype),
+            )
+            z_stats_spatial = scipy.stats.norm.isf(z_p_values / 2)
             if simp_con_group.shape[0] == 1:
                 z_stats_spatial *= np.sign(contrast_log_intensity.flatten())
         z_stats_spatial = np.clip(z_stats_spatial, a_min=-10, a_max=10)
@@ -1370,13 +1387,27 @@ class CBMRInference(object):
             involved_std_moderator_coef = np.sqrt(involved_var_moderator_coef)
             z_stats_moderator = contrast_moderator_coef / involved_std_moderator_coef
             p_vals_moderator = scipy.stats.norm.sf(abs(z_stats_moderator)) * 2
+            p_vals_moderator = _clip_p_values(
+                p_vals_moderator,
+                dtype=np.asarray(p_vals_moderator).dtype,
+                copy=False,
+            )
             chi_sq_moderator = None
         else:
             contrast_covariance = con_moderator @ cov_moderator_coef @ con_moderator.T
             solved = np.linalg.solve(contrast_covariance, contrast_moderator_coef)
             chi_sq_moderator = contrast_moderator_coef.T @ solved
-            p_vals_moderator = 1 - scipy.stats.chi2.cdf(chi_sq_moderator, df=m_con_moderator)
-            z_stats_moderator = scipy.stats.norm.isf(p_vals_moderator / 2)
+            p_vals_moderator = scipy.stats.chi2.sf(chi_sq_moderator, df=m_con_moderator)
+            p_vals_moderator = _clip_p_values(
+                p_vals_moderator,
+                dtype=np.asarray(p_vals_moderator).dtype,
+                copy=False,
+            )
+            z_p_values = np.maximum(
+                p_vals_moderator,
+                2 * _minimum_positive_float(np.asarray(p_vals_moderator).dtype),
+            )
+            z_stats_moderator = scipy.stats.norm.isf(z_p_values / 2)
 
         return {
             "contrast_count": m_con_moderator,

--- a/nimare/results.py
+++ b/nimare/results.py
@@ -10,7 +10,13 @@ import pandas as pd
 from nibabel.funcs import squeeze_image
 
 from nimare.base import NiMAREBase
-from nimare.utils import DEFAULT_FLOAT_DTYPE, get_description_references, get_masker
+from nimare.utils import (
+    DEFAULT_FLOAT_DTYPE,
+    _clip_logp_values,
+    _clip_p_values,
+    get_description_references,
+    get_masker,
+)
 
 LGR = logging.getLogger(__name__)
 
@@ -96,6 +102,10 @@ class MetaResult(NiMAREBase):
             if map_.ndim != 1:
                 LGR.warning(f"Map '{map_name}' should be 1D, not {map_.ndim}D. Squeezing.")
                 map_ = np.squeeze(map_)
+            if map_name == "p" or map_name.startswith("p_"):
+                map_ = _clip_p_values(map_, dtype=DEFAULT_FLOAT_DTYPE)
+            elif map_name.startswith("logp"):
+                map_ = _clip_logp_values(map_, dtype=DEFAULT_FLOAT_DTYPE)
             if np.issubdtype(map_.dtype, np.floating) and map_.dtype != DEFAULT_FLOAT_DTYPE:
                 map_ = map_.astype(DEFAULT_FLOAT_DTYPE)
             maps[map_name] = map_

--- a/nimare/tests/test_correct.py
+++ b/nimare/tests/test_correct.py
@@ -1,6 +1,20 @@
 """Tests for nimare.correct module."""
 
-from nimare.correct import FWECorrector
+import numpy as np
+
+from nimare.correct import FDRCorrector, FWECorrector
+from nimare.results import MetaResult
+from nimare.transforms import p_to_z
+from nimare.utils import _minimum_positive_float
+
+
+class DummyEstimator:
+    """Minimal estimator stand-in for correction tests."""
+
+
+def _masked_values(mask_img, fill_value=0.5):
+    mask_data = np.asanyarray(mask_img.dataobj).astype(bool)
+    return np.full(mask_data.sum(), fill_value, dtype=np.float32)
 
 
 def test_FWECorrector_montecarlo_default_parameters():
@@ -20,3 +34,59 @@ def test_FWECorrector_montecarlo_custom_parameters():
 
     assert corr.parameters["n_iters"] == 10
     assert corr.parameters["n_cores"] == 2
+
+
+def test_MetaResult_clips_tiny_analytical_p_values_to_float32_floor(mni_mask):
+    """Analytical p-values below float32 resolution should be censored, not zeroed."""
+    p_values = _masked_values(mni_mask)
+    p_values[:2] = [0, 1e-50]
+    z_values = p_to_z(p_values, tail="one")
+
+    result = MetaResult(
+        DummyEstimator(),
+        mask=mni_mask,
+        maps={
+            "p": p_values,
+            "z": z_values,
+            "stat": np.arange(p_values.size, dtype=np.float32),
+        },
+    )
+
+    assert result.maps["p"].dtype == np.float32
+    assert np.all(result.maps["p"][:2] == _minimum_positive_float())
+    assert np.all(np.isfinite(result.maps["z"][:2]))
+
+
+def test_FDRCorrector_clips_tiny_p_values_and_finite_secondary_maps(mni_mask):
+    """FDR correction should not generate infinite z/logp maps from tiny p-values."""
+    p_values = _masked_values(mni_mask)
+    p_values[:3] = [0, 1e-50, 0.01]
+    z_values = p_to_z(p_values)
+    with np.errstate(divide="ignore"):
+        logp_values = -np.log10(p_values)
+
+    result = MetaResult(
+        DummyEstimator(),
+        mask=mni_mask,
+        maps={
+            "p": p_values,
+            "z": z_values,
+            "logp": logp_values,
+        },
+    )
+
+    assert np.all(np.isfinite(result.maps["logp"][:3]))
+    corr_result = FDRCorrector(method="indep").transform(result)
+
+    assert corr_result.maps["p_corr-FDR_method-indep"].dtype == np.float32
+    assert np.all(corr_result.maps["p_corr-FDR_method-indep"][:2] > 0)
+    assert np.all(np.isfinite(corr_result.maps["z_corr-FDR_method-indep"][:3]))
+    assert np.all(np.isfinite(corr_result.maps["logp_corr-FDR_method-indep"][:3]))
+
+
+def test_p_to_z_uses_float32_probability_floor():
+    """Zero p-values should map to the finite float32-resolution z ceiling."""
+    z_values = p_to_z(np.array([0, 0], dtype=np.float32), tail="two")
+
+    assert np.all(np.isfinite(z_values))
+    assert np.all(z_values > 0)

--- a/nimare/tests/test_meta_cbmr.py
+++ b/nimare/tests/test_meta_cbmr.py
@@ -6,6 +6,7 @@ import warnings
 import numpy as np
 import pandas as pd
 import pytest
+import scipy
 
 try:
     import torch
@@ -369,6 +370,28 @@ def test_cbmr_chi_square_log_intensity_matches_legacy_loop():
     )
 
     np.testing.assert_allclose(actual, np.asarray(expected))
+
+
+@pytest.mark.skipif(not TORCH_INSTALLED, reason="Torch not installed.")
+def test_cbmr_group_glh_uses_stable_chi_square_survival_function():
+    """Extreme chi-square statistics should retain nonzero p-values when representable."""
+    inference = CBMRInference(device="cpu")
+
+    chi_square, z_values, p_values = inference._compute_group_glh_statistics(
+        simp_con_group=np.array([[1.0]]),
+        involved_groups=["group"],
+        cov_spatial_coef=np.array([[1.0]]),
+        contrast_log_intensity=np.array([[10.0]]),
+        X=np.array([[1.0]]),
+        spatial_coef_dim=1,
+        n_brain_voxel=1,
+        is_homogeneity_test=False,
+    )
+
+    np.testing.assert_allclose(chi_square, [100.0])
+    np.testing.assert_allclose(p_values, scipy.stats.chi2.sf(100.0, df=1), rtol=1e-6, atol=0)
+    assert p_values[0] > 0
+    assert np.isfinite(z_values[0])
 
 
 @pytest.mark.skipif(not TORCH_INSTALLED, reason="Torch not installed.")

--- a/nimare/tests/test_transforms.py
+++ b/nimare/tests/test_transforms.py
@@ -270,3 +270,20 @@ def test_z_to_p(z, tail, expected_p):
     p = transforms.z_to_p(z, tail)
 
     assert np.all(np.isclose(p, expected_p))
+
+
+def test_z_to_p_clips_extreme_values_to_positive_floor():
+    """Extreme z-values should not produce exact-zero p-values."""
+    p = transforms.z_to_p(np.array([50.0]), tail="two")
+
+    assert np.isfinite(p[0])
+    assert p[0] > 0
+
+
+def test_z_to_t_clips_extreme_tail_probabilities():
+    """Extreme z-values should not produce infinite t-values from inverse CDF calls."""
+    t_values = transforms.z_to_t(np.array([-50.0, 50.0]), dof=10)
+
+    assert np.all(np.isfinite(t_values))
+    assert t_values[0] < 0
+    assert t_values[1] > 0

--- a/nimare/tests/test_transforms.py
+++ b/nimare/tests/test_transforms.py
@@ -272,12 +272,24 @@ def test_z_to_p(z, tail, expected_p):
     assert np.all(np.isclose(p, expected_p))
 
 
-def test_z_to_p_clips_extreme_values_to_positive_floor():
-    """Extreme z-values should not produce exact-zero p-values."""
-    p = transforms.z_to_p(np.array([50.0]), tail="two")
+@pytest.mark.parametrize(
+    "tail,z_values,expected_equal",
+    [
+        ("two", np.array([50.0, -50.0]), True),
+        ("one", np.array([50.0, -50.0]), False),
+    ],
+)
+def test_z_to_p_clips_extreme_values_to_positive_floor(tail, z_values, expected_equal):
+    """Extreme z-values should stay finite and avoid zero underflow across tails."""
+    p = transforms.z_to_p(z_values, tail=tail)
 
-    assert np.isfinite(p[0])
+    assert np.all(np.isfinite(p))
     assert p[0] > 0
+    if expected_equal:
+        assert p[1] > 0
+        assert p[0] == p[1]
+    else:
+        assert p[1] == 1.0
 
 
 def test_z_to_t_clips_extreme_tail_probabilities():

--- a/nimare/tests/test_utils.py
+++ b/nimare/tests/test_utils.py
@@ -13,6 +13,39 @@ from nimare import utils
 from nimare.meta.utils import _apply_liberal_mask
 
 
+def test_clip_p_values_copy_parameter_controls_mutation():
+    """P-value clipping should preserve inputs by default and mutate only when requested."""
+    p_values = np.array([np.nan, 0.0, 1e-50, 0.5, 2.0], dtype=np.float32)
+    original = p_values.copy()
+
+    clipped = utils._clip_p_values(p_values)
+
+    assert not np.shares_memory(clipped, p_values)
+    np.testing.assert_array_equal(p_values, original)
+    assert clipped[1] == utils._minimum_positive_float()
+    assert clipped[2] == utils._minimum_positive_float()
+    assert clipped[4] == np.float32(1.0)
+
+    clipped_in_place = utils._clip_p_values(p_values, copy=False)
+
+    assert np.shares_memory(clipped_in_place, p_values)
+    assert p_values[1] == utils._minimum_positive_float()
+    assert p_values[2] == utils._minimum_positive_float()
+    assert p_values[4] == np.float32(1.0)
+
+
+def test_p_to_logp_values_can_reuse_owned_array():
+    """p-to-logp conversion should support in-place mutation for owned arrays."""
+    p_values = np.array([1.0, 0.01, 0.0, np.nan], dtype=np.float32)
+
+    logp_values = utils._p_to_logp_values(p_values, copy=False)
+
+    assert np.shares_memory(logp_values, p_values)
+    np.testing.assert_allclose(logp_values[:2], [0.0, 2.0], atol=1e-6)
+    assert np.isfinite(logp_values[2])
+    assert np.isnan(logp_values[3])
+
+
 def test_find_stem():
     """Test nimare.utils._find_stem."""
     test_array = [

--- a/nimare/tests/utils.py
+++ b/nimare/tests/utils.py
@@ -80,8 +80,11 @@ def _check_p_values(
     # CHECK IF P-VALUES ARE WITHIN THE CORRECT RANGE
     ################################################
     if n_iters:
-        assert p_array.min() >= (1.0 / n_iters)
-        assert p_array.max() <= 1.0 - (1.0 / n_iters)
+        # Compare in the same dtype as p_array to avoid numpy 2.4+ float32/float64
+        # comparison semantics where float32(0.01) < float64(0.01).
+        p_dtype = p_array.dtype
+        assert p_array.min() >= p_dtype.type(1.0 / n_iters)
+        assert p_array.max() <= p_dtype.type(1.0 - 1.0 / n_iters)
     else:
         assert (p_array >= 0).all() and (p_array <= 1).all()
 

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -755,6 +755,7 @@ def z_to_p(z, tail="two"):
     else:
         raise ValueError('Argument "tail" must be one of ["one", "two"]')
 
+    p = _clip_p_values(p, dtype=np.asarray(p).dtype, copy=False)
     if p.shape == ():
         p = p[()]
     return p
@@ -778,9 +779,9 @@ def p_to_z(p, tail="two"):
     z : array_like
         Z-statistics (unsigned)
     """
-    p = _clip_p_values(np.array(p), dtype=DEFAULT_FLOAT_DTYPE)
+    p = _clip_p_values(p, dtype=DEFAULT_FLOAT_DTYPE)
     if tail == "two":
-        p = np.maximum(p, 2 * _minimum_positive_float(DEFAULT_FLOAT_DTYPE))
+        np.maximum(p, 2 * _minimum_positive_float(DEFAULT_FLOAT_DTYPE), out=p)
         z = stats.norm.isf(p / 2)
     elif tail == "one":
         z = stats.norm.isf(p)
@@ -912,10 +913,14 @@ def z_to_t(z_values, dof):
 
     # Calculate p values for <=0
     p_values_z1 = stats.norm.cdf(z1)
+    eps = np.finfo(p_values_z1.dtype).eps
+    np.clip(p_values_z1, eps, 1.0 - eps, out=p_values_z1)
     t_values_z1 = stats.t.ppf(p_values_z1, df=dof)
 
     # Calculate p values for > 0
     p_values_z2 = stats.norm.cdf(-z2)
+    eps = np.finfo(p_values_z2.dtype).eps
+    np.clip(p_values_z2, eps, 1.0 - eps, out=p_values_z2)
     t_values_z2 = -stats.t.ppf(p_values_z2, df=dof)
     t_values_nonzero[k1] = t_values_z1
     t_values_nonzero[k2] = t_values_z2

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -16,9 +16,11 @@ from nimare.base import NiMAREBase
 from nimare.studyset import normalize_collection
 from nimare.utils import (
     DEFAULT_FLOAT_DTYPE,
+    _clip_p_values,
     _dict_to_coordinates,
     _dict_to_df,
     _listify,
+    _minimum_positive_float,
     get_masker,
 )
 
@@ -776,8 +778,9 @@ def p_to_z(p, tail="two"):
     z : array_like
         Z-statistics (unsigned)
     """
-    p = np.array(p)
+    p = _clip_p_values(np.array(p), dtype=DEFAULT_FLOAT_DTYPE)
     if tail == "two":
+        p = np.maximum(p, 2 * _minimum_positive_float(DEFAULT_FLOAT_DTYPE))
         z = stats.norm.isf(p / 2)
     elif tail == "one":
         z = stats.norm.isf(p)

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -34,19 +34,33 @@ def _minimum_positive_float(dtype=DEFAULT_FLOAT_DTYPE):
     return np.nextafter(dtype.type(0), dtype.type(1), dtype=dtype)
 
 
-def _clip_p_values(p_values, dtype=DEFAULT_FLOAT_DTYPE):
+def _clip_p_values(p_values, dtype=DEFAULT_FLOAT_DTYPE, copy=True):
     """Clip p-values to the positive range representable by a floating dtype."""
     dtype = np.dtype(dtype)
-    p_values = np.asarray(p_values, dtype=dtype)
-    return np.clip(p_values, _minimum_positive_float(dtype), dtype.type(1))
+    p_values = (
+        np.array(p_values, dtype=dtype, copy=True) if copy else np.asarray(p_values, dtype=dtype)
+    )
+    return np.clip(p_values, _minimum_positive_float(dtype), dtype.type(1), out=p_values)
 
 
-def _clip_logp_values(logp_values, dtype=DEFAULT_FLOAT_DTYPE):
+def _clip_logp_values(logp_values, dtype=DEFAULT_FLOAT_DTYPE, copy=True):
     """Clip -log10(p) values to the range implied by a floating p-value dtype."""
     dtype = np.dtype(dtype)
-    logp_values = np.asarray(logp_values, dtype=dtype)
+    logp_values = (
+        np.array(logp_values, dtype=dtype, copy=True)
+        if copy
+        else np.asarray(logp_values, dtype=dtype)
+    )
     max_value = -np.log10(_minimum_positive_float(dtype))
-    return np.clip(logp_values, dtype.type(0), max_value)
+    return np.clip(logp_values, dtype.type(0), max_value, out=logp_values)
+
+
+def _p_to_logp_values(p_values, dtype=DEFAULT_FLOAT_DTYPE, copy=True):
+    """Convert p-values to finite -log10(p) values with shared clipping rules."""
+    p_values = _clip_p_values(p_values, dtype=dtype, copy=copy)
+    np.log10(p_values, out=p_values)
+    np.negative(p_values, out=p_values)
+    return p_values
 
 
 def _mask_img_to_bool(mask_img):

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -28,6 +28,27 @@ LGR = logging.getLogger(__name__)
 DEFAULT_FLOAT_DTYPE = np.float32
 
 
+def _minimum_positive_float(dtype=DEFAULT_FLOAT_DTYPE):
+    """Return the smallest positive value representable by a floating dtype."""
+    dtype = np.dtype(dtype)
+    return np.nextafter(dtype.type(0), dtype.type(1), dtype=dtype)
+
+
+def _clip_p_values(p_values, dtype=DEFAULT_FLOAT_DTYPE):
+    """Clip p-values to the positive range representable by a floating dtype."""
+    dtype = np.dtype(dtype)
+    p_values = np.asarray(p_values, dtype=dtype)
+    return np.clip(p_values, _minimum_positive_float(dtype), dtype.type(1))
+
+
+def _clip_logp_values(logp_values, dtype=DEFAULT_FLOAT_DTYPE):
+    """Clip -log10(p) values to the range implied by a floating p-value dtype."""
+    dtype = np.dtype(dtype)
+    logp_values = np.asarray(logp_values, dtype=dtype)
+    max_value = -np.log10(_minimum_positive_float(dtype))
+    return np.clip(logp_values, dtype.type(0), max_value)
+
+
 def _mask_img_to_bool(mask_img):
     """Load mask data as boolean without forcing float conversion."""
     return np.asanyarray(mask_img.dataobj).astype(bool)


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #1070  .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- clip (log)p values to be the smallest representable values
-

## Summary by Sourcery

Clamp extremely small p-values and derived statistics to the representable float32 range to avoid underflow/overflow in meta-analytic results and corrections.

Bug Fixes:
- Prevent zero or underflowed p-values from producing infinite or NaN z, t, and log(p) statistics across CBMA, CBMR, decoding, and correction workflows.
- Ensure chi-square and binomial-based p-values use survival functions and are clipped to maintain positive, finite values.

Enhancements:
- Introduce shared utilities for clipping p-values and -log10(p) values and reuse them across ALE, MKDA, CBMA base classes, and result handling.
- Normalize MetaResult map handling so p and log(p) maps are automatically clipped and stored with a consistent float32 dtype.
- Strengthen numerical stability in z-to-p, p-to-z, and z-to-t transforms by enforcing probability floors and bounded tail probabilities.

Tests:
- Add regression tests covering p-value clipping utilities, MetaResult map coercion, transforms’ behavior for extreme inputs, CBMR chi-square survival usage, and FDR correction of tiny p-values.