### PR TITLE
[PERF] reduce test runtime

### DIFF
--- a/nimare/diagnostics.py
+++ b/nimare/diagnostics.py
@@ -457,12 +457,18 @@ class Diagnostics(NiMAREBase):
 
         return list(batches.values())
 
-    def _transform_batch(self, expid, tail_contexts, result, target_value_map=None):
+    def _transform_batch(
+        self, expid, tail_contexts, result, target_value_map=None, image_cache=None
+    ):
         """Apply transform to one study ID for each tail in a batch.
 
         Returns one 1D array per entry in ``tail_contexts``, in the same order. Subclasses
         whose per-experiment work does not vary across a batch should override this to do
         that work once and derive every tail's contributions from it.
+
+        ``image_cache`` is a store the caller shares across every experiment of one
+        :meth:`transform`, for subclasses that would otherwise redo work per experiment that
+        does not depend on the experiment. Diagnostics that read no images ignore it.
         """
         return [
             self._transform(
@@ -523,6 +529,12 @@ class Diagnostics(NiMAREBase):
         self._is_pairwaise_estimator = issubclass(type(result.estimator), PairwiseCBMAEstimator)
         masker = result.estimator.masker
         diag_name = self.__class__.__name__
+
+        # One store per call, shared by every per-experiment job below. Keeping it local means
+        # it is released with this call, rather than living on through the diagnostic that
+        # ``result`` keeps a reference to. Its entries are only valid while the input files
+        # are unchanged, which is another reason not to let it outlive the call.
+        image_cache = {}
 
         # Collect the thresholded cluster map
         if self.target_image in result.maps:
@@ -673,6 +685,7 @@ class Diagnostics(NiMAREBase):
                             batch_contexts,
                             result,
                             target_value_map,
+                            image_cache,
                         )
                         for expid in meta_ids
                     ),
@@ -740,7 +753,7 @@ class Jackknife(Diagnostics):
     averaging the resulting proportion values across all voxels in each cluster.
     """
 
-    def _leave_one_out_values(self, expid, sign, result, target_value_map):
+    def _leave_one_out_values(self, expid, sign, result, target_value_map, image_cache=None):
         """Refit the Estimator without ``expid`` and return voxelwise proportional reductions.
 
         Parameters
@@ -754,6 +767,10 @@ class Jackknife(Diagnostics):
             A MetaResult produced by a coordinate- or image-based meta-analysis.
         target_value_map : :obj:`str`
             Name of the map used for per-cluster contribution calculations.
+        image_cache : :obj:`dict` or None
+            Store shared with the other refits of the same :meth:`transform`, so that the
+            input images are masked once rather than once per left-out study. None masks them
+            afresh, which is what a single refit outside ``transform`` wants.
 
         Returns
         -------
@@ -765,6 +782,13 @@ class Jackknife(Diagnostics):
         # We need to copy the estimator because it will otherwise overwrite the original version
         # with one missing a study in its inputs.
         estimator = copy.deepcopy(result.estimator)
+
+        # Every refit here masks the same files, so hand each copy the one store shared by
+        # this call. It is attached after the copy so that ``deepcopy`` does not duplicate it,
+        # and so that the caller's own estimator is left as it was.
+        share_cache = getattr(estimator, "share_masked_image_cache", None)
+        if share_cache is not None and image_cache is not None:
+            share_cache(image_cache)
 
         if self._is_pairwaise_estimator:
             all_ids = estimator.inputs_["id1"] if sign == POSTAIL_LBL else estimator.inputs_["id2"]
@@ -796,7 +820,9 @@ class Jackknife(Diagnostics):
 
         return 1 - prop_values, estimator.masker
 
