### PR TITLE
[ENH] Add d, g and g_var targets to ImageTransformer

### DIFF
--- a/nimare/tests/test_transforms.py
+++ b/nimare/tests/test_transforms.py
@@ -1,5 +1,6 @@
 """Test nimare.transforms."""
 
+import logging
 import re
 
 import nibabel as nib
@@ -35,6 +36,60 @@ def test_ImageTransformer(testdata_ibma):
     new_dset = t_transformer.transform(dset)
     new_t_files = new_dset.images["t"].tolist()
     assert t_files[:-1] == new_t_files[:-1]
+
+
+@pytest.mark.parametrize("target", ["d", "g", "g_var"])
+def test_resolve_transforms_standardized_effect_sizes(testdata_ibma, target):
+    """Match the direct conversion from t and the sample size."""
+    masker = testdata_ibma.masker
+    row = testdata_ibma.images.iloc[0]
+    sample_sizes = testdata_ibma.metadata.loc[
+        testdata_ibma.metadata["id"] == row["id"], "sample_sizes"
+    ].iloc[0]
+    available = {"t": row["t"], "sample_sizes": sample_sizes}
+
+    img = transforms.resolve_transforms(target, dict(available), masker)
+
+    n = transforms.sample_sizes_to_sample_size(sample_sizes)
+    d = transforms.t_to_d(masker.transform(available["t"]), n)
+    g, g_var = transforms.d_to_g(d, n, return_variance=True)
+    expected = {"d": d, "g": g, "g_var": g_var}[target]
+
+    assert np.allclose(masker.transform(img), expected)
+
+
+def test_resolve_transforms_reaches_g_from_z_alone(testdata_ibma):
+    """A studyset with only z maps can still get to a standardized effect size, via t."""
+    masker = testdata_ibma.masker
+    row = testdata_ibma.images.iloc[0]
+    sample_sizes = testdata_ibma.metadata.loc[
+        testdata_ibma.metadata["id"] == row["id"], "sample_sizes"
+    ].iloc[0]
+
+    img = transforms.resolve_transforms("g", {"z": row["z"], "sample_sizes": sample_sizes}, masker)
+
+    assert img is not None
+    assert np.isfinite(masker.transform(img)).any()
+
+
+@pytest.mark.parametrize("target", ["d", "g", "g_var"])
+def test_resolve_transforms_needs_a_sample_size(testdata_ibma, target):
+    """Without a sample size there is nothing to standardize by, so decline rather than guess."""
+    row = testdata_ibma.images.iloc[0]
+
+    assert transforms.resolve_transforms(target, {"t": row["t"]}, testdata_ibma.masker) is None
+
+
+def test_resolve_transforms_warns_on_multiple_group_sample_sizes(testdata_ibma, caplog):
+    """Warn when the one-sample conversion is applied to more than one group."""
+    row = testdata_ibma.images.iloc[0]
+
+    with caplog.at_level(logging.WARNING, logger="nimare.transforms"):
+        transforms.resolve_transforms(
+            "g", {"t": row["t"], "sample_sizes": [20, 20]}, testdata_ibma.masker
+        )
+
+    assert "one-sample" in caplog.text
 
 
 def test_transform_images(testdata_ibma):

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -120,8 +120,11 @@ class ImageTransformer(NiMAREBase):
 
     Parameters
     ----------
-    target : {'z', 'p', 'beta', 'varcope'} or list
+    target : {'z', 'p', 't', 'beta', 'varcope', 'd', 'g', 'g_var'} or list
         Target image type. Multiple target types may be specified as a list.
+        ``'g'`` and ``'g_var'`` give a standardized effect size and its variance, which
+        unlike :term:`beta` and :term:`varcope` are comparable across studies whose
+        pipelines used different units.
     overwrite : :obj:`bool`, optional
         Whether to overwrite existing files or not. Default is False.
 
