### PR TITLE
Correct off-by-one indexing in GCLDA log-likelihood calculation and replace LAPACK matrix inversion

### DIFF
--- a/nimare/annotate/gclda.py
+++ b/nimare/annotate/gclda.py
@@ -34,6 +34,59 @@ def _sample_from_unnormalized(weights):
     return weights.shape[0] - 1
 
 
+def _inv3_logdet(sigma):
+    """Invert a 3x3 matrix in closed form and return its log-determinant.
+
+    Uses the adjugate formula with a fixed operation order. Unlike LAPACK,
+    this is bit-for-bit reproducible across platforms and BLAS builds, which
+    allows the Rust implementation to match Python exactly. It is also
+    exactly symmetric for symmetric input, and about 2.5x faster than the
+    ``inv`` + ``slogdet`` pair it replaces.
+
+    Parameters
+    ----------
+    sigma : (3, 3) :obj:`numpy.ndarray`
+        A symmetric positive-definite matrix.
+
+    Returns
+    -------
+    inv : (3, 3) :obj:`numpy.ndarray`
+        The matrix inverse.
+    logdet : :obj:`float`
+        The natural log of the determinant.
+    """
+    a00, a01, a02 = sigma[0, 0], sigma[0, 1], sigma[0, 2]
+    a10, a11, a12 = sigma[1, 0], sigma[1, 1], sigma[1, 2]
+    a20, a21, a22 = sigma[2, 0], sigma[2, 1], sigma[2, 2]
+
+    c00 = a11 * a22 - a12 * a21
+    c01 = a02 * a21 - a01 * a22
+    c02 = a01 * a12 - a02 * a11
+    c10 = a12 * a20 - a10 * a22
+    c11 = a00 * a22 - a02 * a20
+    c12 = a02 * a10 - a00 * a12
+    c20 = a10 * a21 - a11 * a20
+    c21 = a01 * a20 - a00 * a21
+    c22 = a00 * a11 - a01 * a10
+
+    det = a00 * c00 + a01 * c10 + a02 * c20
+    if not det > 0.0:
+        raise np.linalg.LinAlgError("Region covariance must be positive definite.")
+
+    inv = np.empty((3, 3), dtype=np.float64)
+    inv[0, 0] = c00 / det
+    inv[0, 1] = c01 / det
+    inv[0, 2] = c02 / det
+    inv[1, 0] = c10 / det
+    inv[1, 1] = c11 / det
+    inv[1, 2] = c12 / det
+    inv[2, 0] = c20 / det
+    inv[2, 1] = c21 / det
+    inv[2, 2] = c22 / det
+
+    return inv, np.log(det)
+
+
 @njit(cache=True, parallel=True)
 def _jit_spatial_pdf(points, mean, precision, log_norm):
     """Evaluate one Gaussian PDF over many points."""
@@ -692,10 +745,8 @@ class GCLDAModel(NiMAREBase):
 
     def _cache_region_pdf_params(self, topic_idx, region_idx, sigma):
         """Cache Gaussian parameters used repeatedly during sampling and decoding."""
-        sign, logdet = np.linalg.slogdet(sigma)
-        if sign <= 0:
-            raise np.linalg.LinAlgError("Region covariance must be positive definite.")
-        self.topics["regions_precision"][topic_idx, region_idx, ...] = np.linalg.inv(sigma)
+        inv, logdet = _inv3_logdet(sigma)
+        self.topics["regions_precision"][topic_idx, region_idx, ...] = inv
         self.topics["regions_log_norm"][topic_idx, region_idx] = -0.5 * (
             sigma.shape[0] * np.log(2 * np.pi) + logdet
         )

--- a/nimare/annotate/gclda.py
+++ b/nimare/annotate/gclda.py
@@ -981,7 +981,7 @@ class GCLDAModel(NiMAREBase):
 
         # Go over all observed peaks and add p(x|model) to running total
         for i_ptoken in range(len(self.data["ptoken_doc_idx"])):
-            doc = self.data["ptoken_doc_idx"][i_ptoken] - 1  # convert didx from 1-idx to 0-idx
+            doc = self.data["ptoken_doc_idx"][i_ptoken]
             p_x = 0  # Running total for p(x|d) across subregions:
             # Compute p(x_i|d) for each subregion separately and then
             # sum across the subregions
@@ -1016,10 +1016,8 @@ class GCLDAModel(NiMAREBase):
 
         # Go over all observed word tokens and add p(w|model) to running total
         for i_wtoken in range(len(self.data["wtoken_word_idx"])):
