### PR TITLE
Add public API skeletons and export ml module

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -242,6 +242,27 @@ all NiMARE workflows.
    transforms.z_to_t
    transforms.z_to_p
 
+.. _api_ml_ref:
+
+:mod:`nimare.ml`: Machine-learning helpers
+-----------------------------------------------------
+
+.. automodule:: nimare.ml
+   :no-members:
+   :no-inherited-members:
+
+.. currentmodule:: nimare
+
+.. autosummary::
+   :toctree: generated/
+   :template: class.rst
+
+   ml.MAFeatureDataset
+   ml.MAFeatureExtractor
+   :template: function.rst
+
+   ml.make_map_reducer
+
 
 .. _api_extract_ref:
 

--- a/nimare/__init__.py
+++ b/nimare/__init__.py
@@ -17,6 +17,7 @@ with warnings.catch_warnings(record=True) as w:
         decode,
         io,
         meta,
+        ml,
         reports,
         resources,
         stats,
@@ -29,6 +30,7 @@ with warnings.catch_warnings(record=True) as w:
     __all__ = [
         "base",
         "dataset",
+        "ml",
         "meta",
         "correct",
         "annotate",

--- a/nimare/ml.py
+++ b/nimare/ml.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 from nimare.base import NiMAREBase
@@ -17,16 +18,16 @@ class MAFeatureDataset(NiMAREBase):
 
     Attributes
     ----------
-    ids : list of str
+    ids : sequence of str
         Full Studyset analysis identifiers ("<study_id>-<analysis_id>") per row.
-    study_ids : list of str
+    study_ids : sequence of str
         Study-level grouping label for each row; used for grouped splitting and leakage control.
     features : array-like or sparse matrix
         Analysis-by-feature matrix combining map features (sparse voxelwise)
         and optional descriptor features. Unreduced voxelwise map features must
         remain in a sparse representation. Reduced map features or
         descriptor-only matrices may be dense.
-    feature_names : list of str
+    feature_names : sequence of str or None
         Names for columns in `features`, aligned to column order.
     target : array-like or None
         Optional row-aligned prediction target (y), by default None.
@@ -38,11 +39,11 @@ class MAFeatureDataset(NiMAREBase):
     def __init__(
         self,
         features: Any,
-        ids: list[str],
-        study_ids: list[str],
-        feature_names: list[str] | None = None,
+        ids: Sequence[str],
+        study_ids: Sequence[str],
+        feature_names: Sequence[str] | None = None,
         target: Any | None = None,
-        provenance: Any | None = None,
+        provenance: dict[str, Any] | None = None,
     ) -> None:
         # Infer sizes from features. Prefer .shape for ndarray/sparse, fall back
         # to len() for generic sequences.
@@ -101,7 +102,7 @@ class MAFeatureDataset(NiMAREBase):
 
     def _split_by_groups(
         self,
-        test_size: float = 0.25,
+        test_size: float | int = 0.25,
         random_state: int | None = None,
         cv: Any = None,
     ):
@@ -114,7 +115,7 @@ class MAFeatureDataset(NiMAREBase):
 
     def split(
         self,
-        test_size: float = 0.25,
+        test_size: float | int = 0.25,
         random_state: int | None = None,
         cv: Any = None,
     ):
@@ -122,8 +123,8 @@ class MAFeatureDataset(NiMAREBase):
 
         Parameters
         ----------
-        test_size : float, default=0.25
-            Proportion of grouped data to assign to the test partition.
+        test_size : float or int, default=0.25
+            Proportion or count of grouped data to assign to the test partition.
         random_state : int or None, default=None
             Seed used when the splitter is stochastic.
         cv : object, default=None
@@ -131,7 +132,7 @@ class MAFeatureDataset(NiMAREBase):
 
         Returns
         -------
-        (MAFeatureDataset, MAFeatureDataset)
+        (MAFeatureDataset, MAFeatureDataset or None)
             Tuple of (train_dataset, test_dataset). If no test partition is
             requested, the second element may be ``None``.
 
@@ -205,13 +206,13 @@ class MAFeatureExtractor(NiMAREBase):
         Existing NiMARE kernel transformer instance or class. No implicit
         scientific default is selected; public examples must pass an explicit
         kernel transformer.
-    descriptor_fields : list of dict, optional
+    descriptor_fields : list of dict or object, optional
         Field selectors from metadata, annotations, or texts, by default None.
     descriptor_transformers : dict, optional
         Optional mapping from descriptor field selectors to explicit
         transformers or vectorizers for non-numeric descriptor fields, by
         default None.
-    target_field : dict, optional
+    target_field : dict or object, optional
         Optional field selector for y, by default None.
     target_transformer : object, optional
         Optional transformer or label extractor for free-text or multi-label
@@ -267,11 +268,11 @@ class MAFeatureExtractor(NiMAREBase):
             "MAFeatureExtractor._get_studyset_tables is not yet implemented."
         )
 
-    def _stack_sparse_features(self, map_features: Any, descriptor_features: Any | None = None):
-        """Combine sparse map features with optional descriptor features.
+    def _stack_sparse_features(self, sparse_rows: Any):
+        """Concatenate sparse feature rows.
 
         This private helper is reserved for the future feature assembly path
-        that builds sklearn-ready matrices from aligned feature blocks.
+        that builds sklearn-ready matrices from row-aligned sparse feature blocks.
         """
         raise NotImplementedError(
             "MAFeatureExtractor._stack_sparse_features is not yet implemented."
@@ -302,7 +303,7 @@ class MAFeatureExtractor(NiMAREBase):
         self,
         studyset: Any,
         map_reducer: Any | None = None,
-        map_reducer_params: Any | None = None,
+        map_reducer_params: dict[str, Any] | None = None,
     ):
         """Run the full public pipeline convenience wrapper.
 
@@ -312,7 +313,7 @@ class MAFeatureExtractor(NiMAREBase):
             NiMARE Studyset input.
         map_reducer : object, optional
             Optional map-feature reducer, by default None.
-        map_reducer_params : object, optional
+        map_reducer_params : dict, optional
             Optional reducer parameters, by default None.
 
         Returns

--- a/nimare/ml.py
+++ b/nimare/ml.py
@@ -17,119 +17,80 @@ class MAFeatureDataset(NiMAREBase):
 
     Attributes
     ----------
-    map_features : array-like or sparse matrix
-        Sample-by-map-feature matrix (n_samples, n_features).
-        Sparse matrices remain sparse unless explicitly densified.
-    sample_ids : list of str
-        Identifiers for each sample.
+    ids : list of str
+        Full Studyset analysis identifiers ("<study_id>-<analysis_id>") per row.
     study_ids : list of str