-    def _transform_batch(self, expid, tail_contexts, result, target_value_map=None):
+    def _transform_batch(
+        self, expid, tail_contexts, result, target_value_map=None, image_cache=None
+    ):
         """Apply transform to one study ID for each tail in a batch.
 
         The leave-one-out refit is the expensive part and does not vary within a batch, so it
@@ -812,6 +838,7 @@ class Jackknife(Diagnostics):
             tail_contexts[0]["sign"],
             result,
             target_value_map,
+            image_cache,
         )
         return [
             _summarize_cluster_values(

--- a/nimare/diagnostics.py
+++ b/nimare/diagnostics.py
@@ -11,7 +11,6 @@ import pandas as pd
 from joblib import Parallel, delayed
 from nilearn.maskers import NiftiLabelsMasker
 from nilearn.reporting import get_clusters_table
-from scipy.spatial.distance import cdist
 from tqdm.auto import tqdm
 
 from nimare.base import NiMAREBase
@@ -234,6 +233,61 @@ def _get_clusters_table_and_label_maps(
         two_sided or (masked_peak_data < 0).any(),
     )
     return peak_clusters_table, label_maps
+
+
+def _count_foci_per_cluster(label_arr, clust_ids, ijk):
+    """Count how many of ``ijk`` fall within one voxel of each cluster in ``label_arr``.
+
+    A focus counts towards a cluster when some voxel of that cluster lies less than one
+    voxel away from it, which is the same rule as measuring every cluster voxel's distance
+    to every focus and keeping the foci with a hit. Doing it that way costs one pass over the
+    whole volume per cluster, so a map with a few hundred clusters spends minutes on
+    distances that a focus's own neighbourhood already settles: only integer voxels strictly
+    inside a unit ball around the focus can qualify, and there are at most 27 of those.
+
+    Parameters
+    ----------
+    label_arr : 3D :obj:`numpy.ndarray`
+        Cluster label map. Zero is background.
+    clust_ids : :obj:`list`
+        Cluster labels to count for, in the order the counts are returned in.
+    ijk : (N, 3) array_like
+        Matrix subscripts of the foci, which need not be integers.
+
+    Returns
+    -------
+    :obj:`numpy.ndarray`
+        One count per entry of ``clust_ids``.
+    """
+    counts = dict.fromkeys(clust_ids, 0)
+    ijk = np.atleast_2d(np.asarray(ijk, dtype=float))
+    if ijk.size == 0:
+        return np.array([counts[c_val] for c_val in clust_ids])
+
+    shape = np.asarray(label_arr.shape)
+    # The 27 integer offsets around a focus's containing voxel. Every voxel within a unit
+    # distance of any point in that voxel is among them.
+    offsets = np.stack(np.meshgrid(*([np.arange(-1, 2)] * 3), indexing="ij"), axis=-1)
+    offsets = offsets.reshape(-1, 3)
+
+    for focus in ijk:
+        candidates = np.floor(focus).astype(np.int64) + offsets
+        in_bounds = np.all((candidates >= 0) & (candidates < shape), axis=1)
+        candidates = candidates[in_bounds]
+        if not candidates.size:
+            continue
+
+        near = np.sum(np.square(candidates - focus), axis=1) < 1.0
+        candidates = candidates[near]
+        if not candidates.size:
+            continue
+
+        labels = label_arr[candidates[:, 0], candidates[:, 1], candidates[:, 2]]
+        for c_val in np.unique(labels):
+            if c_val in counts:
+                counts[c_val] += 1
+
+    return np.array([counts[c_val] for c_val in clust_ids])
 
 
 def _cluster_masker_kwargs():
@@ -963,17 +1017,7 @@ class FocusCounter(Diagnostics):
         coords = coordinates_df.loc[coordinates_df["id"] == expid]
         ijk = mm2vox(coords[["x", "y", "z"]], affine)
 
-        focus_counts = []
-        for c_val in clust_ids:
-            cluster_mask = label_arr == c_val
-            cluster_idx = np.vstack(np.where(cluster_mask))
-            distances = cdist(cluster_idx.T, ijk)
-            distances = distances < 1
-            distances = np.any(distances, axis=0)
-            n_included_voxels = np.sum(distances)
-            focus_counts.append(n_included_voxels)
-
-        return np.array(focus_counts)
+        return _count_foci_per_cluster(label_arr, clust_ids, ijk)
 
 
 class ResampledStability(NiMAREBase):

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -199,6 +199,10 @@ class IBMAEstimator(Estimator):
             mask = get_masker(mask, memory=memory, memory_level=memory_level)
         self.masker = mask
 
+        # Filled in only when a caller asks for masked images to be reused between fits; see
+        # ``share_masked_image_cache``.
+        self._masked_image_cache = None
+
         super().__init__(
             memory=memory,
             memory_level=memory_level,
@@ -324,6 +328,30 @@ class IBMAEstimator(Estimator):
 
         return resample_to_img(img, mask_img, **self._resample_kwargs)
 
+    def share_masked_image_cache(self, cache):
+        """Reuse already-masked input images across repeated fits of the same studyset.
+
+        A leave-one-out diagnostic fits this estimator once per study, over subsets of one
+        fixed set of images. Masking is per-image and does not depend on which other images
+        are in the fit, so the default -- reload, resample and mask every file on every fit --
+        repeats the same work a number of times that grows with the square of the studyset.
+
+        Parameters
+        ----------
+        cache : :obj:`dict` or None
+            Mapping used to hold one masked row per image path. Callers that want the reuse
+            to span several estimators (the copies a diagnostic refits) must hand the same
+            dict to each of them; passing None turns the reuse off again. The caller owns the
+            dict, and therefore its lifetime: entries live until it is dropped. It is only
+            valid while the files it was filled from are unchanged.
+
+        Notes
+        -----
+        The cached row is never handed out, only copied into each fit's own array, so a
+        caller that edits ``inputs_`` cannot corrupt a later fit.
+        """
+        self._masked_image_cache = cache
+
     def _mask_images(self, masker, mask_img, filenames):
         """Return an (S x V) array holding the in-mask values of each input image.
 
