### PR TITLE
[ENH] Report an uncorrected p map from PermutedOLS

### DIFF
--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -1554,9 +1554,7 @@ class PermutedOLS(IBMAEstimator):
         * Nilearn's :func:`~nilearn.mass_univariate.permuted_ols` is no longer called, so
           exchangeability blocks work on every supported Nilearn version. The ``t`` map is
           unchanged.
-        * New output: an uncorrected ``p`` map, which makes
-          :class:`~nimare.correct.FDRCorrector` and Bonferroni correction usable here as they
-          already were for every other estimator.
+        * New output: an uncorrected ``p`` map
 
     .. versionchanged:: 0.2.1
 
@@ -1712,11 +1710,6 @@ class PermutedOLS(IBMAEstimator):
         t_map = result["t"].squeeze()
         dof = result["dof"]
         z_map = t_to_z(t_map, dof)
-
-        # A Corrector reads "p", and FDR and Bonferroni have nothing to work from without
-        # it. Derived from the z map rather than from t directly, which is how the rest of
-        # NiMARE converts and keeps the two maps in exact agreement. The tail is the one the
-        # permutation test and the corrected map already use.
         p_map = z_to_p(z_map, tail="two" if self.two_sided else "one")
 
         return t_map, z_map, p_map, np.full(n_voxels, dof, dtype=float)
@@ -1776,11 +1769,6 @@ class PermutedOLS(IBMAEstimator):
             raise ValueError("n_iters must be a positive integer.")
         n_cores = _check_ncores(n_cores)
 
-        # One column per dataset-wide exchangeability block. Every bag draws its signs from
-        # this one matrix, so a block that appears in two bags is flipped the same way in
-        # both and the null describes the whole brain rather than one bag of it. Sorted,
-        # because searchsorted below is what maps a bag's blocks onto these columns --
-        # DependenceModel.blocks guarantees the two label spaces are the same.
         global_labels = np.unique(self._dependence().blocks)
         rng = np.random.RandomState(self.random_state)
         global_sign_flips = rng.choice((-1.0, 1.0), size=(n_iters, global_labels.size))
@@ -1806,13 +1794,6 @@ class PermutedOLS(IBMAEstimator):
             )
             observed_z[voxel_mask] = bag_z
 
-            # Maximize over z, not t. Bags hold different numbers of images, so their t
-            # statistics carry different degrees of freedom and are not on a common scale:
-            # a two-image bag reached |t| = 130 on the example studyset, which is only
-            # z = 2.8, and maximizing over t let those 47 voxels set the threshold for the
-            # whole brain. z is pivotal, so the max over it means the same thing everywhere.
-            # t -> z is monotone at a fixed dof, and dof is constant within a bag, so the
-            # already-maximized per-bag values can be converted directly.
             bag_null = self.null_distributions_["values_level-voxel_corr-fwe_method-montecarlo"]
             np.maximum(h0_max_z, t_to_z(bag_null, bag_dof[0]), out=h0_max_z)
 

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -1604,7 +1604,7 @@ class PermutedOLS(IBMAEstimator):
     ============== ===============================================================================
     "t"            T-statistic map from one-sample test.
     "z"            Z-statistic map from one-sample test.
-    "p"            P-value map from one-sample test, referred to the t distribution.
+    "p"            P-value map from one-sample test.
     "dof"          Degrees of freedom map from one-sample test.
     ============== ===============================================================================
 

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -28,7 +28,7 @@ from nimare.estimator import Estimator
 from nimare.meta._dependence import DependenceModel, hashable_label
 from nimare.meta._permutation import _empirical_max_p, _permuted_ols
 from nimare.meta.utils import _liberal_mask_bags, _liberal_mask_values
