### PR TITLE
[FIX] Keep assigned Studyset tables through projection rebuilds

### DIFF
--- a/nimare/nimads.py
+++ b/nimare/nimads.py
@@ -772,10 +772,13 @@ class Studyset:
     def __setstate__(self, state):
         """Restore state and re-install mutation tracking after unpickling."""
         self.__dict__.update(state)
+        self.__dict__.setdefault("_table_overrides", {})
         if self._studies is not None:
             self._install_mutation_tracking()
 
-    def _initialize_from_store(self, store, execution_profile, selection_full_ids=None):
+    def _initialize_from_store(
+        self, store, execution_profile, selection_full_ids=None, table_overrides=None
+    ):
         """Initialize Studyset state from a canonical store and execution profile."""
         self.id = store.studyset_id
         self.name = store.studyset_name or ""
@@ -787,16 +790,19 @@ class Studyset:
         )
         self._execution_profile = execution_profile
         self._projection_cache = {}
+        self._table_overrides = {} if table_overrides is None else dict(table_overrides)
         self._revision = 0
         self._studies = None
         self._annotations = None
         self._store_revision = 0
 
     @classmethod
-    def _from_store(cls, store, execution_profile, selection_full_ids=None):
+    def _from_store(cls, store, execution_profile, selection_full_ids=None, table_overrides=None):
         """Create a Studyset from an existing store without reparsing source payloads."""
         studyset = object.__new__(cls)
-        studyset._initialize_from_store(store, execution_profile, selection_full_ids)
+        studyset._initialize_from_store(
+            store, execution_profile, selection_full_ids, table_overrides
+        )
         return studyset
 
     def _selection_key(self):
@@ -865,6 +871,31 @@ class Studyset:
             return self._copy_table_cache(table_cache)
         return table_cache
 
+    def _apply_table_overrides(self, table_cache):
+        """Re-apply caller-assigned tables on top of a store-derived projection.
+
+        Tables assigned through the setters (e.g. the images that
+        :class:`~nimare.transforms.ImageTransformer` derives) are not part of the
+        canonical store, so any projection rebuilt from the store would otherwise
+        revert to the store's values. Rows the override does not cover keep their
+        store-derived values.
+        """
+        if not self._table_overrides:
+            return table_cache
+
+        ids = table_cache.get("ids")
+        selected = None if ids is None else set(np.asarray(ids, dtype=str).tolist())
+        for attr, override in self._table_overrides.items():
+            if selected is not None:
+                override = override.loc[override["id"].astype(str).isin(selected)]
+            base = table_cache.get(attr)
+            if base is not None and not base.empty:
+                retained = base.loc[~base["id"].astype(str).isin(set(override["id"]))]
+                if not retained.empty:
+                    override = pd.concat([override, retained], ignore_index=True)
+            table_cache[attr] = override.sort_values(by="id").reset_index(drop=True)
+        return table_cache
+
     def _get_projected_table_cache(
         self, *, target=None, mask=None, basepath=None, copy_tables=False
     ):
@@ -877,9 +908,11 @@ class Studyset:
         )
         cache_key = self._cache_key(execution_profile)
         if cache_key not in self._projection_cache:
-            self._projection_cache[cache_key] = self._studyset_store.projected_tables(
-                execution_profile,
-                self._selection_full_ids,
+            self._projection_cache[cache_key] = self._apply_table_overrides(
+                self._studyset_store.projected_tables(
+                    execution_profile,
+                    self._selection_full_ids,
+                )
             )
 
         table_cache = self._projection_cache[cache_key]
@@ -1096,6 +1129,11 @@ class Studyset:
         table_cache[attr] = df.sort_values(by="id").reset_index(drop=True)
         if update_ids and "id" in df.columns:
             table_cache["ids"] = np.sort(df["id"].astype(str).unique())
+
+        if not update_ids:
+            # Tables that redefine the ID space (coordinates) are left untracked,
+            # because the store owns the selection those IDs belong to.
+            self._table_overrides[attr] = table_cache[attr]
 
         default_key = self._cache_key(self._execution_profile)
         self._projection_cache[default_key] = table_cache
@@ -1597,6 +1635,7 @@ class Studyset:
             key: self._copy_table_cache(table_cache)
             for key, table_cache in self._projection_cache.items()
         }
+        result._table_overrides = {attr: df.copy() for attr, df in self._table_overrides.items()}
         result._revision = self._revision
         result._store_revision = self._store_revision
         if self._studies is not None:
@@ -1630,7 +1669,10 @@ class Studyset:
         )
         execution_profile = self._copy_execution_profile()
         return self.__class__._from_store(
-            self._studyset_store, execution_profile, selection_full_ids=resolved_ids
+            self._studyset_store,
+            execution_profile,
+            selection_full_ids=resolved_ids,
+            table_overrides=self._table_overrides,
         )
 
     def filter_annotations(self, labels, threshold=0.001, match="all"):