@@ -352,14 +380,23 @@ class IBMAEstimator(Estimator):
             imgs = [self._load_image(filename, mask_img) for filename in filenames]
             return masker.transform(concat_imgs(imgs, ensure_ndim=4))
 
+        # Only the one-image-at-a-time path can be reused, since it is the only one whose
+        # result for a file does not depend on the rest of the fit.
+        cache = getattr(self, "_masked_image_cache", None)
+
         data = None
         for i, filename in enumerate(filenames):
-            # A one-image list keeps the masker on its 4D code path; a bare 3D image comes
-            # back as a 1D array instead.
-            row = masker.transform([self._load_image(filename, mask_img)])
+            row = None if cache is None else cache.get(filename)
+            if row is None:
+                # A one-image list keeps the masker on its 4D code path; a bare 3D image
+                # comes back as a 1D array instead.
+                row = masker.transform([self._load_image(filename, mask_img)])[0]
+                if cache is not None:
+                    cache[filename] = row
+
             if data is None:
-                data = np.empty((len(filenames), row.shape[1]), dtype=row.dtype)
-            data[i] = row[0]
+                data = np.empty((len(filenames), row.shape[0]), dtype=row.dtype)
+            data[i] = row
 
         return data
 

--- a/nimare/tests/conftest.py
+++ b/nimare/tests/conftest.py
@@ -1,6 +1,7 @@
 """Generate fixtures for tests."""
 
 import copy
+import gc
 import os
 from shutil import copyfile
 
@@ -18,6 +19,35 @@ from nimare.utils import get_resource_path, load_json
 
 # Only enable the following once in a while for a check for SettingWithCopyWarnings
 # pd.options.mode.chained_assignment = "raise"
+
+
+@pytest.fixture(autouse=True)
+def _cheap_forced_collections():
+    """Keep the collections nilearn forces from re-walking the whole heap on every image read.
+
+    :func:`nilearn._utils.niimg.safe_get_data` runs a full :func:`gc.collect` every time it
+    reads an image's data array, to stop the transient copy it makes from doubling peak
+    memory. A full collection walks every tracked object, and importing NiMARE's dependency
+    tree alone leaves over 400,000 of them alive, so each call costs ~0.2 s. The suite reads
+    images tens of thousands of times -- once per study for every estimator fit, and once per
+    fit for every leave-one-out refit -- and those collections, not the meta-analyses, were
+    the bulk of the wall clock.
+
+    :func:`gc.freeze` moves the objects alive at this point into the permanent generation,
+    which collections skip, so nilearn's collections only walk what the test itself allocates.
+    Freezing is a splice of the generation lists, not a traversal, so it costs nothing per
+    test. Unfreezing afterwards is what keeps this from being a leak: anything this test
+    stranded is back under the collector's control before the next one starts, so peak memory
+    is bounded by a single test rather than by the session.
+
+    No test's inputs, assertions or tolerances change -- only how long the interpreter spends
+    re-tracing objects that are not going away.
+    """
+    gc.freeze()
+    try:
+        yield
+    finally:
+        gc.unfreeze()
 
 
 @pytest.fixture(scope="session")