-        Study-group labels used for grouped splitting.
-    sample_metadata : DataFrame-like
-        Tabular provenance containing at least sample ID, study ID,
-        analysis ID when available, and exclusion status where relevant.
-    masker : object
-        Masker (e.g., nilearn) defining voxel feature order.
-    descriptor_features : array-like, optional
-        Sample-aligned descriptor values, by default None.
-    target : array-like, optional
-        Sample-aligned prediction target (numeric or categorical), by default None.
-    feature_names : list of str, optional
-        Feature names aligned to map_features columns, by default None.
-    exclusion_report : dict, optional
-        Excluded analyses and reasons, by default None.
-    provenance : dict, optional
-        Map-generation settings and collection details, by default None.
+        Study-level grouping label for each row; used for grouped splitting and leakage control.
+    features : array-like or sparse matrix
+        Analysis-by-feature matrix combining map features (sparse voxelwise)
+        and optional descriptor features. Unreduced voxelwise map features must
+        remain in a sparse representation. Reduced map features or
+        descriptor-only matrices may be dense.
+    feature_names : list of str
+        Names for columns in `features`, aligned to column order.
+    target : array-like or None
+        Optional row-aligned prediction target (y), by default None.
+    provenance : dict or None
+        Map-generation settings and source Studyset details, including
+        `missing_coordinates` and any `dropped_ids`, by default None.
     """
 
     def __init__(
         self,
-        map_features: Any,
-        sample_ids: list[str],
+        features: Any,
+        ids: list[str],
         study_ids: list[str],
-        sample_metadata: Any,
-        masker: Any,
-        descriptor_features: Any | None = None,
-        target: Any | None = None,
         feature_names: list[str] | None = None,
-        exclusion_report: Any | None = None,
+        target: Any | None = None,
         provenance: Any | None = None,
     ) -> None:
-        # Infer sizes from map_features. Prefer .shape for ndarray/sparse, fall back
-        # to len() for generic sequences. Use int(...) to coerce numpy scalars to
-        # native ints when present.
+        # Infer sizes from features. Prefer .shape for ndarray/sparse, fall back
+        # to len() for generic sequences.
         try:
-            n_samples = int(map_features.shape[0])
-            n_features = int(map_features.shape[1])
+            n_rows = int(features.shape[0])
+            n_cols = int(features.shape[1])
         except Exception:
             try:
-                # len(map_features) works for lists and other sized containers
-                n_samples = int(len(map_features))
-                # infer number of features from first row when possible
-                n_features = int(len(map_features[0])) if n_samples > 0 else 0
+                n_rows = int(len(features))
+                n_cols = int(len(features[0])) if n_rows > 0 else 0
             except Exception:
-                raise ValueError(
-                    "Unable to determine number of samples or features from map_features"
-                )
+                raise ValueError("Unable to determine number of rows or columns from features")
 
-        if len(sample_ids) != n_samples:
-            raise ValueError("sample_ids length must match number of rows in map_features")
+        if len(ids) != n_rows:
+            raise ValueError("ids length must match number of rows in features")
 
-        if len(study_ids) != n_samples:
-            raise ValueError("study_ids length must match number of rows in map_features")
-
-        if len(sample_metadata) != n_samples:
-            raise ValueError("sample_metadata length must match number of rows in map_features")
-
-        if descriptor_features is not None:
-            if len(descriptor_features) != n_samples:
-                raise ValueError(
-                    "descriptor_features length must match number of rows in map_features"
-                )
+        if len(study_ids) != n_rows:
+            raise ValueError("study_ids length must match number of rows in features")
 
         if target is not None:
-            if len(target) != n_samples:
-                raise ValueError("target length must match number of rows in map_features")
+            if len(target) != n_rows:
+                raise ValueError("target length must match number of rows in features")
 
         if feature_names is not None:
-            if len(feature_names) != n_features:
-                raise ValueError(
-                    "feature_names length must match number of columns in map_features"
-                )
+            if len(feature_names) != n_cols:
+                raise ValueError("feature_names length must match number of columns in features")
 
-        self.map_features = map_features
-        self.sample_ids = list(sample_ids)
+        self.features = features
+        self.ids = list(ids)
         self.study_ids = list(study_ids)
-        self.sample_metadata = sample_metadata
-        self.masker = masker
-        self.descriptor_features = descriptor_features
-        self.target = target
         self.feature_names = feature_names
-        self.exclusion_report = exclusion_report
+        self.target = target
         self.provenance = provenance
 
-    def to_sklearn(
-        self,
-        include_descriptors: bool = True,
-        include_target: bool = True,
-        dense: bool = False,
-    ):
+    def to_sklearn(self):
         """Export the dataset as a scikit-learn-compatible bundle.
-
-        Parameters
-        ----------
-        include_descriptors : bool, default=True
-            Whether descriptor features should be included in the exported
-            data matrix.
-        include_target : bool, default=True
-            Whether the target vector should be included in the export.
-        dense : bool, default=False
-            Whether to densify sparse map features during export.
 
         Returns
         -------
         sklearn.utils.Bunch-like
-            Dataset bundle with aligned data, target, groups, metadata, and
-            feature names.
+            Dataset bundle with attributes `data` (same as `features`),
+            `target` (or `None`), `groups` (same as `study_ids`), and
+            `feature_names`.
+
+        Notes
+        -----
+        Implementations must preserve sparsity for unreduced voxelwise
+        features; reduced representations may be dense.
 
         Raises
         ------
@@ -137,6 +98,19 @@ class MAFeatureDataset(NiMAREBase):
             This public API is scaffolded only.
         """
         raise NotImplementedError("MAFeatureDataset.to_sklearn is not yet implemented.")
+
+    def _split_by_groups(
+        self,
+        test_size: float = 0.25,
+        random_state: int | None = None,
+        cv: Any = None,
+    ):
+        """Split row-aligned feature data while keeping study groups intact.
+
+        This private helper is reserved for leakage-safe grouped splitting by
+        study ID.
+        """
+        raise NotImplementedError("MAFeatureDataset._split_by_groups is not yet implemented.")
 
     def split(
         self,
@@ -157,8 +131,9 @@ class MAFeatureDataset(NiMAREBase):
 
         Returns
         -------
-        tuple of MAFeatureDataset
-            Train and test dataset slices.
+        (MAFeatureDataset, MAFeatureDataset)
+            Tuple of (train_dataset, test_dataset). If no test partition is
+            requested, the second element may be ``None``.
 
         Raises
         ------
@@ -182,7 +157,8 @@ class MAFeatureDataset(NiMAREBase):
         Returns
         -------
         MAFeatureDataset
-            Dataset copy with reduced map features.
+            New dataset instance with reduced map features and preserved
+            metadata (ids, study_ids, feature_names, target, provenance).
 
         Raises
         ------
@@ -191,20 +167,14 @@ class MAFeatureDataset(NiMAREBase):
         """
         raise NotImplementedError("MAFeatureDataset.apply_map_reducer is not yet implemented.")
 