@@ -191,7 +194,7 @@ def transform_images(images_df, target, masker, metadata_df=None, out_dir=None, 
     ----------
     images_df : :class:`pandas.DataFrame`
         DataFrame with paths to images for studies in Dataset.
-    target : {'z', 'p', 'beta', 'varcope'}
+    target : {'z', 'p', 't', 'beta', 'varcope', 'd', 'g', 'g_var'}
         Target data type.
     masker : :class:`~nilearn.maskers.NiftiMasker` or similar
         Masker used to define orientation and resolution of images.
@@ -213,7 +216,7 @@ def transform_images(images_df, target, masker, metadata_df=None, out_dir=None, 
     """
     new_images_df = images_df.copy()  # Work on a copy of the images_df
 
-    valid_targets = {"t", "z", "p", "beta", "varcope"}
+    valid_targets = {"t", "z", "p", "beta", "varcope", "d", "g", "g_var"}
     if target not in valid_targets:
         raise ValueError(
             f"Target type {target} not supported. Must be one of: {', '.join(valid_targets)}"
@@ -284,8 +287,10 @@ def resolve_transforms(target, available_data, masker):
 
     Parameters
     ----------
-    target : {'z', 'p', 't', 'beta', 'varcope'}
-        Target image type.
+    target : {'z', 'p', 't', 'beta', 'varcope', 'd', 'g', 'g_var'}
+        Target image type. ``'d'`` is Cohen's d, ``'g'`` is Hedges' g and ``'g_var'`` is the
+        sampling variance of g; the latter two are the effect estimate and variance a
+        meta-regression takes.
     available_data : dict
         Dictionary mapping data types to their values. Images in the dictionary
         are paths to files.
@@ -330,6 +335,36 @@ def resolve_transforms(target, available_data, masker):
             return t
         else:
             return None
+    elif target in ("d", "g", "g_var"):
+        # All three start from t and the sample size. t itself resolves from z, so a
+        # studyset holding only z maps can still reach a standardized effect size.
+        if "t" not in available_data.keys():
+            temp = resolve_transforms("t", available_data, masker)
+            if temp is not None:
+                available_data["t"] = temp
+
+        if ("t" not in available_data.keys()) or ("sample_sizes" not in available_data.keys()):
+            return None
+
+        sample_sizes = available_data["sample_sizes"]
+        if np.size(sample_sizes) > 1:
+            LGR.warning(
+                "Converting to '%s' from %d group sample sizes. The conversion is the "
+                "one-sample d = t / sqrt(N), so a between-group contrast will come out "
+                "wrong; that needs both group sizes separately.",
+                target,
+                np.size(sample_sizes),
+            )
+        sample_size = sample_sizes_to_sample_size(sample_sizes)
+
+        d = t_to_d(masker.transform(available_data["t"]), sample_size)
+        if target == "d":
+            values = d
+        else:
+            g, g_var = d_to_g(d, sample_size, return_variance=True)
+            values = g if target == "g" else g_var
+
+        return masker.inverse_transform(values.squeeze())
     elif target == "beta":
         if "t" not in available_data.keys():
             # will return none given no transform/target exists


### PR DESCRIPTION
Standardized effect sizes were reachable only inside FixedEffectsHedges, which derives them internally and is fixed-effect only. Exposing them as transform targets makes the pair a meta-regression takes -- g in the effect slot, g_var in the variance slot -- available to any estimator, which matters when studies report betas in pipeline-specific units that no varcope can reconcile.

All three resolve from t and the sample size, and t already resolves from z, so a studyset holding nothing but z maps can reach them. The conversion is the one-sample d = t / sqrt(N); more than one group sample size now warns, since a between-group contrast needs both sizes separately.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Expose standardized effect sizes and their variance as image transformation targets for broader meta-analysis workflows.

New Features:
- Add ImageTransformer and transform_images support for Cohen’s d, Hedges’ g, and the sampling variance of g.
- Enable standardized effect-size targets to be derived from t or z maps and study sample sizes for use in meta-regression.

Enhancements:
- Warn when standardized effect sizes are derived from multiple group sample sizes using the one-sample conversion.

Documentation:
- Document the new standardized effect-size transformation targets and their intended use.

Tests:
- Add coverage for direct d, g, and g_var conversions, z-to-g resolution, missing sample sizes, and multiple-group warnings.