### PR TITLE
[DOC] Point the beta-units note at the g and g_var targets

### DIFF
--- a/examples/02_meta-analyses/02_plot_ibma.py
+++ b/examples/02_meta-analyses/02_plot_ibma.py
@@ -328,7 +328,10 @@ pprint(results.bibtex_)
 #
 # There is no supported random-effects counterpart: ``FixedEffectsHedges`` is fixed-effect
 # only, and no NiMARE estimator fits a standardized effect size with a between-study
-# variance.
+# variance. Its inputs are a transform away, though:
+# ``ImageTransformer(target=["g", "g_var"])`` writes Hedges’ g and its sampling
+# variance, which are the effect estimate and variance a meta-regression takes. So what is
+# missing is an estimator that reads them, not a way to build them.
 #
 # None of this applies if your betas do share a scale -- percent signal change, say, or a
 # single pipeline throughout. Then beta and varcope meta-regression is the right tool.


### PR DESCRIPTION
The note told the reader no estimator fits a standardized effect size with an estimated between-study variance, which is still true, but left the impression that building the inputs was the obstacle. Since #1092 it is one transform call, so name it and locate the actual gap in the estimator rather than the maps.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Clarify the beta-units guidance in the IBMA example by distinguishing input construction from estimator support.

Enhancements:
- Clarify the IBMA example’s beta-units note by pointing readers to the g and g_var transformation targets and identifying the missing standardized-effect-size estimator as the remaining limitation.

Documentation:
- Update the IBMA plotting example to more accurately explain how standardized effect-size inputs can be constructed and where NiMARE support is still missing.