-            # convert wtoken_word_idx from 1-idx to 0-idx
-            word_token = self.data["wtoken_word_idx"][i_wtoken] - 1
-            # convert wtoken_doc_idx from 1-idx to 0-idx
-            doc = self.data["wtoken_doc_idx"][i_wtoken] - 1
+            word_token = self.data["wtoken_word_idx"][i_wtoken]
+            doc = self.data["wtoken_doc_idx"][i_wtoken]
             # Probability of sampling current w token from d
             p_wtoken = p_wtoken_g_doc[doc, word_token]
             # Add log-probability of current token to running total for all w tokens

--- a/nimare/annotate/gclda.py
+++ b/nimare/annotate/gclda.py
@@ -38,10 +38,7 @@ def _inv3_logdet(sigma):
     """Invert a 3x3 matrix in closed form and return its log-determinant.
 
     Uses the adjugate formula with a fixed operation order. Unlike LAPACK,
-    this is bit-for-bit reproducible across platforms and BLAS builds, which
-    allows the Rust implementation to match Python exactly. It is also
-    exactly symmetric for symmetric input, and about 2.5x faster than the
-    ``inv`` + ``slogdet`` pair it replaces.
+    this is bit-for-bit reproducible across platforms and BLAS builds.
 
     Parameters
     ----------

--- a/nimare/tests/test_annotate_gclda.py
+++ b/nimare/tests/test_annotate_gclda.py
@@ -121,6 +121,32 @@ def test_gclda_loglikelihood_uses_zero_indexed_tokens(testdata_laird):
     assert np.isclose(w_loglikely, expected_w)
 
 
+def test_gclda_inv3_logdet_matches_lapack_and_is_symmetric():
+    """Closed-form 3x3 inverse must agree with LAPACK and be exactly symmetric."""
+    rng = np.random.default_rng(0)
+    for _ in range(200):
+        m = rng.normal(size=(3, 3)) * rng.uniform(1, 60)
+        sigma = m @ m.T + 50.0 * np.eye(3) * rng.uniform(0.1, 3)
+
+        inv, logdet = annotate.gclda._inv3_logdet(sigma)
+
+        assert np.allclose(inv, np.linalg.inv(sigma), rtol=1e-10)
+        _, ref_logdet = np.linalg.slogdet(sigma)
+        assert np.isclose(logdet, ref_logdet, rtol=1e-12)
+        # Inverse of a symmetric matrix must itself be exactly symmetric.
+        assert np.array_equal(inv, inv.T)
+        # Deterministic: identical inputs give identical bits.
+        inv2, logdet2 = annotate.gclda._inv3_logdet(sigma.copy())
+        assert np.array_equal(inv, inv2) and logdet == logdet2
+
+
+def test_gclda_inv3_logdet_rejects_nonpositive_definite():
+    """A non-positive-definite covariance must raise, as the LAPACK path did."""
+    singular = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0]])
+    with pytest.raises(np.linalg.LinAlgError):
+        annotate.gclda._inv3_logdet(singular)
+
+
 def test_gclda_asymmetric(testdata_laird):
     """A smoke test for GCLDA with three asymmetric regions."""
     counts_df = annotate.text.generate_counts(

--- a/nimare/tests/test_annotate_gclda.py
+++ b/nimare/tests/test_annotate_gclda.py
@@ -58,69 +58,6 @@ def test_gclda_symmetric(testdata_laird):
     assert isinstance(encoded_img, nib.Nifti1Image)
 
 
-def test_gclda_loglikelihood_uses_zero_indexed_tokens(testdata_laird):
-    """Log-likelihood must index documents/words directly, not offset by one.
-
-    Regression test: the indices produced by docidx_mapper are already
-    0-indexed, so subtracting 1 wrapped document 0 to the final document.
-    """
-    counts_df = annotate.text.generate_counts(
-        testdata_laird.texts, text_column="abstract", tfidf=False, min_df=1, max_df=1.0
-    )
-    model = annotate.gclda.GCLDAModel(
-        counts_df,
-        testdata_laird.coordinates,
-        mask=testdata_laird.masker.mask_img,
-        n_topics=5,
-        n_regions=2,
-        symmetric=True,
-    )
-    model._update_regions()
-
-    # Recompute the word log-likelihood independently, with correct indexing.
-    alpha, beta, gamma = model.params["alpha"], model.params["beta"], model.params["gamma"]
-    delta = model.params["delta"]
-    doccounts = model.topics["n_peak_tokens_doc_by_topic"] + gamma
-    docprobs_z = doccounts / np.sum(doccounts, axis=1)[:, None]
-    wordcounts = model.topics["n_word_tokens_word_by_topic"] + beta
-    wordprobs = wordcounts / np.sum(wordcounts, axis=0)[None, :]
-    p_w_g_d = np.dot(docprobs_z, wordprobs.T)
-
-    expected_w = 0.0
-    for i in range(len(model.data["wtoken_word_idx"])):
-        w = model.data["wtoken_word_idx"][i]
-        d = model.data["wtoken_doc_idx"][i]
-        expected_w += np.log(p_w_g_d[d, w])
-
-    # Recompute the peak log-likelihood independently, with correct
-    # (non-offset) indexing into ptoken_doc_idx. This is the other half of
-    # the off-by-one fix: compute_log_likelihood previously subtracted 1
-    # from ptoken_doc_idx (already 0-indexed) as well, which the word-only
-    # assertion above cannot detect.
-    doccounts_y = model.topics["n_peak_tokens_doc_by_topic"] + alpha
-    docprobs_y = doccounts_y / np.sum(doccounts_y, axis=1)[:, None]
-    regioncounts = model.topics["n_peak_tokens_region_by_topic"] + delta
-    regionprobs = regioncounts / np.sum(regioncounts, axis=0)[None, :]
-    peak_probs = model._get_peak_probs(model)
-
-    expected_x = 0.0
-    for i in range(len(model.data["ptoken_doc_idx"])):
-        doc = model.data["ptoken_doc_idx"][i]
-        p_x = 0
-        for j_region in range(model.params["n_regions"]):
-            p_topic_g_doc = docprobs_y[doc]
-            p_region_g_topic = regionprobs[j_region]
-            p_region_g_doc = p_topic_g_doc * p_region_g_topic
-            p_x_r = peak_probs[i, :, j_region]
-            p_x_rd = np.dot(p_region_g_doc, p_x_r)
-            p_x += p_x_rd
-        expected_x += np.log(p_x)
-
-    x_loglikely, w_loglikely, _ = model.compute_log_likelihood(update_vectors=False)
-    assert np.isclose(x_loglikely, expected_x)
-    assert np.isclose(w_loglikely, expected_w)
-
-
 def test_gclda_inv3_logdet_matches_lapack_and_is_symmetric():
     """Closed-form 3x3 inverse must agree with LAPACK and be exactly symmetric."""
     rng = np.random.default_rng(0)

--- a/nimare/tests/test_annotate_gclda.py
+++ b/nimare/tests/test_annotate_gclda.py
@@ -58,6 +58,69 @@ def test_gclda_symmetric(testdata_laird):
     assert isinstance(encoded_img, nib.Nifti1Image)
 
 
+def test_gclda_loglikelihood_uses_zero_indexed_tokens(testdata_laird):
+    """Log-likelihood must index documents/words directly, not offset by one.
+
+    Regression test: the indices produced by docidx_mapper are already
+    0-indexed, so subtracting 1 wrapped document 0 to the final document.
+    """
+    counts_df = annotate.text.generate_counts(
+        testdata_laird.texts, text_column="abstract", tfidf=False, min_df=1, max_df=1.0
+    )
+    model = annotate.gclda.GCLDAModel(
+        counts_df,
+        testdata_laird.coordinates,
+        mask=testdata_laird.masker.mask_img,
+        n_topics=5,
+        n_regions=2,
+        symmetric=True,
+    )
+    model._update_regions()
+
+    # Recompute the word log-likelihood independently, with correct indexing.
+    alpha, beta, gamma = model.params["alpha"], model.params["beta"], model.params["gamma"]
+    delta = model.params["delta"]
+    doccounts = model.topics["n_peak_tokens_doc_by_topic"] + gamma
+    docprobs_z = doccounts / np.sum(doccounts, axis=1)[:, None]
+    wordcounts = model.topics["n_word_tokens_word_by_topic"] + beta
+    wordprobs = wordcounts / np.sum(wordcounts, axis=0)[None, :]
+    p_w_g_d = np.dot(docprobs_z, wordprobs.T)
+
+    expected_w = 0.0
+    for i in range(len(model.data["wtoken_word_idx"])):
+        w = model.data["wtoken_word_idx"][i]
+        d = model.data["wtoken_doc_idx"][i]
+        expected_w += np.log(p_w_g_d[d, w])
+
+    # Recompute the peak log-likelihood independently, with correct
+    # (non-offset) indexing into ptoken_doc_idx. This is the other half of
+    # the off-by-one fix: compute_log_likelihood previously subtracted 1
+    # from ptoken_doc_idx (already 0-indexed) as well, which the word-only
+    # assertion above cannot detect.
+    doccounts_y = model.topics["n_peak_tokens_doc_by_topic"] + alpha
+    docprobs_y = doccounts_y / np.sum(doccounts_y, axis=1)[:, None]
+    regioncounts = model.topics["n_peak_tokens_region_by_topic"] + delta
+    regionprobs = regioncounts / np.sum(regioncounts, axis=0)[None, :]
+    peak_probs = model._get_peak_probs(model)
+
+    expected_x = 0.0
+    for i in range(len(model.data["ptoken_doc_idx"])):
+        doc = model.data["ptoken_doc_idx"][i]
+        p_x = 0
+        for j_region in range(model.params["n_regions"]):
+            p_topic_g_doc = docprobs_y[doc]
+            p_region_g_topic = regionprobs[j_region]
+            p_region_g_doc = p_topic_g_doc * p_region_g_topic
+            p_x_r = peak_probs[i, :, j_region]
+            p_x_rd = np.dot(p_region_g_doc, p_x_r)
+            p_x += p_x_rd
+        expected_x += np.log(p_x)
+
+    x_loglikely, w_loglikely, _ = model.compute_log_likelihood(update_vectors=False)
+    assert np.isclose(x_loglikely, expected_x)
+    assert np.isclose(w_loglikely, expected_w)
+
+
 def test_gclda_asymmetric(testdata_laird):
     """A smoke test for GCLDA with three asymmetric regions."""
     counts_df = annotate.text.generate_counts(


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes none, but addresses two minor issues identified by Claude when I was porting GCLDA to Rust.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- Replace mistaken "1-indexing" with actual 0-indexing in GCLDA log-likelihood estimation.
- Replace LAPACK matrix inversion with closed-form adjugate inverse.

Notes from Claude:

### log-likelihood off-by-one (correctness bug)

`compute_log_likelihood` contains, at `gclda.py:984`, `:1020`, and `:1022`:

```python
doc = self.data["ptoken_doc_idx"][i_ptoken] - 1   # "convert didx from 1-idx to 0-idx"
word_token = self.data["wtoken_word_idx"][i_wtoken] - 1
doc = self.data["wtoken_doc_idx"][i_wtoken] - 1
```

These indices are built by `docidx_mapper = {id_: i for (i, id_) in enumerate(ids)}` and are
**already 0-indexed**. Subtracting 1 maps document 0 to index -1, which wraps to the last
document. Every reported log-likelihood is computed against shifted indices.

This does not corrupt the fitted model — log-likelihood never feeds back into sampling — but
every logged, stored, and plotted likelihood value is wrong.

### LAPACK's 3x3 inverse is NOT reproducible in scalar arithmetic — CONFIRMED PROBLEM

A naive scalar LU with partial pivoting matched `np.linalg.inv` bit-for-bit in only **104 of
3000** trials (worst relative difference 4.0e-13); `slogdet` matched in 2717 of 3000. NumPy
dispatches to OpenBLAS, whose blocked and vectorized kernels depend on build configuration, CPU
features, and threading.

Because these precision matrices feed sampling probabilities directly, a single 1-ulp difference
can flip a sampled index, and the divergence then cascades through every subsequent iteration.

**Resolution — change both sides to a closed-form 3x3 adjugate inverse with a fully specified
operation order.** Peak coordinates are always `(x, y, z)`, so the covariance is always 3x3.
Measured against LAPACK over 3000 random regularized covariances:

| Property | Closed-form adjugate |
|---|---|
| Accuracy vs LAPACK | 4.4e-13 relative (same class as any LU) |
| Self-reproducibility | 3000 / 3000 identical bits |
| Symmetry of result | **Exactly symmetric** (LAPACK's result is not) |
| Speed, 40000 inverse+logdet | **0.064 s vs 0.158 s — 2.5x faster** |

This makes bit-exactness a designed property rather than a coincidence. It also removes 200
LAPACK calls per iteration from the Python hot path and produces the exactly-symmetric inverse
that a covariance inverse mathematically should be. It is a genuine improvement to shipped
NiMARE behavior, not merely a porting convenience.

## Summary by Sourcery

Correct GCLDA likelihood indexing and use deterministic closed-form covariance inversion for reproducible spatial calculations.

Bug Fixes:
- Correct GCLDA log-likelihood calculations to use the already zero-based document and token indices without shifting them.
- Preserve positive-definiteness validation while replacing LAPACK-based covariance inversion with a deterministic closed-form 3x3 inverse and log-determinant calculation.

Enhancements:
- Make GCLDA spatial parameter computation reproducible and ensure inverses of symmetric covariance matrices are exactly symmetric.

Tests:
- Add coverage validating the closed-form inverse against LAPACK, exact symmetry and determinism, and rejection of non-positive-definite matrices.