-    def get_feature_names(self):
-        """Return exported feature names in column order.
+    def _apply_map_reducer(self, reducer: Any, fit: bool = False):
+        """Apply a reducer to map features while preserving aligned metadata.
 
-        Returns
-        -------
-        list of str
-            Feature names aligned to the exported data matrix.
-
-        Raises
-        ------
-        NotImplementedError
-            This public API is scaffolded only.
+        This private helper is reserved for the future reducer workflow that
+        keeps ids, study_ids, target, and provenance aligned with the
+        transformed feature matrix.
         """
-        raise NotImplementedError("MAFeatureDataset.get_feature_names is not yet implemented.")
+        raise NotImplementedError("MAFeatureDataset._apply_map_reducer is not yet implemented.")
 
     def copy(self):
         """Return an independent copy of the dataset.
@@ -223,28 +193,38 @@ class MAFeatureDataset(NiMAREBase):
 
 
 class MAFeatureExtractor(NiMAREBase):
-    """Extract aligned map features and optional descriptors/targets from collections.
+    """Orchestrate conversion from a Studyset to MA feature datasets and sklearn-ready exports.
 
-    Converts NiMARE Studyset into scikit-learn-compatible :class:`MAFeatureDataset`.
-    Handles kernel transformation, field resolution, and sample-group alignment.
+    This helper converts a NiMARE Studyset into aligned MA feature datasets,
+    optionally splits by study group, and can export sklearn-compatible
+    bundles with optional map reduction.
 
     Parameters
     ----------
     kernel_transformer : object
-        NiMARE kernel transformer (instance or class). Required; no implicit default.
+        Existing NiMARE kernel transformer instance or class. No implicit
+        scientific default is selected; public examples must pass an explicit
+        kernel transformer.
     descriptor_fields : list of dict, optional
-        Field selectors (source, field, kind) from metadata, annotations,
-        or texts, by default None.
+        Field selectors from metadata, annotations, or texts, by default None.
     descriptor_transformers : dict, optional
-        Transformers/vectorizers for non-numeric descriptor fields, by default None.
-        Without these, non-numeric fields are rejected.
+        Optional mapping from descriptor field selectors to explicit
+        transformers or vectorizers for non-numeric descriptor fields, by
+        default None.
     target_field : dict, optional
-        Field selector for target variable (y), by default None.
+        Optional field selector for y, by default None.
     target_transformer : object, optional
-        Transformer for free-text or multi-label targets, by default None.
-    missing : {'raise', 'drop'}, default='raise'
-        Strategy for missing values and field resolution failures,
-        by default 'raise'.
+        Optional transformer or label extractor for free-text or multi-label
+        targets, by default None.
+    missing_coordinates : {'include', 'drop'}, default='drop'
+        Whether analyses without coordinates are retained as all-zero sparse
+        rows or removed before row construction.
+    test_size : float or int or None, default=None
+        Optional train/test split specification; ``None`` means no split.
+    random_state : int or None, default=None
+        Random seed for reproducible splits, by default None.
+    cache_maps : bool, default=True
+        Whether to cache generated MA map features across repeated calls.
     memory : object, optional
         joblib Memory-like object for caching, by default None.
     memory_level : int, default=1
@@ -258,7 +238,10 @@ class MAFeatureExtractor(NiMAREBase):
         descriptor_transformers: Any | None = None,
         target_field: Any | None = None,
         target_transformer: Any | None = None,
-        missing: str = "raise",
+        missing_coordinates: str = "drop",
+        test_size: float | int | None = None,
+        random_state: int | None = None,
+        cache_maps: bool = True,
         memory: Any | None = None,
         memory_level: int = 1,
     ):
@@ -267,42 +250,46 @@ class MAFeatureExtractor(NiMAREBase):
         self.descriptor_transformers = descriptor_transformers
         self.target_field = target_field
         self.target_transformer = target_transformer
-        self.missing = missing
+        self.missing_coordinates = missing_coordinates
+        self.test_size = test_size
+        self.random_state = random_state
+        self.cache_maps = cache_maps
         self.memory = memory
         self.memory_level = memory_level
 
-    def fit(self, collection: Any):
-        """Validate a collection and record the feature schema.
+    def _get_studyset_tables(self, studyset: Any):
+        """Extract Studyset tables needed to build aligned MA features.
 
-        Parameters
-        ----------
-        collection : object
-            NiMARE Studyset input.
-
-        Returns
-        -------
-        MAFeatureExtractor
-            Fitted extractor instance.
-
-        Raises
-        ------
-        NotImplementedError
-            This public API is scaffolded only.
+        This private helper is reserved for the future Studyset access path
+        that gathers coordinates, metadata, annotations, texts, and IDs.
         """
-        raise NotImplementedError("MAFeatureExtractor.fit is not yet implemented.")
+        raise NotImplementedError(
+            "MAFeatureExtractor._get_studyset_tables is not yet implemented."
+        )
 
-    def transform(self, collection: Any):
-        """Transform a collection into an :class:`MAFeatureDataset`.
+    def _stack_sparse_features(self, map_features: Any, descriptor_features: Any | None = None):
+        """Combine sparse map features with optional descriptor features.
+
+        This private helper is reserved for the future feature assembly path
+        that builds sklearn-ready matrices from aligned feature blocks.
+        """
+        raise NotImplementedError(
+            "MAFeatureExtractor._stack_sparse_features is not yet implemented."
+        )
+
+    def transform(self, studyset: Any):
+        """Validate the Studyset, orchestrate extraction and optional splitting.
 
         Parameters
         ----------
-        collection : object
+        studyset : object
             NiMARE Studyset input.
 
         Returns
         -------
-        MAFeatureDataset
-            Feature dataset created from the fitted schema.
+        tuple
+            Tuple of ``(train_dataset, test_dataset)``. If ``test_size`` is
+            ``None`` or ``0.0``, return ``(full_dataset, None)``.
 
         Raises
         ------
@@ -311,25 +298,35 @@ class MAFeatureExtractor(NiMAREBase):
         """
         raise NotImplementedError("MAFeatureExtractor.transform is not yet implemented.")
 
-    def fit_transform(self, collection: Any):
-        """Fit the extractor and transform the collection in one call.
+    def to_sklearn(
+        self,
+        studyset: Any,
+        map_reducer: Any | None = None,
+        map_reducer_params: Any | None = None,
+    ):
+        """Run the full public pipeline convenience wrapper.
 
         Parameters
         ----------
