### PR TITLE
Raise an informative error when a fetch query matches no files

### DIFF
--- a/nimare/extract/extract.py
+++ b/nimare/extract/extract.py
@@ -57,6 +57,42 @@ def _find_entities(filename, search_pairs, log=False):
     return False
 
 
+def _get_available_entities(database_file_manifest, data=None):
+    """Collect the searchable entity values present in the database manifest.
+
+    Parameters
+    ----------
+    database_file_manifest : :obj:`list` of :obj:`dict`
+        Parsed ``database_file_manifest.json``; each entry has a ``"features"``
+        list of dictionaries with a ``"features"`` filename.
+    data : :obj:`str` or None, optional
+        If provided, restrict results to feature files for this data source
+        (e.g. ``"neurosynth"``). Default is None (all sources).
+
+    Returns
+    -------
+    :obj:`dict`
+        Mapping of each searchable entity (``"version"``, ``"vocab"``,
+        ``"source"``, ``"type"``) to a sorted list of its distinct values
+        across the matching feature files. Entities with no values are omitted.
+    """
+    searchable = ["version", "vocab", "source", "type"]
+    values = {key: set() for key in searchable}
+    for database in database_file_manifest:
+        for feature_dict in database.get("features", []):
+            entities = {}
+            for part in feature_dict.get("features", "").split("_"):
+                if "-" in part:
+                    key, _, value = part.partition("-")
+                    entities[key] = value
+            if data is not None and entities.get("data") != data:
+                continue
+            for key in searchable:
+                if key in entities:
+                    values[key].add(entities[key])
+    return {key: sorted(vals) for key, vals in values.items() if vals}
+
+
 def _fetch_database(search_pairs, database_url, out_dir, overwrite=False):
     """Fetch generic database."""
     res_dir = get_resource_path()
@@ -107,6 +143,14 @@ def _fetch_database(search_pairs, database_url, out_dir, overwrite=False):
                         }
                     )
                 found_files += [coordinates_file, metadata_file, *feature_dict.values()]
+
+    if not found_databases:
+        available = _get_available_entities(database_file_manifest, data=search_pairs.get("data"))
+        options = "; ".join(f"{key}: {', '.join(vals)}" for key, vals in available.items())
+        raise ValueError(
+            f"No files matched the query {search_pairs}. "
+            f"Available options for data-{search_pairs.get('data')} are: {options}."
+        )
 
     found_files = sorted(list(set(found_files)))
     for found_file in found_files:

--- a/nimare/extract/extract.py
+++ b/nimare/extract/extract.py
@@ -57,8 +57,20 @@ def _find_entities(filename, search_pairs, log=False):
     return False
 
 
+# Entity keys that may appear in a database feature filename, e.g.
+# "data-neurosynth_version-7_vocab-terms_source-abstract_type-tfidf_features.npz".
+# Only these keys are recognized when parsing, so an unexpected filename segment
+# cannot silently produce an incorrect entity mapping.
+_SEARCHABLE_ENTITIES = ("version", "vocab", "source", "type")
+_KNOWN_ENTITIES = ("data", *_SEARCHABLE_ENTITIES)
+
+
 def _get_available_entities(database_file_manifest, data=None):
     """Collect the searchable entity values present in the database manifest.
+
+    Only the known entity keys (``data`` plus the searchable ``version``/``vocab``/
+    ``source``/``type``) are parsed from each feature filename; any other ``key-value``
+    segment is ignored, so filename changes cannot silently mismap entities.
 
     Parameters
     ----------
@@ -76,18 +88,17 @@ def _get_available_entities(database_file_manifest, data=None):
         ``"source"``, ``"type"``) to a sorted list of its distinct values
         across the matching feature files. Entities with no values are omitted.
     """
-    searchable = ["version", "vocab", "source", "type"]
-    values = {key: set() for key in searchable}
+    values = {key: set() for key in _SEARCHABLE_ENTITIES}
     for database in database_file_manifest:
         for feature_dict in database.get("features", []):
             entities = {}
             for part in feature_dict.get("features", "").split("_"):
-                if "-" in part:
-                    key, _, value = part.partition("-")
+                key, sep, value = part.partition("-")
+                if sep and key in _KNOWN_ENTITIES:
                     entities[key] = value
             if data is not None and entities.get("data") != data:
                 continue