--- a/nimare/tests/test_diagnostics.py
+++ b/nimare/tests/test_diagnostics.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from nilearn.maskers import NiftiLabelsMasker
+from scipy.spatial.distance import cdist
 
 from nimare import diagnostics
 from nimare.meta import cbma, ibma
@@ -101,6 +102,61 @@ def test_cluster_ids_survive_a_map_with_no_background():
     # The border must be gone again, so the label map still lines up with the input.
     assert label_maps[0].shape == img.shape
     assert np.array_equal(label_maps[0].affine, img.affine)
+
+
+def test_count_foci_per_cluster_matches_all_pairs_distances():
+    """Focus counts must match measuring every cluster voxel against every focus.
+
+    :func:`nimare.diagnostics._count_foci_per_cluster` only looks at the voxels neighbouring
+    each focus, rather than scanning the volume once per cluster. The two agree because no
+    voxel further away than a focus's own neighbourhood can be within one voxel of it, and
+    this pins that down over shapes, label dtypes, out-of-bounds foci and foci that sit
+    exactly on a voxel centre.
+    """
+
+    def all_pairs(label_arr, clust_ids, ijk):
+        counts = []
+        for c_val in clust_ids:
+            cluster_idx = np.vstack(np.where(label_arr == c_val))
+            distances = cdist(cluster_idx.T, ijk)
+            counts.append(np.sum(np.any(distances < 1, axis=0)))
+        return np.array(counts)
+
+    rng = np.random.default_rng(0)
+    compared = 0
+    for i_trial in range(60):
+        shape = tuple(rng.integers(3, 9, size=3))
+        n_labels = int(rng.integers(1, 6))
+        dtype = rng.choice([np.int16, np.int32, np.float64])
+        label_arr = rng.integers(0, n_labels + 1, size=shape).astype(dtype)
+        clust_ids = diagnostics._cluster_ids(label_arr)
+        if not clust_ids:
+            continue
+
+        # Foci are drawn past the edges of the volume as well as inside it, and every third
+        # trial puts them exactly on voxel centres, which is the boundary case for "within
+        # one voxel".
+        ijk = rng.uniform(-1.5, np.array(shape) + 1.5, size=(int(rng.integers(1, 12)), 3))
+        if i_trial % 3 == 0:
+            ijk = np.round(ijk)
+
+        np.testing.assert_array_equal(
+            diagnostics._count_foci_per_cluster(label_arr, clust_ids, ijk),
+            all_pairs(label_arr, clust_ids, ijk),
+            err_msg=f"trial {i_trial}, shape {shape}",
+        )
+        compared += 1
+
+    assert compared > 40, "too few trials produced clusters to compare"
+
+
+def test_count_foci_per_cluster_with_no_foci():
+    """A study contributing no foci scores zero everywhere, not an empty array."""
+    label_arr = np.array([[[1, 1], [0, 2]]], dtype=np.int16)
+
+    counts = diagnostics._count_foci_per_cluster(label_arr, [1, 2], np.empty((0, 3)))
+
+    assert np.array_equal(counts, [0, 0])
 
 
 def test_cluster_ids_excludes_background():

--- a/nimare/tests/test_meta_cbmr.py
+++ b/nimare/tests/test_meta_cbmr.py
@@ -84,6 +84,28 @@ def inference_results(testdata_cbmr_simulated, cbmr_result):
     )
 
 
