### PR TITLE
[ENH] Evaluate the p-to-z tail in log space

### DIFF
--- a/nimare/tests/test_transforms.py
+++ b/nimare/tests/test_transforms.py
@@ -6,8 +6,10 @@ import re
 import nibabel as nib
 import numpy as np
 import pytest
+from scipy import stats
 
 from nimare import transforms
+from nimare.utils import DEFAULT_FLOAT_DTYPE
 
 
 def test_ImageTransformer(testdata_ibma):
@@ -36,6 +38,75 @@ def test_ImageTransformer(testdata_ibma):
     new_dset = t_transformer.transform(dset)
     new_t_files = new_dset.images["t"].tolist()
     assert t_files[:-1] == new_t_files[:-1]
+
+
+def test_t_to_z_is_unchanged_below_the_old_ceiling():
+    """The log-space tail must reproduce the previous values wherever they were not capped.
+
+    The old implementation floored its internal p-value at the machine epsilon of its
+    dtype, which truncated |z| at about 8.13.
+    """
+    rng = np.random.default_rng(0)
+    for dof in (5, 20, 100):
+        t = rng.normal(0, 2.5, size=50_000)
+        z = transforms.t_to_z(t, dof)
+        # Matched tail probabilities, computed independently of the implementation.
+        expected = np.sign(t) * stats.norm.isf(stats.t.sf(np.abs(t), dof))
+        below = np.abs(z) < 8.0
+        assert below.mean() > 0.99
+        assert np.allclose(z[below], expected[below], atol=1e-10)
+
+
+def test_t_to_z_keeps_going_past_the_old_ceiling():
+    """A large t must no longer saturate, and must keep its sign."""
+    t = np.array([-1000.0, -50.0, 0.0, 50.0, 1000.0])
+
+    z = transforms.t_to_z(t, 20)
+
+    assert np.all(np.abs(z[[0, 1, 3, 4]]) > 8.13), "these all used to be clipped to 8.13"
+    assert np.allclose(z, -z[::-1]), "must stay antisymmetric in t"
+    assert z[2] == 0.0
+    assert np.allclose(np.abs(z[[1, 4]]), [9.755, 14.630], atol=1e-3)
+    # And the result is representable in the dtype the maps are stored in.
+    assert np.all(np.isfinite(np.asarray(z, dtype=DEFAULT_FLOAT_DTYPE)))
+
+
+@pytest.mark.parametrize("tail", ["one", "two"])
+def test_log_p_to_z_matches_p_to_z_while_p_is_representable(tail):
+    """Agree with the ordinary conversion wherever the p-value is still representable.
+
+    ``p_to_z`` clips its input to the float32 range the maps are stored in, so the two only
+    have to agree above that floor; below it, only the log-space form carries a value.
+    """
+    p = np.array([0.5, 0.05, 1e-8, 1e-20, 1e-30])
+    assert np.all(p > np.finfo(DEFAULT_FLOAT_DTYPE).tiny), "fixture must stay representable"
+
+    assert np.allclose(
+        transforms.log_p_to_z(np.log(p), tail=tail),
+        transforms.p_to_z(p.astype(np.float64), tail=tail),
+        atol=1e-7,
+    )
+
+
+def test_log_p_to_z_passes_where_p_to_z_runs_out():
+    """Past the smallest representable p, only the log-space form still carries a value."""
+    # p = 1e-5000: zero in any float, so p_to_z can only return its floor.
+    log_p = -5000 * np.log(10)
+
+    z = transforms.log_p_to_z(log_p, tail="one")
+
+    assert 151 < z < 152
+    assert transforms.p_to_z(np.array([0.0]), tail="one")[0] < 15
+    # Round-trip through float32 storage, which holds z and -log10(p) alike.
+    stored = DEFAULT_FLOAT_DTYPE(z)
+    assert np.isfinite(stored)
+    assert np.isclose(float(stored), z, rtol=1e-6)
+
+
+def test_log_p_to_z_rejects_an_unknown_tail():
+    """Mirror p_to_z rather than silently choosing a tail."""
+    with pytest.raises(ValueError, match='"tail" must be one of'):
+        transforms.log_p_to_z(-1.0, tail="three")
 
 
 @pytest.mark.parametrize("target", ["d", "g", "g_var"])

