### PR TITLE
Document the label_threshold parameter in get_studies_by_label

### DIFF
--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -668,7 +668,12 @@ class Dataset(NiMAREBase):
             the labels above the threshold, it will be returned.
             Default is None.
         label_threshold : :obj:`float`, optional
-            Default is 0.5.
+            Minimum value a study must reach for *every* requested label to be included.
+            For Neurosynth-style annotations these are tf-idf (term frequency-inverse
+            document frequency) weights: a higher value means the label/term is more
+            important to that study's text relative to the rest of the corpus. Because
+            tf-idf is corpus-relative, the threshold is only meaningful within the corpus
+            the annotations were derived from. Default is 0.001.
 
         Returns
         -------


### PR DESCRIPTION
The `label_threshold` parameter of `Dataset.get_studies_by_label` was documented only as "Default is 0.5.", which is both wrong (the default is `0.001`) and unexplained.

This rewrites the entry to state the correct default and explain the threshold: a study is included when its annotation value for every requested label is `>= label_threshold`, and for Neurosynth-style annotations those values are tf-idf weights (higher = the term is more important to that study's text relative to the corpus), so the threshold is only interpretable within the corpus the annotations were derived from. (Per the discussion in the issue.)

Docstring-only; no behavior change. `flake8 nimare/dataset.py` passes.

Closes #950

## Summary by Sourcery

Documentation:
- Expand the documentation of Dataset.get_studies_by_label.label_threshold to describe its inclusion criteria, tf-idf semantics for Neurosynth-style annotations, and correct the documented default value to 0.001.