-            for key in searchable:
+            for key in _SEARCHABLE_ENTITIES:
                 if key in entities:
                     values[key].add(entities[key])
     return {key: sorted(vals) for key, vals in values.items() if vals}
@@ -145,12 +156,18 @@ def _fetch_database(search_pairs, database_url, out_dir, overwrite=False):
                 found_files += [coordinates_file, metadata_file, *feature_dict.values()]
 
     if not found_databases:
-        available = _get_available_entities(database_file_manifest, data=search_pairs.get("data"))
-        options = "; ".join(f"{key}: {', '.join(vals)}" for key, vals in available.items())
-        raise ValueError(
-            f"No files matched the query {search_pairs}. "
-            f"Available options for data-{search_pairs.get('data')} are: {options}."
-        )
+        data_value = search_pairs.get("data")
+        available = _get_available_entities(database_file_manifest, data=data_value)
+        scope = f"data-{data_value}" if data_value else "the requested database"
+        if available:
+            options = "; ".join(f"{key}: {', '.join(vals)}" for key, vals in available.items())
+            detail = f" Available options for {scope} are: {options}."
+        else:
+            detail = (
+                f" No matching entries were found for {scope}; "
+                "see the database file manifest for valid patterns."
+            )
+        raise ValueError(f"No files matched the query {search_pairs}.{detail}")
 
     found_files = sorted(list(set(found_files)))
     for found_file in found_files:

--- a/nimare/tests/test_extract.py
+++ b/nimare/tests/test_extract.py
@@ -7,8 +7,12 @@ from glob import glob
 from io import BytesIO
 from unittest.mock import patch
 
+import pytest
+
 import nimare
+import nimare.extract
 from nimare.dataset import Dataset
+from nimare.extract.extract import _get_available_entities
 from nimare.generate import create_coordinate_studyset
 from nimare.nimads import Studyset
 from nimare.tests.utils import get_test_data_path