--- a/nimare/tests/test_nimads.py
+++ b/nimare/tests/test_nimads.py
@@ -146,6 +146,52 @@ def test_studyset_copy_preserves_projected_image_columns(tmp_path):
     assert copied.images.loc[0, "varcope__relative"] == "contrast_varcope.nii.gz"
 
 
+def test_studyset_slice_preserves_projected_image_columns(tmp_path):
+    """Derived image columns must survive projection rebuilds.
+
+    Losing them silently turns a leave-one-out refit into a drop-every-derived-map
+    refit (see :meth:`~nimare.diagnostics.Jackknife`).
+    """
+    image_dir = tmp_path / "images"
+    image_dir.mkdir()
+    z_file = image_dir / "contrast_z.nii.gz"
+    z_file.write_text("placeholder")
+    varcope_file = image_dir / "contrast_varcope.nii.gz"
+    varcope_file.write_text("placeholder")
+
+    source = {
+        f"study{i}": {
+            "contrasts": {
+                "contrast1": {
+                    "images": {"z": str(z_file)},
+                    "metadata": {"sample_sizes": [20]},
+                }
+            }
+        }
+        for i in (1, 2, 3)
+    }
+
+    studyset = nimads.Studyset.from_dataset(Dataset(source))
+    images = studyset.images.copy()
+    images["varcope"] = str(varcope_file)
+    studyset.images = images
+
+    kept_ids = sorted(studyset.ids)[:-1]
+    sliced = studyset.slice(kept_ids)
+
+    assert sorted(sliced.images["id"]) == kept_ids
+    assert sliced.images["varcope"].tolist() == [str(varcope_file)] * len(kept_ids)
+    relative = os.path.relpath(str(varcope_file), studyset.basepath)
+    assert sliced.images["varcope__relative"].tolist() == [relative] * len(kept_ids)
+    # The override must keep surviving as the derived Studyset is sliced again,
+    # and as its execution context changes.
+    assert sliced.slice(kept_ids[:1]).images["varcope"].tolist() == [str(varcope_file)]
+    assert studyset.filter_study_ids(["study1"]).images["varcope"].tolist() == [str(varcope_file)]
+    assert (
+        studyset.update_path(str(image_dir)).images["varcope"].tolist() == [str(varcope_file)] * 3
+    )
+
+
 def test_studyset_from_dataset_materialized_preserves_point_values_and_coordinate_metadata():
     """Materialized Studysets should preserve coordinate-side data through NIMADS points."""
     source = {


### PR DESCRIPTION
## Summary

`Studyset.images = df` — which is how `ImageTransformer.transform` records the maps it derives — stored the new table only in the projection cache. `filter_ids` builds the derived Studyset with `_from_store`, which starts from an empty cache and reprojects from the immutable store, so the assignment was silently dropped by `slice`, `filter_study_ids` and `filter_annotations`, and by any execution-context change such as `update_path`.

`Jackknife._leave_one_out_values` refits on `estimator.dataset.slice(...)`, so **every leave-one-out refit lost every derived map** rather than only the analysis being left out. Dropping one of those analyses changed nothing, because all of them were already gone — which is why converted analyses produced byte-identical rows in `..._diag-Jackknife_tab-counts.tsv`.

On the IBMA test data (`test_pain_dataset`), with `ImageTransformer("z")`:

| | before | after |
|---|---|---|
| z maps supplied | 20 | 20 |
| z maps after `ImageTransformer` | 21 | 21 |
| z maps in each of the 21 refits | 19 (×20), 20 (×1) | 20 (×21) |

## Fix

Track caller-assigned tables alongside the projection cache and re-apply them whenever a projection is rebuilt, restricted to the IDs that projection selects, and carry them across `filter_ids` and `deepcopy`.

Rows the assignment does not cover keep their store-derived values, so analyses added after the assignment are unaffected. Coordinates are excluded because that setter redefines the ID space, which the store owns.

## Known remaining gap

Serialization (`to_dict`, `to_nimads`, `to_dataset`) reads the canonical store and so still drops assigned tables. Writing them back into the NIMADS graph is a larger change and is left out of this fix.

## Testing

- New regression test in `nimare/tests/test_nimads.py` covering `slice`, re-slicing a derived Studyset, `filter_study_ids` and `update_path`. It fails on `main` and passes here.
- Full suite green (706 passed, 2 skipped; `test_estimator_performance`, `test_extract` and `test_reports` excluded locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve assigned Studyset tables across projection rebuilds and derived Studyset operations.

Bug Fixes:
- Preserve caller-assigned Studyset tables, including derived image columns, when projections are rebuilt or filtered.
- Ensure derived Studysets and copied instances retain assigned tables across slicing, study filtering, annotation filtering, and execution-context changes.

Enhancements:
- Keep store-derived values for rows not covered by an assigned-table override while excluding coordinate tables from override tracking.

Tests:
- Add regression coverage verifying assigned image columns survive slicing, re-slicing, study filtering, and path updates.