-        collection : object
+        studyset : object
             NiMARE Studyset input.
+        map_reducer : object, optional
+            Optional map-feature reducer, by default None.
+        map_reducer_params : object, optional
+            Optional reducer parameters, by default None.
 
         Returns
         -------
-        MAFeatureDataset
-            Feature dataset created from the fitted schema.
+        tuple
+            Tuple of sklearn-ready exports as ``(train_bunch, test_bunch)``. If
+            ``test_size`` is ``None`` or ``0.0``, return ``(full_bunch, None)``.
 
         Raises
         ------
         NotImplementedError
             This public API is scaffolded only.
         """
-        raise NotImplementedError("MAFeatureExtractor.fit_transform is not yet implemented.")
+        raise NotImplementedError("MAFeatureExtractor.to_sklearn is not yet implemented.")
 
 
 def make_map_reducer(method: str, **kwargs: Any):

--- a/nimare/ml.py
+++ b/nimare/ml.py
@@ -142,6 +142,15 @@ class MAFeatureDataset(NiMAREBase):
         """
         raise NotImplementedError("MAFeatureDataset.split is not yet implemented.")
 
+    def _apply_map_reducer(self, reducer: Any, fit: bool = False):
+        """Apply a reducer to map features while preserving aligned metadata.
+
+        This private helper is reserved for the future reducer workflow that
+        keeps ids, study_ids, target, and provenance aligned with the
+        transformed feature matrix.
+        """
+        raise NotImplementedError("MAFeatureDataset._apply_map_reducer is not yet implemented.")
+
     def apply_map_reducer(self, reducer: Any, fit: bool = False):
         """Apply a map-feature reducer and return a transformed dataset copy.
 
@@ -166,15 +175,6 @@ class MAFeatureDataset(NiMAREBase):
             This public API is scaffolded only.
         """
         raise NotImplementedError("MAFeatureDataset.apply_map_reducer is not yet implemented.")
-
-    def _apply_map_reducer(self, reducer: Any, fit: bool = False):
-        """Apply a reducer to map features while preserving aligned metadata.
-
-        This private helper is reserved for the future reducer workflow that
-        keeps ids, study_ids, target, and provenance aligned with the
-        transformed feature matrix.
-        """
-        raise NotImplementedError("MAFeatureDataset._apply_map_reducer is not yet implemented.")
 
     def copy(self):
         """Return an independent copy of the dataset.

--- a/nimare/ml.py
+++ b/nimare/ml.py
@@ -13,19 +13,343 @@ __all__ = ["MAFeatureDataset", "MAFeatureExtractor", "make_map_reducer"]
 
 
 class MAFeatureDataset(NiMAREBase):
-    """Placeholder for masked activation feature datasets."""
+    """Container for aligned map features, descriptors, targets, and provenance.
 
-    def __init__(self, *args: Any, **kwargs: Any):
-        raise NotImplementedError("MAFeatureDataset is not yet implemented.")
+    Attributes
+    ----------
+    map_features : array-like or sparse matrix
+        Sample-by-map-feature matrix (n_samples, n_features).
+        Sparse matrices remain sparse unless explicitly densified.
+    sample_ids : list of str
+        Identifiers for each sample.
+    study_ids : list of str
+        Study-group labels used for grouped splitting.
+    sample_metadata : DataFrame-like
+        Tabular provenance containing at least sample ID, study ID,
+        analysis ID when available, and exclusion status where relevant.
+    masker : object
+        Masker (e.g., nilearn) defining voxel feature order.
+    descriptor_features : array-like, optional
+        Sample-aligned descriptor values, by default None.
+    target : array-like, optional
+        Sample-aligned prediction target (numeric or categorical), by default None.
+    feature_names : list of str, optional
+        Feature names aligned to map_features columns, by default None.
+    exclusion_report : dict, optional
+        Excluded analyses and reasons, by default None.
+    provenance : dict, optional
+        Map-generation settings and collection details, by default None.
+    """
+
+    def __init__(
+        self,
+        map_features: Any,
+        sample_ids: list[str],
+        study_ids: list[str],
+        sample_metadata: Any,
+        masker: Any,
+        descriptor_features: Any | None = None,
+        target: Any | None = None,
+        feature_names: list[str] | None = None,
+        exclusion_report: Any | None = None,
+        provenance: Any | None = None,
+    ) -> None:
+        # Infer sizes from map_features. Prefer .shape for ndarray/sparse, fall back
+        # to len() for generic sequences. Use int(...) to coerce numpy scalars to
+        # native ints when present.
+        try:
+            n_samples = int(map_features.shape[0])
+            n_features = int(map_features.shape[1])
+        except Exception:
+            try:
+                # len(map_features) works for lists and other sized containers
+                n_samples = int(len(map_features))
+                # infer number of features from first row when possible
+                n_features = int(len(map_features[0])) if n_samples > 0 else 0
+            except Exception:
+                raise ValueError(
+                    "Unable to determine number of samples or features from map_features"
+                )
+
+        if len(sample_ids) != n_samples:
+            raise ValueError("sample_ids length must match number of rows in map_features")
+
+        if len(study_ids) != n_samples:
+            raise ValueError("study_ids length must match number of rows in map_features")
+
+        if len(sample_metadata) != n_samples:
+            raise ValueError("sample_metadata length must match number of rows in map_features")
+
+        if descriptor_features is not None:
+            if len(descriptor_features) != n_samples:
+                raise ValueError(
+                    "descriptor_features length must match number of rows in map_features"
+                )
+
+        if target is not None:
+            if len(target) != n_samples:
+                raise ValueError("target length must match number of rows in map_features")
+
+        if feature_names is not None:
+            if len(feature_names) != n_features:
+                raise ValueError(
+                    "feature_names length must match number of columns in map_features"
+                )
+
+        self.map_features = map_features
+        self.sample_ids = list(sample_ids)
+        self.study_ids = list(study_ids)
+        self.sample_metadata = sample_metadata
+        self.masker = masker
+        self.descriptor_features = descriptor_features
+        self.target = target
+        self.feature_names = feature_names
+        self.exclusion_report = exclusion_report
+        self.provenance = provenance
+
+    def to_sklearn(
+        self,
+        include_descriptors: bool = True,
+        include_target: bool = True,
+        dense: bool = False,
+    ):
+        """Export the dataset as a scikit-learn-compatible bundle.
+
+        Parameters
+        ----------
+        include_descriptors : bool, default=True
+            Whether descriptor features should be included in the exported
+            data matrix.
+        include_target : bool, default=True
+            Whether the target vector should be included in the export.
+        dense : bool, default=False
+            Whether to densify sparse map features during export.
+
+        Returns
+        -------
+        sklearn.utils.Bunch-like
+            Dataset bundle with aligned data, target, groups, metadata, and
+            feature names.
+
+        Raises
+        ------
+        NotImplementedError
+            This public API is scaffolded only.
+        """
+        raise NotImplementedError("MAFeatureDataset.to_sklearn is not yet implemented.")
+
+    def split(
+        self,
+        test_size: float = 0.25,
+        random_state: int | None = None,
+        cv: Any = None,
+    ):
+        """Split the dataset into leakage-safe train and test partitions.
+
+        Parameters
+        ----------
+        test_size : float, default=0.25
+            Proportion of grouped data to assign to the test partition.
+        random_state : int or None, default=None
+            Seed used when the splitter is stochastic.
+        cv : object, default=None
+            Optional grouped cross-validation splitter.
+
+        Returns
+        -------
+        tuple of MAFeatureDataset
+            Train and test dataset slices.
+
+        Raises
+        ------
+        NotImplementedError
+            This public API is scaffolded only.
+        """
+        raise NotImplementedError("MAFeatureDataset.split is not yet implemented.")
+
+    def apply_map_reducer(self, reducer: Any, fit: bool = False):
+        """Apply a map-feature reducer and return a transformed dataset copy.
+
+        Parameters
+        ----------
+        reducer : object
+            Scikit-learn-compatible transformer or pipeline used to reduce map
+            features.
+        fit : bool, default=False
+            Whether the reducer should be fitted before transforming the map
+            features.
+
+        Returns
+        -------
+        MAFeatureDataset
+            Dataset copy with reduced map features.
+
+        Raises
+        ------
+        NotImplementedError
+            This public API is scaffolded only.
+        """
+        raise NotImplementedError("MAFeatureDataset.apply_map_reducer is not yet implemented.")
+
+    def get_feature_names(self):
+        """Return exported feature names in column order.
+
+        Returns
+        -------
+        list of str
+            Feature names aligned to the exported data matrix.
+
+        Raises
+        ------
+        NotImplementedError
+            This public API is scaffolded only.
+        """
+        raise NotImplementedError("MAFeatureDataset.get_feature_names is not yet implemented.")
+
+    def copy(self):
+        """Return an independent copy of the dataset.
+
+        Returns
+        -------
+        MAFeatureDataset
+            Independent dataset copy.
+
+        Raises
+        ------
+        NotImplementedError
+            This public API is scaffolded only.
+        """
+        raise NotImplementedError("MAFeatureDataset.copy is not yet implemented.")
 
 
 class MAFeatureExtractor(NiMAREBase):
-    """Placeholder for masked activation feature extraction."""
+    """Extract aligned map features and optional descriptors/targets from collections.
 