@@ -170,6 +174,68 @@ def test_fetch_neuroquery_returns_studyset_by_default(monkeypatch, tmp_path_fact
     assert isinstance(outputs, list)
     assert len(outputs) == 1
     assert isinstance(outputs[0], Studyset)
+
+
+def test_get_available_entities_lists_distinct_values():
+    """_get_available_entities returns sorted, source-scoped distinct entity values."""
+    manifest = [
+        {
+            "coordinates": "data-neurosynth_version-7_coordinates.tsv.gz",
+            "metadata": "data-neurosynth_version-7_metadata.tsv.gz",
+            "features": [
+                {
+                    "features": (
+                        "data-neurosynth_version-7_vocab-terms_"
+                        "source-abstract_type-tfidf_features.npz"
+                    )
+                },
+                {
+                    "features": (
+                        "data-neurosynth_version-7_vocab-LDA200_"
+                        "source-abstract_type-weight_features.npz"
+                    )
+                },
+            ],
+        },
+        {
+            "coordinates": "data-neuroquery_version-1_coordinates.tsv.gz",
+            "metadata": "data-neuroquery_version-1_metadata.tsv.gz",
+            "features": [
+                {
+                    "features": (
+                        "data-neuroquery_version-1_vocab-neuroquery6308_"
+                        "source-combined_type-tfidf_features.npz"
+                    )
+                },
+            ],
+        },
+    ]
+    ns = _get_available_entities(manifest, data="neurosynth")
+    assert ns["version"] == ["7"]
+    assert ns["vocab"] == ["LDA200", "terms"]
+    assert ns["source"] == ["abstract"]
+    assert ns["type"] == ["tfidf", "weight"]
+    assert "neuroquery6308" not in ns["vocab"]  # other source must not leak in
+
+    allsrc = _get_available_entities(manifest)
+    assert allsrc["version"] == ["1", "7"]
+    assert "neuroquery6308" in allsrc["vocab"]
+
+
+def test_fetch_neurosynth_raises_on_unmatched_query(tmp_path):
+    """An unmatched query raises an informative ValueError before any download."""
+    with pytest.raises(ValueError) as excinfo:
+        nimare.extract.fetch_neurosynth(data_dir=str(tmp_path), vocab="not_a_real_vocab")
+    msg = str(excinfo.value)
+    assert "No files matched the query" in msg
+    assert "terms" in msg  # an available neurosynth vocab is surfaced
+
+
+def test_fetch_neuroquery_raises_on_unmatched_query(tmp_path):
+    """fetch_neuroquery raises the same informative error on an unmatched query."""
+    with pytest.raises(ValueError) as excinfo:
+        nimare.extract.fetch_neuroquery(data_dir=str(tmp_path), vocab="not_a_real_vocab")
+    assert "No files matched the query" in str(excinfo.value)
 
 
 def test_download_abstracts_accepts_studyset(monkeypatch):

--- a/nimare/tests/test_extract.py
+++ b/nimare/tests/test_extract.py
@@ -12,7 +12,7 @@ import pytest
 import nimare
 import nimare.extract
 from nimare.dataset import Dataset
-from nimare.extract.extract import _get_available_entities
+from nimare.extract.extract import _fetch_database, _get_available_entities
 from nimare.generate import create_coordinate_studyset
 from nimare.nimads import Studyset
 from nimare.tests.utils import get_test_data_path
@@ -236,6 +236,45 @@ def test_fetch_neuroquery_raises_on_unmatched_query(tmp_path):
     with pytest.raises(ValueError) as excinfo:
         nimare.extract.fetch_neuroquery(data_dir=str(tmp_path), vocab="not_a_real_vocab")
     assert "No files matched the query" in str(excinfo.value)
+
+
+def test_get_available_entities_ignores_unknown_segments():
+    """Unknown key-value segments are ignored, and known entities still parse correctly."""
+    manifest = [
+        {
+            "features": [
+                {
+                    "features": (
+                        "data-neurosynth_version-7_vocab-terms_source-abstract_"
+                        "type-tfidf_garbage-xyz_features.npz"
+                    )
+                },
+            ],
+        },
+    ]
+    out = _get_available_entities(manifest, data="neurosynth")
+    assert out["vocab"] == ["terms"]
+    assert out["version"] == ["7"]
+    assert "garbage" not in out  # unrecognized key is never surfaced
+
+
+def test_fetch_database_message_omits_data_none(tmp_path):
+    """When the query has no 'data' key, the message uses a generic scope (no 'data-None')."""
+    with pytest.raises(ValueError) as excinfo:
+        _fetch_database({"version": "999"}, "http://example.com/", str(tmp_path))
+    msg = str(excinfo.value)
+    assert "No files matched the query" in msg
+    assert "data-None" not in msg
+    assert "the requested database" in msg
+
+
+def test_fetch_database_message_falls_back_when_no_entities(tmp_path):
+    """An unknown data source (no available entities) yields a generic fallback message."""
+    with pytest.raises(ValueError) as excinfo:
+        _fetch_database({"data": "not_a_database"}, "http://example.com/", str(tmp_path))
+    msg = str(excinfo.value)
+    assert "No matching entries were found" in msg
+    assert "see the database file manifest" in msg
 
 
 def test_download_abstracts_accepts_studyset(monkeypatch):


### PR DESCRIPTION
`fetch_neurosynth`/`fetch_neuroquery` passed an unmatched query straight through `_fetch_database`, which returned an empty list and silently yielded no data — so a typo'd `source`/`vocab`/`type` looked like an empty result with no hint.

This raises an informative `ValueError` when a query matches no files in the bundled manifest, listing the available values per entity (version/vocab/source/type) for the requested data source. The match happens before any download, so the error is immediate. Adds a small pure helper (`_get_available_entities`) with unit tests, plus offline tests that the fetch functions raise.

Closes #640

### Before / after
```python
>>> nimare.extract.fetch_neurosynth(vocab="not_a_real_vocab", return_type="files")
```
Before:
```
[]        # silent empty result, no hint
```
After:
```
ValueError: No files matched the query {'vocab': 'not_a_real_vocab', 'data': 'neurosynth', 'version': '7'}.
Available options for data-neurosynth are: version: 3, 4, 5, 6, 7;
vocab: LDA100, LDA200, LDA400, LDA50, terms; source: abstract; type: tfidf, weight.
```

## Summary by Sourcery

Fail fast with actionable guidance when database fetch queries do not match any bundled files.

Bug Fixes:
- Raise an informative ValueError when a fetch query matches no files, including available entity values for the requested data source.

Enhancements:
- Add manifest-based entity discovery with source-scoped, sorted options and safe handling of unknown filename segments.

Tests:
- Add unit and offline fetch tests covering entity discovery, informative unmatched-query errors, and fallback messages.