-from nimare.transforms import d_to_g, p_to_z, t_to_d, t_to_z
+from nimare.transforms import d_to_g, p_to_z, t_to_d, t_to_z, z_to_p
 from nimare.utils import (
     _check_ncores,
     get_masker,
@@ -1554,6 +1554,9 @@ class PermutedOLS(IBMAEstimator):
         * Nilearn's :func:`~nilearn.mass_univariate.permuted_ols` is no longer called, so
           exchangeability blocks work on every supported Nilearn version. The ``t`` map is
           unchanged.
+        * New output: an uncorrected ``p`` map, which makes
+          :class:`~nimare.correct.FDRCorrector` and Bonferroni correction usable here as they
+          already were for every other estimator.
 
     .. versionchanged:: 0.2.1
 
@@ -1603,6 +1606,7 @@ class PermutedOLS(IBMAEstimator):
     ============== ===============================================================================
     "t"            T-statistic map from one-sample test.
     "z"            Z-statistic map from one-sample test.
+    "p"            P-value map from one-sample test, referred to the t distribution.
     "dof"          Degrees of freedom map from one-sample test.
     ============== ===============================================================================
 
@@ -1707,13 +1711,21 @@ class PermutedOLS(IBMAEstimator):
 
         t_map = result["t"].squeeze()
         dof = result["dof"]
-        return t_map, t_to_z(t_map, dof), np.full(n_voxels, dof, dtype=float)
+        z_map = t_to_z(t_map, dof)
+
+        # A Corrector reads "p", and FDR and Bonferroni have nothing to work from without
+        # it. Derived from the z map rather than from t directly, which is how the rest of
+        # NiMARE converts and keeps the two maps in exact agreement. The tail is the one the
+        # permutation test and the corrected map already use.
+        p_map = z_to_p(z_map, tail="two" if self.two_sided else "one")
+
+        return t_map, z_map, p_map, np.full(n_voxels, dof, dtype=float)
 
     def _fit(self, dataset):
         self.dataset = dataset
         self._resolve_masker(dataset)
 
-        maps = self._fit_over_bags(["beta_maps"], ["t", "z", "dof"])
+        maps = self._fit_over_bags(["beta_maps"], ["t", "z", "p", "dof"])
         return maps, {}, self._description_text()
 
     def correct_fwe_montecarlo(self, result, n_iters=5000, n_cores=1):
@@ -1785,7 +1797,7 @@ class PermutedOLS(IBMAEstimator):
             # group_order is by first occurrence, which is the column order _permuted_ols
             # expects; map those onto the shared matrix's sorted columns.
             local_indices = np.searchsorted(global_labels, dependence.group_order)
-            _, bag_z, bag_dof = self._fit_model(
+            _, bag_z, _, bag_dof = self._fit_model(
                 values,
                 study_mask=study_mask,
                 n_perm=n_iters,

--- a/nimare/tests/test_meta_ibma_dependence.py
+++ b/nimare/tests/test_meta_ibma_dependence.py
@@ -11,6 +11,7 @@ from nimare.meta import ibma
 from nimare.meta._dependence import DependenceModel
 from nimare.meta._permutation import _permuted_ols
 from nimare.meta.utils import _apply_liberal_mask
+from nimare.transforms import z_to_p
 
 
 class _FakeDataset:
@@ -532,6 +533,47 @@ def test_permuted_ols_fwe_handles_a_bag_with_one_image_per_group():
     p_map = maps["p_level-voxel"]
     assert np.isfinite(p_map).all()
     assert np.all((p_map > 0) & (p_map <= 1))
+
+
+def test_permuted_ols_reports_an_uncorrected_p_map(fitted):
+    """Without a ``p`` map, FDR and Bonferroni correction have nothing to read."""
+    from nimare.correct import FDRCorrector
+
+    results = fitted(ibma.PermutedOLS)
+
+    p_map = results.maps["p"]
+    finite = np.isfinite(p_map)
+    assert finite.any()
+    assert np.all((p_map[finite] > 0) & (p_map[finite] <= 1))
+    # Voxels the model did not cover stay NaN, as in every other map.
+    assert np.isnan(p_map[~np.isfinite(results.maps["t"])]).all()
+
+    corrected = FDRCorrector(method="indep", alpha=0.05).transform(results)
+    q_map = corrected.maps["p_corr-FDR_method-indep"]
+    covered = np.isfinite(q_map)
+    assert covered.any()
+    # Correcting can only raise a p-value.
+    assert np.all(q_map[covered] >= p_map[covered] - 1e-12)
+
+
+@pytest.mark.parametrize("two_sided", [True, False])
+def test_permuted_ols_p_map_agrees_with_its_z_map(two_sided):
+    """Match the z map's own p-value, on the tail the test was run on.
+
+    Deriving p from t independently would let the two maps disagree, since ``t_to_z`` floors
+    the tail probability it converts through.
+    """
+    betas = np.array([[1.0, -1.0], [1.2, -1.2], [0.8, -0.8], [1.1, -1.1]])
+    meta = _bagged_estimator(
+        ibma.PermutedOLS, {"beta_maps": betas}, codes=np.arange(4), two_sided=two_sided
+    )
+    meta.generate_description = False
+    maps, _, _ = meta._fit(_FakeDataset(meta.masker))
+
+    p = maps["p"]
+    assert np.allclose(p, z_to_p(maps["z"], tail="two" if two_sided else "one"))
+    # Voxel 1 is the mirror of voxel 0. Two-sided cannot tell them apart; one-sided must.
+    assert np.isclose(p[0], p[1]) == two_sided
 
 
 def test_permuted_ols_fwe_is_not_saturated_by_a_small_bag():


### PR DESCRIPTION
Every other IBMA estimator emits a "p" map; PermutedOLS emitted only t, z and dof, so FDRCorrector and Bonferroni raised "requires 'p' maps ... but none were found". FDRCorrector.inspect() advertised them anyway, so the failure came after a green light.

The p-value is parametric, referred to the same t distribution the z map already uses, and on the same tail as the permutation test and the corrected map.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Expose uncorrected p-value maps from PermutedOLS so downstream multiple-comparison correction can be applied consistently.

New Features:
- Add an uncorrected p-value map to PermutedOLS results, using the test’s configured one- or two-sided tail.

Bug Fixes:
- Enable FDR and Bonferroni correction workflows for PermutedOLS by providing the p maps they require.

Documentation:
- Document the new PermutedOLS p-value output.

Tests:
- Verify p-map validity, masking behavior, compatibility with FDR correction, and agreement with the z-map across both tails.