-    def __init__(self, *args: Any, **kwargs: Any):
-        raise NotImplementedError("MAFeatureExtractor is not yet implemented.")
+    Converts NiMARE Studyset into scikit-learn-compatible :class:`MAFeatureDataset`.
+    Handles kernel transformation, field resolution, and sample-group alignment.
+
+    Parameters
+    ----------
+    kernel_transformer : object
+        NiMARE kernel transformer (instance or class). Required; no implicit default.
+    descriptor_fields : list of dict, optional
+        Field selectors (source, field, kind) from metadata, annotations,
+        or texts, by default None.
+    descriptor_transformers : dict, optional
+        Transformers/vectorizers for non-numeric descriptor fields, by default None.
+        Without these, non-numeric fields are rejected.
+    target_field : dict, optional
+        Field selector for target variable (y), by default None.
+    target_transformer : object, optional
+        Transformer for free-text or multi-label targets, by default None.
+    missing : {'raise', 'drop'}, default='raise'
+        Strategy for missing values and field resolution failures,
+        by default 'raise'.
+    memory : object, optional
+        joblib Memory-like object for caching, by default None.
+    memory_level : int, default=1
+        Caching verbosity, by default 1.
+    """
+
+    def __init__(
+        self,
+        kernel_transformer: Any,
+        descriptor_fields: list[Any] | None = None,
+        descriptor_transformers: Any | None = None,
+        target_field: Any | None = None,
+        target_transformer: Any | None = None,
+        missing: str = "raise",
+        memory: Any | None = None,
+        memory_level: int = 1,
+    ):
+        self.kernel_transformer = kernel_transformer
+        self.descriptor_fields = descriptor_fields
+        self.descriptor_transformers = descriptor_transformers
+        self.target_field = target_field
+        self.target_transformer = target_transformer
+        self.missing = missing
+        self.memory = memory
+        self.memory_level = memory_level
+
+    def fit(self, collection: Any):
+        """Validate a collection and record the feature schema.
+
+        Parameters
+        ----------
+        collection : object
+            NiMARE Studyset input.
+
+        Returns
+        -------
+        MAFeatureExtractor
+            Fitted extractor instance.
+
+        Raises
+        ------
+        NotImplementedError
+            This public API is scaffolded only.
+        """
+        raise NotImplementedError("MAFeatureExtractor.fit is not yet implemented.")
+
+    def transform(self, collection: Any):
+        """Transform a collection into an :class:`MAFeatureDataset`.
+
+        Parameters
+        ----------
+        collection : object
+            NiMARE Studyset input.
+
+        Returns
+        -------
+        MAFeatureDataset
+            Feature dataset created from the fitted schema.
+
+        Raises
+        ------
+        NotImplementedError
+            This public API is scaffolded only.
+        """
+        raise NotImplementedError("MAFeatureExtractor.transform is not yet implemented.")
+
+    def fit_transform(self, collection: Any):
+        """Fit the extractor and transform the collection in one call.
+
+        Parameters
+        ----------
+        collection : object
+            NiMARE Studyset input.
+
+        Returns
+        -------
+        MAFeatureDataset
+            Feature dataset created from the fitted schema.
+
+        Raises
+        ------
+        NotImplementedError
+            This public API is scaffolded only.
+        """
+        raise NotImplementedError("MAFeatureExtractor.fit_transform is not yet implemented.")
 
 
-def make_map_reducer(*args: Any, **kwargs: Any):
-    """Construct a map reducer placeholder."""
+def make_map_reducer(method: str, **kwargs: Any):
+    """Construct a map-feature reducer.
+
+    Parameters
+    ----------
+    method : str
+        Reduction workflow name.
+    **kwargs : dict
+        Additional reducer-specific keyword arguments.
+
+    Returns
+    -------
+    object
+        Scikit-learn-compatible transformer or pipeline.
+
+    Raises
+    ------
+    NotImplementedError
+        This public API is scaffolded only.
+    """
     raise NotImplementedError("make_map_reducer is not yet implemented.")

--- a/nimare/tests/test_ml.py
+++ b/nimare/tests/test_ml.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import numpy as np
+import pandas as pd
 import pytest
 
 from nimare.ml import MAFeatureDataset, MAFeatureExtractor, make_map_reducer
@@ -77,18 +79,182 @@ def test_studyset_builder_and_ambiguous_short_ids():
 
 
 def test_ma_feature_dataset_initialization():
-    """Test that MAFeatureDataset currently raises NotImplementedError."""
+    """Test that MAFeatureDataset initializes and stores documented attributes."""
+    map_features = np.array([[1.0, 2.0], [3.0, 4.0]])
+    sample_ids = ["s1", "s2"]
+    study_ids = ["study_a", "study_b"]
+    sample_metadata = pd.DataFrame({"sample_id": sample_ids, "study_id": study_ids})
+    masker = object()
+
+    ds = MAFeatureDataset(
+        map_features=map_features,
+        sample_ids=sample_ids,
+        study_ids=study_ids,
+        sample_metadata=sample_metadata,
+        masker=masker,
+    )
+
+    assert (ds.map_features == map_features).all()
+    assert ds.sample_ids == sample_ids
+    assert ds.study_ids == study_ids
+    assert ds.sample_metadata is sample_metadata
+    assert ds.masker is masker
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        (
+            {
+                "sample_ids": ["s1"],
+                "study_ids": ["study_a", "study_b"],
+                "sample_metadata": [{}, {}],
+            },
+            "sample_ids length must match number of rows in map_features",
+        ),
+        (
+            {
+                "sample_ids": ["s1", "s2"],
+                "study_ids": ["study_a"],
+                "sample_metadata": [{}, {}],
+            },
+            "study_ids length must match number of rows in map_features",
+        ),
+        (
+            {
+                "sample_ids": ["s1", "s2"],
+                "study_ids": ["study_a", "study_b"],
+                "sample_metadata": [{}],
+            },
+            "sample_metadata length must match number of rows in map_features",
+        ),
+        (
+            {
+                "sample_ids": ["s1", "s2"],
+                "study_ids": ["study_a", "study_b"],
+                "sample_metadata": [{}, {}],
+                "descriptor_features": [[0.1], [0.2], [0.3]],
+            },
+            "descriptor_features length must match number of rows in map_features",
+        ),
+        (
+            {
+                "sample_ids": ["s1", "s2"],
+                "study_ids": ["study_a", "study_b"],
+                "sample_metadata": [{}, {}],
+                "target": [1],
+            },
+            "target length must match number of rows in map_features",
+        ),
+        (
+            {
+                "sample_ids": ["s1", "s2"],
+                "study_ids": ["study_a", "study_b"],
+                "sample_metadata": [{}, {}],
+                "feature_names": ["f1"],
+            },
+            "feature_names length must match number of columns in map_features",
+        ),
+    ],
+)
+def test_ma_feature_dataset_initialization_length_mismatches(kwargs, message):
+    """Test each validation branch in MAFeatureDataset initialization."""
+    base_kwargs = {
+        "map_features": np.array([[1.0, 2.0], [3.0, 4.0]]),
+        "sample_ids": ["s1", "s2"],
+        "study_ids": ["study_a", "study_b"],
+        "sample_metadata": [{}, {}],
+        "masker": object(),
+    }
+
+    base_kwargs.update(kwargs)
+
+    with pytest.raises(ValueError, match=message):
+        MAFeatureDataset(**base_kwargs)
+
+
+def test_ma_feature_dataset_initialization_map_features_shape_undetermined():
+    """Test the fallback error when map_features has no usable size information."""
+
+    class UnknownShape:
+        def __len__(self):
+            raise TypeError("no length")
+
+    with pytest.raises(
+        ValueError,
+        match="Unable to determine number of samples or features from map_features",
+    ):
+        MAFeatureDataset(
+            map_features=UnknownShape(),
+            sample_ids=[],
+            study_ids=[],
+            sample_metadata=[],
+            masker=object(),
+        )
+
+
+def test_ma_feature_dataset_methods_raise_not_implemented():
+    """Dataset instance methods are scaffolded and should raise NotImplementedError."""
+    map_features = np.array([[1.0, 2.0], [3.0, 4.0]])
+    sample_ids = ["s1", "s2"]
+    study_ids = ["study_a", "study_b"]
+    sample_metadata = [{}, {}]
+    masker = object()
+
+    ds = MAFeatureDataset(
+        map_features=map_features,
+        sample_ids=sample_ids,
+        study_ids=study_ids,
+        sample_metadata=sample_metadata,
+        masker=masker,
+    )
+
     with pytest.raises(NotImplementedError):
-        MAFeatureDataset()
+        ds.to_sklearn()
+
+    with pytest.raises(NotImplementedError):
+        ds.split()
+
+    with pytest.raises(NotImplementedError):
+        ds.apply_map_reducer(object())
+
+    with pytest.raises(NotImplementedError):
+        ds.get_feature_names()
+
+    with pytest.raises(NotImplementedError):
+        ds.copy()
 
 
 def test_ma_feature_extractor_initialization():
-    """Test that MAFeatureExtractor currently raises NotImplementedError."""
+    """Test that MAFeatureExtractor initializes and stores documented parameters."""
+    kernel_transformer = object()
+    extractor = MAFeatureExtractor(
+        kernel_transformer=kernel_transformer,
+        descriptor_fields=[{"source": "metadata", "field": "sample_sizes"}],
+        target_field={"source": "annotations", "field": "alpha_label"},
+    )
+
+    assert extractor.kernel_transformer is kernel_transformer
+    assert extractor.descriptor_fields == [{"source": "metadata", "field": "sample_sizes"}]
+    assert extractor.target_field == {"source": "annotations", "field": "alpha_label"}
+    assert extractor.missing == "raise"
+
+
+def test_ma_feature_extractor_methods_raise_not_implemented():
+    """Test that MAFeatureExtractor methods currently raise NotImplementedError."""
+    extractor = MAFeatureExtractor(kernel_transformer=object())
+
     with pytest.raises(NotImplementedError):
-        MAFeatureExtractor()
+        extractor.fit(build_studyset())
+
+    with pytest.raises(NotImplementedError):
+        extractor.transform(build_studyset())
+
+    with pytest.raises(NotImplementedError):
+        extractor.fit_transform(build_studyset())
 
 
 def test_make_map_reducer_placeholder():
     """Test that make_map_reducer currently raises NotImplementedError."""
     with pytest.raises(NotImplementedError):
-        make_map_reducer()
+        make_map_reducer("variance_threshold")

--- a/nimare/tests/test_ml.py
+++ b/nimare/tests/test_ml.py
@@ -205,7 +205,13 @@ def test_ma_feature_dataset_methods_raise_not_implemented():
         ds.to_sklearn()
 
     with pytest.raises(NotImplementedError):
+        ds._split_by_groups()
+
+    with pytest.raises(NotImplementedError):
         ds.split()
+
+    with pytest.raises(NotImplementedError):
+        ds._apply_map_reducer(object())
 
     with pytest.raises(NotImplementedError):
         ds.apply_map_reducer(object())
@@ -235,6 +241,13 @@ def test_ma_feature_extractor_initialization():
 def test_ma_feature_extractor_methods_raise_not_implemented():
     """Test that MAFeatureExtractor methods currently raise NotImplementedError."""
     extractor = MAFeatureExtractor(kernel_transformer=object())
+
+    with pytest.raises(NotImplementedError):
+        extractor._get_studyset_tables(build_studyset())
+
+    with pytest.raises(NotImplementedError):
+        extractor._stack_sparse_features(sparse.csr_matrix([[1.0, 0.0]]))
+
     with pytest.raises(NotImplementedError):
         extractor.transform(build_studyset())
 

--- a/nimare/tests/test_ml.py
+++ b/nimare/tests/test_ml.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 from scipy import sparse
@@ -73,7 +75,7 @@ def assert_sklearn_bunch_valid(
     expected_feature_rows: int,
     expected_feature_columns: int,
     expected_groups: list[str] | None = None,
-    expected_target: list[int] | None = None,
+    expected_target: list[Any] | None = None,
 ):
     """Assert the shared sklearn-export contract for MA feature bundles."""
     assert isinstance(bunch, Bunch)

--- a/nimare/tests/test_ml.py
+++ b/nimare/tests/test_ml.py
@@ -3,23 +3,27 @@
 from __future__ import annotations
 
 import numpy as np
-import pandas as pd
 import pytest
+from scipy import sparse
+from sklearn.linear_model import LogisticRegression
+from sklearn.utils import Bunch
 
 from nimare.ml import MAFeatureDataset, MAFeatureExtractor, make_map_reducer
 from nimare.nimads import Studyset
+from nimare.utils import get_masker, get_template
 
 
 def _build_studyset_ml_source():
-    """Create one canonical source dict for Studyset/NIMADS builder.
+    """Build the Studyset fixture used by the ML tests.
 
-    The two studies intentionally reuse the same contrast ID (``task``) so that
-    short analysis IDs are ambiguous and must be resolved via the full
-    ``<study_id>-<contrast_id>`` identifier.
+    This source intentionally includes a masker, valid MNI coordinates,
+    numeric metadata, numeric annotations, text fields, unique study IDs, and
+    unique full analysis IDs.
     """
     return {
         "id": "studyset_ml_source",
         "name": "Studyset ML source",
+        "masker": get_masker(get_template(space="mni152_2mm", mask="brain")),
         "studies": [
             {
                 "id": "study_alpha",
@@ -60,45 +64,58 @@ def _build_studyset_ml_source():
 
 def build_studyset():
     """Build a fresh Studyset from the studyset ML source dict."""
-    return Studyset(_build_studyset_ml_source())
+    source = _build_studyset_ml_source()
+    return Studyset(source, mask=source["masker"])
 
 
-def test_studyset_builder_and_ambiguous_short_ids():
-    """The Studyset builder should preserve full IDs and expose ambiguity."""
-    studyset = build_studyset()
+def assert_sklearn_bunch_valid(
+    bunch,
+    expected_feature_rows: int,
+    expected_feature_columns: int,
+    expected_groups: list[str] | None = None,
+    expected_target: list[int] | None = None,
+):
+    """Assert the shared sklearn-export contract for MA feature bundles."""
+    assert isinstance(bunch, Bunch)
+    assert bunch.data.shape == (expected_feature_rows, expected_feature_columns)
+    assert sparse.issparse(bunch.data)
+    assert len(bunch.groups) == expected_feature_rows
+    assert len(bunch.target) == expected_feature_rows
 
-    assert isinstance(studyset, Studyset)
-    assert studyset.ids.tolist() == ["study_alpha-task", "study_beta-task"]
-    assert studyset.study_ids.tolist() == ["study_alpha", "study_beta"]
-    assert list(studyset.coordinates["id"].unique()) == ["study_alpha-task", "study_beta-task"]
-    assert studyset.filter_ids("task").ids.tolist() == ["study_alpha-task", "study_beta-task"]
-    assert "abstract" in studyset.texts.columns
-    assert "sample_sizes" in studyset.metadata.columns
-    assert "alpha_label" in studyset.annotations_df.columns
-    assert "beta_label" in studyset.annotations_df.columns
+    if expected_groups is not None:
+        np.testing.assert_array_equal(bunch.groups, expected_groups)
+
+    if expected_target is not None:
+        np.testing.assert_array_equal(bunch.target, expected_target)
+
+    estimator = LogisticRegression(max_iter=1000, solver="liblinear")
+    estimator.fit(bunch.data, bunch.target)
 
 
 def test_ma_feature_dataset_initialization():
     """Test that MAFeatureDataset initializes and stores documented attributes."""
-    map_features = np.array([[1.0, 2.0], [3.0, 4.0]])
-    sample_ids = ["s1", "s2"]
+    features = np.array([[1.0, 2.0], [3.0, 4.0]])
+    ids = ["study_a-task", "study_b-task"]
     study_ids = ["study_a", "study_b"]
-    sample_metadata = pd.DataFrame({"sample_id": sample_ids, "study_id": study_ids})
-    masker = object()
+    feature_names = ["feature_1", "feature_2"]
+    target = [0, 1]
+    provenance = {"source": "unit-test"}
 
     ds = MAFeatureDataset(
-        map_features=map_features,
-        sample_ids=sample_ids,
+        features=features,
+        ids=ids,
         study_ids=study_ids,
-        sample_metadata=sample_metadata,
-        masker=masker,
+        feature_names=feature_names,
+        target=target,
+        provenance=provenance,
     )
 
-    assert (ds.map_features == map_features).all()
-    assert ds.sample_ids == sample_ids
+    assert (ds.features == features).all()
+    assert ds.ids == ids
     assert ds.study_ids == study_ids
-    assert ds.sample_metadata is sample_metadata
-    assert ds.masker is masker
+    assert ds.feature_names == feature_names
+    assert ds.target == target
+    assert ds.provenance is provenance
 
 
 @pytest.mark.parametrize(
@@ -106,65 +123,46 @@ def test_ma_feature_dataset_initialization():
     [
         (
             {
-                "sample_ids": ["s1"],
+                "ids": ["s1"],
                 "study_ids": ["study_a", "study_b"],
-                "sample_metadata": [{}, {}],
+                "feature_names": ["f1", "f2"],
             },
-            "sample_ids length must match number of rows in map_features",
+            "ids length must match number of rows in features",
         ),
         (
             {
-                "sample_ids": ["s1", "s2"],
+                "ids": ["s1", "s2"],
                 "study_ids": ["study_a"],
-                "sample_metadata": [{}, {}],
+                "feature_names": ["f1", "f2"],
             },
-            "study_ids length must match number of rows in map_features",
+            "study_ids length must match number of rows in features",
         ),
         (
             {
-                "sample_ids": ["s1", "s2"],
+                "ids": ["s1", "s2"],
                 "study_ids": ["study_a", "study_b"],
-                "sample_metadata": [{}],
-            },
-            "sample_metadata length must match number of rows in map_features",
-        ),
-        (
-            {
-                "sample_ids": ["s1", "s2"],
-                "study_ids": ["study_a", "study_b"],
-                "sample_metadata": [{}, {}],
-                "descriptor_features": [[0.1], [0.2], [0.3]],
-            },
-            "descriptor_features length must match number of rows in map_features",
-        ),
-        (
-            {
-                "sample_ids": ["s1", "s2"],
-                "study_ids": ["study_a", "study_b"],
-                "sample_metadata": [{}, {}],
+                "feature_names": ["f1", "f2"],
                 "target": [1],
             },
-            "target length must match number of rows in map_features",
+            "target length must match number of rows in features",
         ),
         (
             {
-                "sample_ids": ["s1", "s2"],
+                "ids": ["s1", "s2"],
                 "study_ids": ["study_a", "study_b"],
-                "sample_metadata": [{}, {}],
                 "feature_names": ["f1"],
             },
-            "feature_names length must match number of columns in map_features",
+            "feature_names length must match number of columns in features",
         ),
     ],
 )
 def test_ma_feature_dataset_initialization_length_mismatches(kwargs, message):
     """Test each validation branch in MAFeatureDataset initialization."""
     base_kwargs = {
-        "map_features": np.array([[1.0, 2.0], [3.0, 4.0]]),
-        "sample_ids": ["s1", "s2"],
+        "features": np.array([[1.0, 2.0], [3.0, 4.0]]),
+        "ids": ["s1", "s2"],
         "study_ids": ["study_a", "study_b"],
-        "sample_metadata": [{}, {}],
-        "masker": object(),
+        "feature_names": ["f1", "f2"],
     }
 
     base_kwargs.update(kwargs)
@@ -173,8 +171,8 @@ def test_ma_feature_dataset_initialization_length_mismatches(kwargs, message):
         MAFeatureDataset(**base_kwargs)
 
 
-def test_ma_feature_dataset_initialization_map_features_shape_undetermined():
-    """Test the fallback error when map_features has no usable size information."""
+def test_ma_feature_dataset_initialization_features_shape_undetermined():
+    """Test the fallback error when features has no usable size information."""
 
     class UnknownShape:
         def __len__(self):
@@ -182,31 +180,25 @@ def test_ma_feature_dataset_initialization_map_features_shape_undetermined():
 
     with pytest.raises(
         ValueError,
-        match="Unable to determine number of samples or features from map_features",
+        match="Unable to determine number of rows or columns from features",
     ):
         MAFeatureDataset(
-            map_features=UnknownShape(),
-            sample_ids=[],
+            features=UnknownShape(),
+            ids=[],
             study_ids=[],
-            sample_metadata=[],
-            masker=object(),
         )
 
 
 def test_ma_feature_dataset_methods_raise_not_implemented():
     """Dataset instance methods are scaffolded and should raise NotImplementedError."""
-    map_features = np.array([[1.0, 2.0], [3.0, 4.0]])
-    sample_ids = ["s1", "s2"]
+    features = np.array([[1.0, 2.0], [3.0, 4.0]])
+    ids = ["s1", "s2"]
     study_ids = ["study_a", "study_b"]
-    sample_metadata = [{}, {}]
-    masker = object()
 
     ds = MAFeatureDataset(
-        map_features=map_features,
-        sample_ids=sample_ids,
+        features=features,
+        ids=ids,
         study_ids=study_ids,
-        sample_metadata=sample_metadata,
-        masker=masker,
     )
 
     with pytest.raises(NotImplementedError):
@@ -217,9 +209,6 @@ def test_ma_feature_dataset_methods_raise_not_implemented():
 
     with pytest.raises(NotImplementedError):
         ds.apply_map_reducer(object())
-
-    with pytest.raises(NotImplementedError):
-        ds.get_feature_names()
 
     with pytest.raises(NotImplementedError):
         ds.copy()
@@ -237,21 +226,20 @@ def test_ma_feature_extractor_initialization():
     assert extractor.kernel_transformer is kernel_transformer
     assert extractor.descriptor_fields == [{"source": "metadata", "field": "sample_sizes"}]
     assert extractor.target_field == {"source": "annotations", "field": "alpha_label"}
-    assert extractor.missing == "raise"
+    assert extractor.missing_coordinates == "drop"
+    assert extractor.test_size is None
+    assert extractor.random_state is None
+    assert extractor.cache_maps is True
 
 
 def test_ma_feature_extractor_methods_raise_not_implemented():
     """Test that MAFeatureExtractor methods currently raise NotImplementedError."""
     extractor = MAFeatureExtractor(kernel_transformer=object())
-
-    with pytest.raises(NotImplementedError):
-        extractor.fit(build_studyset())
-
     with pytest.raises(NotImplementedError):
         extractor.transform(build_studyset())
 
     with pytest.raises(NotImplementedError):
-        extractor.fit_transform(build_studyset())
+        extractor.to_sklearn(build_studyset())
 
 
 def test_make_map_reducer_placeholder():


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #1016 #1017 (T006 T007 T008 T009).

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Add public API skeletons
- Export nimare/ml module
- Add shared assertions and internel helper placeholders

## Summary by Sourcery

Introduce initial public machine learning API scaffolding and export the ml module at the package level.

New Features:
- Add MAFeatureDataset container class for aligned map features, metadata, targets, and provenance.
- Add MAFeatureExtractor interface for converting NiMARE study collections into MAFeatureDataset objects.
- Add make_map_reducer factory function for constructing map-feature reduction workflows.

Enhancements:
- Export the ml submodule from the top-level nimare package namespace.

Tests:
- Add unit tests covering MAFeatureDataset initialization, validation, and placeholder methods.
- Add unit tests covering MAFeatureExtractor initialization and placeholder methods.
- Update tests for make_map_reducer to use a named reduction method argument.