--- a/nimare/tests/test_utils.py
+++ b/nimare/tests/test_utils.py
@@ -278,6 +278,30 @@ def test_apply_liberal_mask():
         assert np.array_equal(pred_val, true_val)
 
 
+def test_clip_logp_values_keeps_values_a_p_value_could_not_hold():
+    """A -log10(p) must not be clipped to the range of the p-value it came from.
+
+    Storing p itself bottoms out around 1.4e-45 in float32, i.e. -log10(p) of 44.85 or a z
+    of 14.1. Clipping the logarithm there would discard anything computed in log space,
+    which is the whole reason for computing in log space.
+    """
+    values = np.array([0.0, 44.85, 100.0, 1000.0, 5000.0])
+
+    clipped = utils._clip_logp_values(values)
+
+    assert np.allclose(clipped, values)
+    assert clipped.dtype == np.dtype(utils.DEFAULT_FLOAT_DTYPE)
+
+
+def test_clip_logp_values_still_bounds_the_non_finite_ends():
+    """Only the ends a float cannot hold are clipped: negatives and infinity."""
+    clipped = utils._clip_logp_values(np.array([-5.0, 0.0, 3.0, np.inf]))
+
+    assert clipped[0] == 0.0, "p <= 1 cannot give a negative -log10(p)"
+    assert clipped[2] == 3.0
+    assert np.isfinite(clipped[3]) and clipped[3] > 1e30, "infinity becomes the dtype max"
+
+
 def test_apply_liberal_mask_groups_voxels_that_are_not_adjacent():
     """Voxels sharing a coverage pattern belong in one bag, however they are ordered.
 

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -10,7 +10,7 @@ import nibabel as nib
 import numpy as np
 import pandas as pd
 from nilearn.reporting import get_clusters_table
-from scipy import stats
+from scipy import special, stats
 
 from nimare.base import NiMAREBase
 from nimare.studyset import normalize_collection
@@ -910,13 +910,63 @@ def p_to_z(p, tail="two"):
     return z
 
 
+def log_p_to_z(log_p, tail="two"):
+    """Convert log p-values to (unsigned) z-values, without materializing the p-value.
+
+    .. versionadded:: 0.21.0
+
+    The log-space counterpart of :func:`p_to_z`. A p-value stops being representable below
+    about 1e-45 in float32 and 5e-324 in float64, which bounds :func:`p_to_z` at a z of
+    roughly 14 and 38 respectively. Taking the log first moves that ceiling out of reach:
+    :func:`scipy.special.ndtri_exp` inverts the normal from a log probability directly, so
+    a ``log_p`` of -11513 (a p of 1e-5000) still returns its z of about 152.
+
+    Only useful where the caller can produce a log p-value at the source, e.g. from
+    :meth:`scipy.stats.rv_continuous.logsf`. A p-value that has already underflowed to zero
+    carries no information left to recover.
+
+    Parameters
+    ----------
+    log_p : array_like
+        Natural logarithm of the p-values. Note natural, not base 10, matching SciPy's
+        ``logsf`` and ``logcdf``.
+    tail : {'one', 'two'}, optional
+        Whether the p-values come from a one-tailed or two-tailed test. Default is 'two'.
+
+    Returns
+    -------
+    z : array_like
+        Z-statistics (unsigned).
+
+    See Also
+    --------
+    p_to_z : The same conversion for a p-value that is already a number.
+    """
+    log_p = np.asarray(log_p, dtype=float)
+    if tail == "two":
+        # p_to_z halves a two-tailed p before inverting; in log space that is a subtraction.
+        z = -special.ndtri_exp(log_p - np.log(2.0))
+    elif tail == "one":
+        z = -special.ndtri_exp(log_p)
+        z = np.array(z)
+        z[z < 0] = 0
+    else:
+        raise ValueError('Argument "tail" must be one of ["one", "two"]')
+
+    if z.shape == ():
+        z = z[()]
+    return z
+
+
 def t_to_z(t_values, dof):
     """Convert t-statistics to z-statistics.
 
