### PR TITLE
[FIX] Keep the combination tests' z maps finite when the combined p u…

### DIFF
--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -12,6 +12,7 @@ import pymare
 from joblib import Memory
 from nilearn.image import concat_imgs, resample_to_img
 from nilearn.maskers import NiftiMasker
+from scipy import stats as sp_stats
 
 try:
     # nilearn >= 0.13.0
@@ -31,6 +32,7 @@ from nimare.meta.utils import _liberal_mask_bags, _liberal_mask_values
 from nimare.transforms import d_to_g, p_to_z, t_to_d, t_to_z, z_to_p
 from nimare.utils import (
     _check_ncores,
+    _minimum_positive_float,
     get_masker,
     get_masker_mask_image,
 )
@@ -83,6 +85,12 @@ as NaN.""",
 }
 
 _DOC_PLACEHOLDER = re.compile(r"^(?P<indent> *)%\((?P<key>\w+)\)s *$")
+
+#: The largest z that :func:`scipy.stats.norm.isf` returns for a representable p-value,
+#: i.e. for the smallest positive double. A p-value any further into the tail is exactly
+#: zero in double precision and ``isf`` of that is infinite, so this is where the
+#: combination tests' z maps are bounded rather than left non-finite.
+_MAX_FINITE_Z = float(sp_stats.norm.isf(_minimum_positive_float(np.float64)))
 
 #: Constructor arguments that used to exist, and what to tell a caller still passing one.
 #: Without these, the generic "unexpected keyword argument" error points at the
@@ -502,6 +510,34 @@ class IBMAEstimator(Estimator):
         dependence = self._dependence(study_mask)
         return dependence.per_image(self._sample_sizes_for_mask(study_mask))
 
+    @staticmethod
+    def _combination_stats(est_summary):
+        """Return the z and p maps of a combination test, with the tail underflow bounded.
+
+        PyMARE reports z as ``isf(p)``. Far enough into the tail p underflows to exactly
+        zero, so z comes back infinite -- 856 voxels of the 21-study pain studyset, for
+        Fisher's. An infinite z reaches the results map, where it breaks thresholding, any
+        maximum over the map, and plotting. Bound it at :data:`_MAX_FINITE_Z`, keeping the
+        sign PyMARE assigned. The p map needs no repair; it is already clipped when the
+        :class:`~nimare.results.MetaResult` is built.
+        """
+        z_map = np.asarray(est_summary.z, dtype=float).squeeze()
+        p_map = np.asarray(est_summary.p, dtype=float).squeeze()
+
+        underflowed = np.isinf(z_map)
+        if underflowed.any():
+            LGR.warning(
+                "The combined p-value underflowed to zero at %d voxel(s), leaving an "
+                "infinite z. Reporting %.2f there, the largest z a double-precision "
+                "p-value can represent.",
+                int(underflowed.sum()),
+                _MAX_FINITE_Z,
+            )
+            z_map = z_map.copy()
+            z_map[underflowed] = _MAX_FINITE_Z * np.sign(z_map[underflowed])
+
+        return z_map, p_map
+
     def _resolve_group_labels(self, dataset):
         """Return one group label per image, in ``inputs_["id"]`` order."""
         if isinstance(self.groupby, str):
@@ -855,8 +891,7 @@ class Fishers(IBMAEstimator):
         est.fit_dataset(pymare_dset, corr=sub_corr)
         est_summary = est.summary()
 
-        z_map = est_summary.z.squeeze()
-        p_map = est_summary.p.squeeze()
+        z_map, p_map = self._combination_stats(est_summary)
         dof_map = self._dof_map(study_mask, n_voxels)
 
         return z_map, p_map, dof_map
@@ -1026,8 +1061,7 @@ class Stouffers(IBMAEstimator):
         est.fit_dataset(pymare_dset, corr=sub_corr)
         est_summary = est.summary()
 
-        z_map = est_summary.z.squeeze()
-        p_map = est_summary.p.squeeze()
+        z_map, p_map = self._combination_stats(est_summary)
         dof_map = self._dof_map(study_mask, n_voxels)
 
         return z_map, p_map, dof_map

--- a/nimare/tests/test_meta_ibma_dependence.py
+++ b/nimare/tests/test_meta_ibma_dependence.py
@@ -715,6 +715,50 @@ def test_stouffers_aggregates_groups_whenever_they_exist(monkeypatch):
     assert captured["group_level"] is True
 
 
+@pytest.mark.parametrize("estimator", COMBINATION_ESTIMATORS)
+def test_combination_z_is_finite_when_the_combined_p_underflows(estimator, caplog):
+    """An underflowed p must not leave an infinite z in the results map.
+
+    PyMARE reports z as isf(p), and p is exactly zero in double precision beyond about
+    z = 38. An infinite z breaks thresholding, plotting and any maximum over the map.
+    """
+    # Twenty strongly concordant studies drive the combined p below double precision.
+    z_maps = np.full((20, 4), 12.0)
+    z_maps[:, 1] *= -1  # the same magnitude, opposite direction
+    z_maps[:, 2] = 0.5  # ordinary values must be untouched
+    z_maps[:, 3] = -0.5
+
+    meta = estimator()
+    meta.inputs_ = {
+        "contrast_names": np.arange(20),
+        "corr_matrix": None,
+        "id": [f"s{i}" for i in range(20)],
+    }
+    with caplog.at_level(logging.WARNING, logger="nimare.meta.ibma"):
+        z_map, p_map, _ = meta._fit_model(z_maps, study_mask=np.arange(20))
+
+    assert np.isfinite(z_map).all()
+    assert np.abs(z_map[0]) <= ibma._MAX_FINITE_Z
+    assert "underflowed" in caplog.text
+    # The sign of the bounded voxels survives, and the unaffected ones keep their values.
+    assert z_map[0] > 0 and z_map[1] < 0
+    assert np.abs(z_map[2]) < ibma._MAX_FINITE_Z
+    assert np.all(p_map >= 0)
+
+
+def test_max_finite_z_is_the_double_precision_limit():
+    """The bound must be where a p-value stops being representable, not a round number."""
+    from scipy import stats
+
+    from nimare.utils import _minimum_positive_float
+
+    assert ibma._MAX_FINITE_Z == stats.norm.isf(_minimum_positive_float(np.float64))
+    assert np.isfinite(ibma._MAX_FINITE_Z)
+    # It is the largest finite z isf can produce: one p-value further out is zero, and isf
+    # of zero is the infinity being replaced.
+    assert np.isinf(stats.norm.isf(0.0))
+
+
 def test_fishers_preserves_two_sided_positional_argument():
     """Adding sample-size weighting must not reinterpret released positional calls."""
     estimator = ibma.Fishers(False)


### PR DESCRIPTION
…nderflows

PyMARE reports z as isf(p), and the combined p is exactly zero in double precision beyond about z = 38, so z came back infinite -- 332 voxels of the 21-study pain studyset for Fisher's. An infinite z reached the results map, where it breaks thresholding, plotting and any maximum over the map, while the p and logp maps were already clipped and so looked fine.

Bounded at the largest z isf returns for a representable p-value, with the sign preserved and a warning naming the voxel count. This caps the reported statistic rather than recovering the true one; computing z accurately past that point needs log-space evaluation (chi2.logsf and ndtri_exp) inside PyMARE.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Keep combination-test z maps finite when extreme combined p-values underflow.

Bug Fixes:
- Prevent combination-test z maps from containing infinite values when combined p-values underflow to zero.
- Preserve the sign of underflowed z values and emit a warning identifying affected voxels.

Enhancements:
- Define the finite double-precision limit for normal inverse-survival z values and apply it consistently across combination estimators.

Tests:
- Add coverage for finite, sign-preserving z values, warning behavior, unaffected voxels, and the double-precision z limit.