+def _assert_frame_equal_by_block(left, right):
+    """Assert two frames match, comparing their values as one block.
+
+    Every check :func:`pandas.testing.assert_frame_equal` makes is made below -- axes,
+    axis names and dtypes, then the values -- but it makes them column by column. These
+    frames carry one row per group and one column per voxel, a few hundred thousand of them,
+    so that walk costs about thirty seconds per table: several times more than fitting the
+    model the table summarizes. The values are compared exactly rather than within a
+    tolerance, so this is the stricter of the two.
+    """
+    for axis_name, left_axis, right_axis in (
+        ("index", left.index, right.index),
+        ("columns", left.columns, right.columns),
+    ):
+        assert left_axis.name == right_axis.name, axis_name
+        assert left_axis.dtype == right_axis.dtype, axis_name
+        assert left_axis.equals(right_axis), axis_name
+
+    assert left.dtypes.equals(right.dtypes)
+    np.testing.assert_array_equal(left.to_numpy(), right.to_numpy())
+
+
 @pytest.fixture(
     scope="session",
     params=[
@@ -296,7 +318,7 @@ def test_cbmr_summary_tables_match_legacy_from_dict_construction(cbmr_result):
         )
 
     for table_name, legacy_table in legacy_tables.items():
-        pd.testing.assert_frame_equal(cbmr_result.tables[table_name], legacy_table)
+        _assert_frame_equal_by_block(cbmr_result.tables[table_name], legacy_table)
 
 
 def test_cbmr_inference(inference_results):

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -325,3 +325,53 @@ def test_mask_images_rejects_an_empty_input(testdata_ibma):
 
     with pytest.raises(ValueError, match="No images were found"):
         estimator._mask_images(testdata_ibma.masker, testdata_ibma.masker.mask_img, [])
+
+
+def test_shared_masked_image_cache_reuses_rows(testdata_ibma, monkeypatch):
+    """A shared store must give the same masked values while loading each file once.
+
+    :class:`~nimare.diagnostics.Jackknife` refits an estimator once per study over subsets of
+    one fixed set of images, so without sharing, the number of times each file is loaded,
+    resampled and masked grows with the size of the studyset.
+    """
+    reference = ibma.Fishers()
+    reference.fit(testdata_ibma)
+    expected = reference.inputs_["z_maps"]
+
+    loaded = []
+    real_load_image = ibma.IBMAEstimator._load_image
+
+    def _counting_load_image(self, filename, mask_img):
+        loaded.append(filename)
+        return real_load_image(self, filename, mask_img)
+
+    monkeypatch.setattr(ibma.IBMAEstimator, "_load_image", _counting_load_image)
+
+    cache = {}
+    for _ in range(2):
+        estimator = ibma.Fishers()
+        estimator.share_masked_image_cache(cache)
+        estimator.fit(testdata_ibma)
+        np.testing.assert_array_equal(estimator.inputs_["z_maps"], expected)
+
+    assert len(loaded) == len(set(loaded)) == len(cache) == expected.shape[0]
+
+
+def test_masked_image_cache_is_off_by_default(testdata_ibma, monkeypatch):
+    """Nothing is held onto, or reused, unless a caller asks for it."""
+    loaded = []
+    real_load_image = ibma.IBMAEstimator._load_image
+
+    def _counting_load_image(self, filename, mask_img):
+        loaded.append(filename)
+        return real_load_image(self, filename, mask_img)
+
+    monkeypatch.setattr(ibma.IBMAEstimator, "_load_image", _counting_load_image)
+
+    estimator = ibma.Fishers()
+    estimator.fit(testdata_ibma)
+    n_images = estimator.inputs_["z_maps"].shape[0]
+    estimator.fit(testdata_ibma)
+
+    assert estimator._masked_image_cache is None
+    assert len(loaded) == 2 * n_images


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Tests are taking an hour+ sometimes and should not be taking that long, this pull request fixes a couple inefficiencies found in the algorithms themselves, and stops nilearn from constantly garbage collecting from nilearn's images.

## Summary by Sourcery

Accelerate the test suite and diagnostic workflows by eliminating redundant distance, image-masking, garbage-collection, and dataframe-comparison work.

Enhancements:
- Reduce diagnostic runtime by replacing exhaustive cluster-to-focus distance calculations with localized neighborhood counting.
- Reuse masked input images across repeated leave-one-out estimator fits to avoid redundant image loading and masking.

Tests:
- Add coverage validating optimized focus counting against exhaustive distance calculations and masked-image cache behavior.
- Speed up large table comparisons in tests through block-wise equality checks and reduce garbage-collection overhead during image-heavy tests.