-    .. versionadded:: 0.0.3
+    .. versionchanged:: 0.21.0
 
-    An implementation of :footcite:t:`hughett2008accurate` from Vanessa Sochat's TtoZ package
-    :footcite:p:`sochat2015ttoz`.
+        The tail is evaluated in log space, so ``|z|`` is no longer bounded at about 8.13.
+        Values below that bound are unchanged.
+
+    .. versionadded:: 0.0.3
 
     Parameters
     ----------
@@ -928,62 +978,35 @@ def t_to_z(t_values, dof):
     Returns
     -------
     z_values : array_like
-        Z-statistics
+        Z-statistics, carrying the sign of ``t_values``.
 
-    License
-    -------
-    The MIT License (MIT)
-    Copyright (c) 2015 Vanessa Sochat
+    Notes
+    -----
+    The t and normal tail probabilities are matched, which is the transform of
+    :footcite:t:`hughett2008accurate`. It is evaluated through
+    :meth:`~scipy.stats.rv_continuous.logsf` and :func:`scipy.special.ndtri_exp` rather
+    than through the p-value itself: the earlier implementation floored that p-value at the
+    machine epsilon of its dtype, and since epsilon measures precision rather than
+    magnitude, it truncated ``|z|`` at about 8.13 for float64. A ``t`` of 1000 on 20
+    degrees of freedom reports 14.63 now and reported 8.13 before.
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy of this software
-    and associated documentation files (the "Software"), to deal in the Software without
-    restriction, including without limitation the rights to use, copy, modify, merge, publish,
-    distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the
-    Software is furnished to do so, subject to the following conditions:
-
-    The above copyright notice and this permission notice shall be included in all copies or
-    substantial portions of the Software.
-
-    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
-    INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
-    PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
-    FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
-    ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-    SOFTWARE.
+    Non-finite input propagates: an infinite ``t`` gives an infinite ``z``, and NaN gives
+    NaN.
 
     References
     ----------
     .. footbibliography::
     """
-    # Select just the nonzero voxels
-    nonzero = t_values[t_values != 0]
+    t_values = np.asarray(t_values, dtype=float)
 
-    # We will store our results here
-    z_values_nonzero = np.zeros(len(nonzero))
+    # The one-tailed log p of |t|, then the normal quantile of it. Working from |t| and
+    # reapplying the sign keeps both tails on the accurate branch of logsf.
+    log_p = stats.t.logsf(np.abs(t_values), dof)
+    # The trailing addition turns the -0.0 that t == 0 produces back into 0.0.
+    z_values = np.sign(t_values) * log_p_to_z(log_p, tail="one") + 0.0
 
-    # Select values less than or == 0, and greater than zero
-    c = np.zeros(len(nonzero))
-    k1 = nonzero <= c
-    k2 = nonzero > c
-
-    # Subset the data into two sets
-    t1 = nonzero[k1]
-    t2 = nonzero[k2]
-
-    # Calculate p values for <=0
-    p_values_t1 = stats.t.cdf(t1, df=dof)
-    p_values_t1[p_values_t1 < np.finfo(p_values_t1.dtype).eps] = np.finfo(p_values_t1.dtype).eps
-    z_values_t1 = stats.norm.ppf(p_values_t1)
-
-    # Calculate p values for > 0
-    p_values_t2 = stats.t.cdf(-t2, df=dof)
-    p_values_t2[p_values_t2 < np.finfo(p_values_t2.dtype).eps] = np.finfo(p_values_t2.dtype).eps
-    z_values_t2 = -stats.norm.ppf(p_values_t2)
-    z_values_nonzero[k1] = z_values_t1
-    z_values_nonzero[k2] = z_values_t2
-
-    z_values = np.zeros(t_values.shape)
-    z_values[t_values != 0] = z_values_nonzero
+    if z_values.shape == ():
+        z_values = z_values[()]
     return z_values
 
 

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -47,15 +47,26 @@ def _clip_p_values(p_values, dtype=DEFAULT_FLOAT_DTYPE, copy=True):
 
 
 def _clip_logp_values(logp_values, dtype=DEFAULT_FLOAT_DTYPE, copy=True):
-    """Clip -log10(p) values to the range implied by a floating p-value dtype."""
+    """Clip -log10(p) values to the finite range of a floating dtype.
+
+    Only the non-finite ends are clipped: below at zero, since a p-value of at most one
+    cannot give a negative ``-log10(p)``, and above at the largest value the dtype holds,
+    which a p-value of exactly zero would otherwise map to positive infinity.
+
+    Deliberately *not* clipped at ``-log10(smallest positive p)``. That was the range
+    implied by storing the p-value itself, which for float32 is about 44.85, or a z of
+    14.1 -- and clipping a logarithm to the range of the unlogged quantity throws away the
+    headroom that taking the logarithm bought. A ``-log10(p)`` of 5000 is an ordinary
+    float32 and describes a z of about 152, so a statistic computed in log space can be
+    stored here without being truncated on the way in.
+    """
     dtype = np.dtype(dtype)
     logp_values = (
         np.array(logp_values, dtype=dtype, copy=True)
         if copy
         else np.asarray(logp_values, dtype=dtype)
     )
-    max_value = -np.log10(_minimum_positive_float(dtype))
-    return np.clip(logp_values, dtype.type(0), max_value, out=logp_values)
+    return np.clip(logp_values, dtype.type(0), np.finfo(dtype).max, out=logp_values)
 
 
 def _p_to_logp_values(p_values, dtype=DEFAULT_FLOAT_DTYPE, copy=True):


### PR DESCRIPTION
Three ceilings were bounding z, none of them a property of the float32 the maps are stored in:

- t_to_z floored its internal p-value at the machine epsilon of its dtype. Epsilon measures precision, not magnitude, so |z| saturated at about 8.13: a t of 1000 on 20 dof reported 8.13 rather than 14.63. Now evaluated through logsf and ndtri_exp, which agrees with the previous values to 1e-15 below the old bound and keeps going above it.

- p_to_z bottoms out at the smallest positive float32, i.e. a z of 14.1, because a p-value that small is all a float32 can hold. log_p_to_z takes the log p-value a caller already has from logsf and never materializes the p, so that bound does not apply.

- _clip_logp_values clipped -log10(p) at -log10(smallest positive p), 44.85, which is again a z of 14.1. Clipping a logarithm to the range of the unlogged quantity discards the headroom the logarithm buys; float32 holds a -log10(p) of 5000, describing a z of about 152. Only the non-finite ends are clipped now.

The p-value itself is still bounded, and inherently: 1.4e-45 in float32 is a z of 14.1, and 4.9e-324 in float64 is 38.5. So -log10(p), not p, is the map that can carry a deep tail.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Preserve deep statistical tails by evaluating p-to-z transformations and t-to-z conversions in log space.

New Features:
- Add a log-space p-value to z-score conversion that preserves extremely small tail probabilities without materializing the p-value.

Bug Fixes:
- Remove artificial z-score saturation in t-to-z conversion caused by flooring tail probabilities at machine epsilon.
- Allow stored -log10(p) values to retain deep-tail results beyond the representable p-value range.

Enhancements:
- Evaluate t-distribution tails in log space while preserving prior results below the former ceiling and maintaining signed, antisymmetric z-scores.

Documentation:
- Document the log-space conversion and the expanded tail behavior of t-to-z and -log10(p) values.

Tests:
- Add coverage for conversion accuracy below the former ceiling, deep-tail behavior, tail validation, and preservation of large finite -log10(p) values.