### PR TITLE
[ENH] Forward PyMARE's small_sample_correction

### DIFF
--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -20,7 +20,7 @@ except ImportError:
     # nilearn >= 0.12.0; nilearn <= 0.12.1
     from nilearn._utils.niimg_conversions import check_same_fov
 
-from pymare.estimators.estimators import WEIGHT_SCHEMES
+from pymare.estimators.estimators import SMALL_SAMPLE_CORRECTIONS, WEIGHT_SCHEMES
 from pymare.stats import estimate_null_correlation
 
 from nimare import _version
@@ -63,6 +63,16 @@ _DOC_DICT = {
     ``'individual'`` leaves the weights alone; ``'collapse'`` fits one row per group.
     Group labels also switch the standard errors to CR2 and the reference to a t
     distribution with Satterthwaite degrees of freedom :footcite:p:`tipton2015small`.
+small_sample_correction : None or {'knapp-hartung', 'knapp-hartung-conservative', 'wald'}, optional
+    How PyMARE corrects its model-based standard errors for a small number of studies,
+    passed through unchanged. The Wald reference treats an estimated tau^2 as if it were
+    known, which is anti-conservative with few studies; the Knapp-Hartung adjustment
+    rescales the variance by the observed weighted residual spread and refers it to a t
+    distribution :footcite:p:`knapp2003improved`. Default is None, which leaves each
+    PyMARE estimator on its own default -- the adjustment where tau^2 is estimated, and
+    ``'wald'`` for :class:`WeightedLeastSquares`, whose tau^2 is supplied rather than
+    estimated. Ignored once group labels are present, where CR2 and Satterthwaite degrees
+    of freedom are the correction instead.
 rho : :obj:`float`, optional
     Assumed within-group correlation, in [0, 1]. Enters only through tau^2, to which
     results are weakly sensitive. Default is 0.8, matching ``robumeta``. Ignored when
@@ -651,11 +661,18 @@ class _PyMARERegressionEstimator(IBMAEstimator):
     #: must have an entry in :data:`_EXTRA_MAP_SOURCES`.
     _extra_maps = ()
 
-    def __init__(self, weight_scheme="rescale", rho=0.8, **kwargs):
+    def __init__(self, weight_scheme="rescale", rho=0.8, small_sample_correction=None, **kwargs):
         if weight_scheme not in WEIGHT_SCHEMES:
             raise ValueError(
                 f"Invalid weight_scheme '{weight_scheme}'; must be one of "
                 f"{sorted(WEIGHT_SCHEMES)}."
+            )
+        if small_sample_correction is not None and (
+            small_sample_correction not in SMALL_SAMPLE_CORRECTIONS
+        ):
+            raise ValueError(
+                f"Invalid small_sample_correction '{small_sample_correction}'; must be None "
+                f"or one of {sorted(SMALL_SAMPLE_CORRECTIONS)}."
             )
         if not isinstance(rho, (int, float, np.integer, np.floating)) or isinstance(rho, bool):
             raise ValueError(f"Invalid rho {rho!r}; must be a number.")
@@ -664,6 +681,7 @@ class _PyMARERegressionEstimator(IBMAEstimator):
 
         self.weight_scheme = weight_scheme
         self.rho = float(rho)
+        self.small_sample_correction = small_sample_correction
         super().__init__(**kwargs)
 
     def _pymare_weighting_kwargs(self, study_mask):
@@ -682,10 +700,16 @@ class _PyMARERegressionEstimator(IBMAEstimator):
 
     def _pymare_estimator(self, study_mask):
         """Return the PyMARE estimator to fit over the current model's images."""
-        return self._pymare_estimator_class(
+        kwargs = {
             **self._pymare_estimator_kwargs(),
             **self._pymare_weighting_kwargs(study_mask),
-        )
+        }
+        # Omitted when None so that each PyMARE estimator keeps its own default, which
+        # differs: the ones that estimate tau^2 correct by default, WeightedLeastSquares
+        # does not, because its tau^2 is supplied rather than estimated.
+        if self.small_sample_correction is not None:
+            kwargs["small_sample_correction"] = self.small_sample_correction
+        return self._pymare_estimator_class(**kwargs)
 
     def _pymare_dataset(self, arrays, study_mask):
         """Return the PyMARE dataset for the current model.

--- a/nimare/resources/references.bib
+++ b/nimare/resources/references.bib
@@ -645,3 +645,14 @@
   url={https://doi.org/10.1016/S0167-7152(02)00310-3},
   doi={10.1016/S0167-7152(02)00310-3}
 }
+@article{knapp2003improved,
+  title={Improved tests for a random effects meta-regression with a single covariate},
+  author={Knapp, Guido and Hartung, Joachim},
+  journal={Statistics in Medicine},
+  volume={22},
+  number={17},
+  pages={2693--2710},
+  year={2003},
+  publisher={Wiley},
+  doi={10.1002/sim.1482}
+}

--- a/nimare/tests/test_meta_ibma_dependence.py
+++ b/nimare/tests/test_meta_ibma_dependence.py
@@ -159,10 +159,11 @@ def test_small_sample_correction_defers_to_pymare_by_default(estimator):
     assert est.small_sample_correction == expected
 
 
+@pytest.mark.parametrize("estimator", REGRESSION_ESTIMATORS)
 @pytest.mark.parametrize("correction", ["knapp-hartung", "knapp-hartung-conservative", "wald"])
-def test_small_sample_correction_is_forwarded(correction):
+def test_small_sample_correction_is_forwarded(estimator, correction):
     """An explicit choice must reach the PyMARE estimator and change the inference."""
-    meta = ibma.DerSimonianLaird(small_sample_correction=correction)
+    meta = estimator(small_sample_correction=correction)
     meta.inputs_ = {"contrast_names": np.array([0, 1, 2])}
 
     assert meta._pymare_estimator(np.arange(3)).small_sample_correction == correction

--- a/nimare/tests/test_meta_ibma_dependence.py
+++ b/nimare/tests/test_meta_ibma_dependence.py
@@ -1,5 +1,6 @@
 """Tests for dependence handling in IBMA estimators."""
 
+import inspect
 import logging
 
 import numpy as np
@@ -133,6 +134,69 @@ def test_weighting_parameters_are_validated(estimator):
         estimator(rho=1.5)
     with pytest.raises(ValueError, match="must be a number"):
         estimator(rho="0.8")
+
+
+@pytest.mark.parametrize("estimator", REGRESSION_ESTIMATORS)
+def test_small_sample_correction_is_validated(estimator):
+    """A misspelled correction should fail at construction, not reach PyMARE."""
+    with pytest.raises(ValueError, match="Invalid small_sample_correction"):
+        estimator(small_sample_correction="knapp_hartung")
+
+
+@pytest.mark.parametrize("estimator", REGRESSION_ESTIMATORS)
+def test_small_sample_correction_defers_to_pymare_by_default(estimator):
+    """None must leave the argument out, so each PyMARE estimator keeps its own default.
+
+    They differ: the estimators that estimate tau^2 correct by default, while
+    WeightedLeastSquares does not, since its tau^2 is supplied rather than estimated.
+    """
+    meta = estimator()
+    assert meta.small_sample_correction is None
+    meta.inputs_ = {"contrast_names": np.array([0, 1, 2])}
+
+    est = meta._pymare_estimator(np.arange(3))
+    expected = inspect.signature(type(est).__init__).parameters["small_sample_correction"].default
+    assert est.small_sample_correction == expected
+
+
+@pytest.mark.parametrize("correction", ["knapp-hartung", "knapp-hartung-conservative", "wald"])
+def test_small_sample_correction_is_forwarded(correction):
+    """An explicit choice must reach the PyMARE estimator and change the inference."""
+    meta = ibma.DerSimonianLaird(small_sample_correction=correction)
+    meta.inputs_ = {"contrast_names": np.array([0, 1, 2])}
+
+    assert meta._pymare_estimator(np.arange(3)).small_sample_correction == correction
+
+
+def test_small_sample_correction_changes_the_model_based_standard_errors(fitted):
+    """On the model-based path the correction must move the p-values, and only those."""
+    corrected = fitted(
+        ibma.DerSimonianLaird, groupby=False, small_sample_correction="knapp-hartung"
+    )
+    uncorrected = fitted(ibma.DerSimonianLaird, groupby=False, small_sample_correction="wald")
+
+    valid = np.isfinite(corrected.maps["p"]) & np.isfinite(uncorrected.maps["p"])
+    assert valid.any()
+    assert not np.allclose(corrected.maps["p"][valid], uncorrected.maps["p"][valid])
+    # Only the reference distribution changes; the point estimate is untouched.
+    assert np.allclose(corrected.maps["est"][valid], uncorrected.maps["est"][valid])
+
+
+def test_small_sample_correction_is_ignored_once_images_are_grouped(fitted):
+    """Group labels bring CR2 and Satterthwaite degrees of freedom, which replace it.
+
+    So the parameter is inert on the grouped path -- which is why PyMARE spells the
+    uncorrected option 'wald' rather than 'none'.
+    """
+    corrected = fitted(ibma.DerSimonianLaird, small_sample_correction="knapp-hartung")
+    uncorrected = fitted(ibma.DerSimonianLaird, small_sample_correction="wald")
+
+    assert np.unique(corrected.estimator.inputs_["contrast_names"]).size < len(
+        corrected.estimator.inputs_["id"]
+    ), "fixture must actually group something"
+    valid = np.isfinite(corrected.maps["p"]) & np.isfinite(uncorrected.maps["p"])
+    assert valid.any()
+    assert np.allclose(corrected.maps["p"][valid], uncorrected.maps["p"][valid])
 
 
 @pytest.mark.parametrize("estimator", REGRESSION_ESTIMATORS)

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     pandas>=2.1.4
     patsy  # for cbmr
     plotly  # nimare.reports
-    pymare>=0.0.11rc1  # nimare.meta.ibma and stats; needs Dataset(g=...) for dependence
+    pymare>=0.0.11rc2  # nimare.meta.ibma and stats; Dataset(g=...) and small_sample_correction
     pyyaml # nimare.reports
     requests  # nimare.extract
     ridgeplot  # nimare.reports
@@ -91,7 +91,7 @@ minimum =
     nilearn==0.12.0; python_version < "3.11"
     numpy==1.22.4; python_version < "3.11"
     pandas==2.2.0; python_version < "3.11"
-    pymare==0.0.11rc1; python_version < "3.11"
+    pymare==0.0.11rc2; python_version < "3.11"
     scikit-learn==1.4.0; python_version < "3.11"
     scipy==1.8.0; python_version < "3.11"
     seaborn==0.13.0; python_version < "3.11"


### PR DESCRIPTION
PyMARE 0.0.11rc2 corrects its model-based standard errors for a small number of studies, defaulting to the Knapp-Hartung adjustment. The Wald reference treats an estimated tau^2 as if it were known, which is anti-conservative once few studies are pooled.

Passed through as None, so each PyMARE estimator keeps its own default rather than a single NiMARE-imposed value. Those differ, and the difference is deliberate: the estimators that estimate tau^2 correct by default, while WeightedLeastSquares does not, since its tau^2 is supplied.

The parameter is inert once group labels are present, where CR2 standard errors and Satterthwaite degrees of freedom are the correction instead.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Forward PyMARE small-sample correction settings through IBMA regression estimators without overriding their native defaults.

New Features:
- Expose PyMARE small-sample correction choices for IBMA regression estimators while preserving estimator-specific defaults when unspecified.

Enhancements:
- Document the correction behavior for model-based and grouped analyses, including Knapp–Hartung and Wald references.
- Validate correction values and add coverage for forwarding, default preservation, model-based inference changes, and grouped-analysis behavior.

Build:
- Raise the minimum PyMARE dependency to 0.0.11rc2 to support small-sample corrections.

Documentation:
- Add the Knapp and Hartung reference to the bibliography.