### PR TITLE
Dep/dataset removal 1.0.0

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -211,6 +211,13 @@ historical import path and adds nothing of its own.
 :mod:`nimare.dataset`: Legacy Dataset IO
 --------------------------------------------------
 
+.. warning::
+    :class:`~nimare.dataset.Dataset` is deprecated and will be removed in NiMARE 1.0.0.
+    Constructing one, or passing one to any algorithm, raises a :class:`FutureWarning`.
+    Use :class:`~nimare.studyset.Studyset` instead -- see
+    :meth:`~nimare.studyset.Studyset.from_dataset` and the
+    ``nimare.io.convert_*_to_studyset`` functions for the migration paths.
+
 .. automodule:: nimare.dataset
    :no-members:
    :no-inherited-members:

--- a/nimare/annotate/lda.py
+++ b/nimare/annotate/lda.py
@@ -105,7 +105,7 @@ class LDAModel(NiMAREBase):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         tabular_source = normalize_collection(dset)
 

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -190,7 +190,7 @@ class NiMAREBase(CacheMixin, metaclass=ABCMeta):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and
-            will be removed in a future release. Prefer
+            will be removed in NiMARE 1.0.0. Prefer
             :class:`~nimare.nimads.Studyset`.
         """
         from nimare.studyset import normalize_collection

--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -64,8 +64,8 @@ class Dataset(NiMAREBase):
     Notes
     -----
     .. warning::
-        :class:`~nimare.dataset.Dataset` is deprecated and will be removed in a future
-        release. For new workflows, use :class:`~nimare.nimads.Studyset` instead.
+        :class:`~nimare.dataset.Dataset` is deprecated and will be removed in NiMARE
+        1.0.0. For new workflows, use :class:`~nimare.nimads.Studyset` instead.
         If you need a Dataset-compatible tabular execution view, use
         :meth:`~nimare.nimads.Studyset.view`.
 

--- a/nimare/dataset.py
+++ b/nimare/dataset.py
@@ -1,9 +1,20 @@
-"""Classes for representing datasets of images and/or coordinates."""
+"""Classes for representing datasets of images and/or coordinates.
 
+.. deprecated:: 0.21.0
+    :class:`~nimare.dataset.Dataset` is deprecated and will be removed in NiMARE 1.0.0.
+    Use :class:`~nimare.nimads.Studyset` instead. Constructing a ``Dataset``, or passing
+    one to any NiMARE algorithm, raises a :class:`FutureWarning`; silence them with::
+
+        warnings.filterwarnings("ignore", message=".*nimare.dataset.Dataset is deprecated")
+"""
+
+import contextlib
+import contextvars
 import copy
 import inspect
 import logging
 import os.path as op
+import sys
 import warnings
 
 import numpy as np
@@ -27,6 +38,89 @@ from nimare.utils import (
 )
 
 LGR = logging.getLogger(__name__)
+
+#: Emitted verbatim by every runtime ``Dataset`` deprecation notice, so that users
+#: can silence the whole family with a single ``warnings`` filter.
+DATASET_DEPRECATION_MESSAGE = (
+    "nimare.dataset.Dataset is deprecated and will be removed in NiMARE 1.0.0. "
+    "Use nimare.nimads.Studyset instead: build one with Studyset(source), "
+    "Studyset.from_dataset(dataset), or one of the nimare.io.convert_*_to_studyset "
+    "functions."
+)
+
+
+#: Set while NiMARE is building a ``Dataset`` purely as an internal stepping stone --
+#: a ContextVar rather than a module global so concurrent callers do not silence each
+#: other's warnings.
+_DEPRECATION_SILENCED = contextvars.ContextVar(
+    "nimare_dataset_deprecation_silenced", default=False
+)
+
+
+@contextlib.contextmanager
+def _quiet_dataset_deprecation():
+    """Suppress ``Dataset`` deprecation notices raised inside the block.
+
+    For NiMARE-internal use only, on the paths where a ``Dataset`` is constructed
+    solely to be converted into a :class:`~nimare.nimads.Studyset`. The caller asked
+    for a ``Studyset`` and never sees the intermediate, so warning them about it would
+    point at code they cannot change.
+    """
+    token = _DEPRECATION_SILENCED.set(True)
+    try:
+        yield
+    finally:
+        _DEPRECATION_SILENCED.reset(token)
+
+
+def _user_stacklevel():
+    """Stack level of the nearest frame outside NiMARE.
+
+    A ``Dataset`` is reached by many routes -- directly, via ``nimare.io.convert_*``,
+    via ``nimare.extract.fetch_*`` -- each a different number of frames deep, so the
+    level is found rather than hard-coded. Falls back to the immediate caller when
+    every frame is NiMARE's own.
+    """
+    package_root = op.dirname(op.abspath(__file__))
+    # NiMARE's own tests are callers, not internals -- they should be blamed like
+    # any other user code rather than skipped over into pytest's frames.
+    test_root = op.join(package_root, "tests")
+
+    # 0 is this function, 1 is _warn_dataset_deprecated, 2 is whoever called it.
+    level, frame = 2, sys._getframe(2)
+    while frame is not None:
+        filename = op.abspath(frame.f_code.co_filename)
+        if not filename.startswith(package_root) or filename.startswith(test_root):
+            return level
+        frame, level = frame.f_back, level + 1
+    return 2
+
+
+def _warn_dataset_deprecated(context=""):
+    """Warn that ``Dataset`` is on its way out.
+
+    Parameters
+    ----------
+    context : :obj:`str`, optional
+        Prepended to :data:`DATASET_DEPRECATION_MESSAGE` to say what the caller was
+        doing with the ``Dataset``. Empty for plain instantiation.
+    """
+    if _DEPRECATION_SILENCED.get():
+        return
+
+    message = DATASET_DEPRECATION_MESSAGE
+    if context:
+        message = f"{context} {message}"
+    warnings.warn(message, FutureWarning, stacklevel=_user_stacklevel())
+
+
+def _warn_dataset_input():
+    """Warn that a ``Dataset`` was handed to an algorithm.
+
+    Most algorithms reach this through :func:`~nimare.studyset.normalize_collection`;
+    the few that consume a ``Dataset`` directly, without normalising, call it themselves.
+    """
+    _warn_dataset_deprecated("Passing a Dataset to a NiMARE algorithm is deprecated.")
 
 
 class Dataset(NiMAREBase):
@@ -78,6 +172,8 @@ class Dataset(NiMAREBase):
     _id_cols = ["id", "study_id", "contrast_id"]
 
     def __init__(self, source, target="mni152_2mm", mask=None):
+        _warn_dataset_deprecated()
+
         if isinstance(source, str):
             data = load_json(source)
         elif isinstance(source, dict):

--- a/nimare/decode/base.py
+++ b/nimare/decode/base.py
@@ -72,7 +72,7 @@ class Decoder(NiMAREBase):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
 
         The `fit` method is a light wrapper that runs input validation and
         preprocessing before fitting the actual model. Decoders' individual

--- a/nimare/decode/continuous.py
+++ b/nimare/decode/continuous.py
@@ -248,7 +248,7 @@ class CorrelationDecoder(Decoder):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         self._precomputed_ma_maps_ = None
         self._precomputed_ma_map_id_to_idx_ = None
@@ -531,7 +531,7 @@ class CorrelationDistributionDecoder(Decoder):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         n_features = len(self.features_)
         maps = _collect_feature_maps(

--- a/nimare/decode/discrete.py
+++ b/nimare/decode/discrete.py
@@ -116,7 +116,7 @@ class BrainMapDecoder(Decoder):
 
     .. warning::
         Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed in
-        a future release. Prefer :class:`~nimare.nimads.Studyset`.
+        NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
 
     .. versionadded:: 0.0.3
 
@@ -199,7 +199,7 @@ class BrainMapDecoder(Decoder):
 
         .. warning::
             Fitting decoders on :class:`~nimare.dataset.Dataset` inputs is deprecated and will be
-            removed in a future release. Prefer fitting on
+            removed in NiMARE 1.0.0. Prefer fitting on
             :class:`~nimare.nimads.Studyset`.
         """
         results = brainmap_decode(
@@ -400,7 +400,7 @@ class NeurosynthDecoder(Decoder):
 
     .. warning::
         Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed in
-        a future release. Prefer :class:`~nimare.nimads.Studyset`.
+        NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
 
     .. versionadded:: 0.0.3
 
@@ -495,7 +495,7 @@ class NeurosynthDecoder(Decoder):
 
         .. warning::
             Fitting decoders on :class:`~nimare.dataset.Dataset` inputs is deprecated and will be
-            removed in a future release. Prefer fitting on
+            removed in NiMARE 1.0.0. Prefer fitting on
             :class:`~nimare.nimads.Studyset`.
         """
         results = neurosynth_decode(
@@ -693,7 +693,7 @@ class ROIAssociationDecoder(Decoder):
 
     .. warning::
         Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed in
-        a future release. Prefer :class:`~nimare.nimads.Studyset`.
+        NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
 
     Parameters
     ----------
@@ -772,7 +772,7 @@ class ROIAssociationDecoder(Decoder):
 
         .. warning::
             Fitting decoders on :class:`~nimare.dataset.Dataset` inputs is deprecated and will be
-            removed in a future release. Prefer fitting on
+            removed in NiMARE 1.0.0. Prefer fitting on
             :class:`~nimare.nimads.Studyset`.
         """
         feature_values = self.inputs_["annotations"][self.features_].values

--- a/nimare/diagnostics.py
+++ b/nimare/diagnostics.py
@@ -1408,7 +1408,7 @@ class FocusFilter(NiMAREBase):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         filtered = normalize_collection(dataset)
 

--- a/nimare/estimator.py
+++ b/nimare/estimator.py
@@ -23,7 +23,7 @@ class Estimator(NiMAREBase):
 
     .. warning::
         Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed in
-        a future release. Prefer :class:`~nimare.nimads.Studyset`.
+        NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
     """
 
     def __init__(
@@ -58,7 +58,7 @@ class Estimator(NiMAREBase):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         pass
 
@@ -102,7 +102,7 @@ class Estimator(NiMAREBase):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
 
         The `fit` method is a light wrapper that runs input validation and
         preprocessing before fitting the actual model. Estimators' individual

--- a/nimare/extract/extract.py
+++ b/nimare/extract/extract.py
@@ -1,5 +1,6 @@
 """Tools for downloading datasets."""
 
+import contextlib
 import itertools
 import logging
 import os
@@ -145,14 +146,21 @@ def _materialize_found_databases(found_databases, return_type, target):
             f"Expected one of: {', '.join(sorted(VALID_FETCH_RETURN_TYPES))}."
         )
 
+    from nimare.dataset import _quiet_dataset_deprecation
+
     materialized = []
     for database in found_databases:
-        dataset = convert_neurosynth_to_dataset(
-            coordinates_file=database["coordinates"],
-            metadata_file=database["metadata"],
-            annotations_files=database["features"],
-            target=target,
+        # A studyset request only passes through Dataset; don't warn about the detour.
+        silence = (
+            contextlib.nullcontext() if return_type == "dataset" else _quiet_dataset_deprecation()
         )
+        with silence:
+            dataset = convert_neurosynth_to_dataset(
+                coordinates_file=database["coordinates"],
+                metadata_file=database["metadata"],
+                annotations_files=database["features"],
+                target=target,
+            )
         if return_type == "dataset":
             materialized.append(dataset)
         else:

--- a/nimare/extract/extract.py
+++ b/nimare/extract/extract.py
@@ -249,7 +249,7 @@ def fetch_neurosynth(
         fetch_neurosynth(version="7", source="abstract", vocab="terms")
 
     .. warning::
-        ``return_type="dataset"`` is deprecated and will be removed in a future release.
+        ``return_type="dataset"`` is deprecated and will be removed in NiMARE 1.0.0.
         Prefer the default ``return_type="studyset"``.
 
     .. warning::
@@ -319,7 +319,7 @@ def fetch_neuroquery(
     This function was adapted from neurosynth.base.dataset.download().
 
     .. warning::
-        ``return_type="dataset"`` is deprecated and will be removed in a future release.
+        ``return_type="dataset"`` is deprecated and will be removed in NiMARE 1.0.0.
         Prefer the default ``return_type="studyset"``.
     """
     URL = (
@@ -519,8 +519,8 @@ def download_abstracts(dataset, email):
     dataset : :obj:`~nimare.dataset.Dataset` or :obj:`~nimare.nimads.Studyset`
 
     .. warning::
-        Passing a :class:`~nimare.dataset.Dataset` is deprecated and will be removed in a future
-        release. Prefer passing a :class:`~nimare.nimads.Studyset`.
+        Passing a :class:`~nimare.dataset.Dataset` is deprecated and will be removed in NiMARE
+        1.0.0. Prefer passing a :class:`~nimare.nimads.Studyset`.
 
     This function assumes that the dataset uses identifiers in the format
     [PMID-EXPID]. Thus, the ``study_id`` column of the

--- a/nimare/generate.py
+++ b/nimare/generate.py
@@ -5,7 +5,7 @@ from itertools import zip_longest
 import numpy as np
 import sparse
 
-from nimare.dataset import Dataset
+from nimare.dataset import Dataset, _quiet_dataset_deprecation
 from nimare.io import convert_neurovault_to_dataset
 from nimare.meta.utils import compute_ale_ma, get_ale_kernel
 from nimare.studyset import normalize_collection
@@ -146,17 +146,18 @@ def create_coordinate_studyset(
         Generated foci in xyz (mm) coordinates.
     studyset : :class:`~nimare.nimads.Studyset`
     """
-    ground_truth_foci, dataset = create_coordinate_dataset(
-        foci=foci,
-        foci_percentage=foci_percentage,
-        fwhm=fwhm,
-        sample_size=sample_size,
-        n_studies=n_studies,
-        n_noise_foci=n_noise_foci,
-        seed=seed,
-        space=space,
-    )
-    return ground_truth_foci, normalize_collection(dataset)
+    with _quiet_dataset_deprecation():
+        ground_truth_foci, dataset = create_coordinate_dataset(
+            foci=foci,
+            foci_percentage=foci_percentage,
+            fwhm=fwhm,
+            sample_size=sample_size,
+            n_studies=n_studies,
+            n_noise_foci=n_noise_foci,
+            seed=seed,
+            space=space,
+        )
+        return ground_truth_foci, normalize_collection(dataset)
 
 
 def create_neurovault_dataset(
@@ -222,10 +223,11 @@ def create_neurovault_dataset(
 
 def _neurovault_studyset(collection_ids, contrasts, img_dir, map_type_conversion, **dset_kwargs):
     """Download NeuroVault images and return them as a studyset with z maps."""
-    dataset = convert_neurovault_to_dataset(
-        collection_ids, contrasts, img_dir, map_type_conversion, **dset_kwargs
-    )
-    return ImageTransformer(target="z").transform(dataset)
+    with _quiet_dataset_deprecation():
+        dataset = convert_neurovault_to_dataset(
+            collection_ids, contrasts, img_dir, map_type_conversion, **dset_kwargs
+        )
+        return ImageTransformer(target="z").transform(dataset)
 
 
 def create_neurovault_studyset(

--- a/nimare/generate.py
+++ b/nimare/generate.py
@@ -36,8 +36,8 @@ def create_coordinate_dataset(
     """Generate coordinate based dataset for meta analysis.
 
     .. warning::
-        :class:`~nimare.dataset.Dataset` output is deprecated and will be removed in a future
-        release. Prefer :func:`~nimare.generate.create_coordinate_studyset`.
+        :class:`~nimare.dataset.Dataset` output is deprecated and will be removed in NiMARE
+        1.0.0. Prefer :func:`~nimare.generate.create_coordinate_studyset`.
 
     .. versionadded:: 0.0.4
 
@@ -171,8 +171,8 @@ def create_neurovault_dataset(
     .. versionadded:: 0.0.8
 
     .. warning::
-        :class:`~nimare.dataset.Dataset` output is deprecated and will be removed in a future
-        release. Prefer :func:`~nimare.generate.create_neurovault_studyset`.
+        :class:`~nimare.dataset.Dataset` output is deprecated and will be removed in NiMARE
+        1.0.0. Prefer :func:`~nimare.generate.create_neurovault_studyset`.
 
     This function will also attempt to generate Z images for any contrasts
     for which this is possible.

--- a/nimare/io.py
+++ b/nimare/io.py
@@ -825,16 +825,18 @@ def convert_neurosynth_to_studyset(
     correctness rather than speed; loading a studyset from NIMADS or from a
     parquet release does not go through it.
     """
+    from nimare.dataset import _quiet_dataset_deprecation
     from nimare.studyset import Studyset
     from nimare.studyset.store import replace
 
-    dataset = convert_neurosynth_to_dataset(
-        coordinates_file,
-        metadata_file,
-        annotations_files=annotations_files,
-        feature_groups=feature_groups,
-        target=target,
-    )
+    with _quiet_dataset_deprecation():
+        dataset = convert_neurosynth_to_dataset(
+            coordinates_file,
+            metadata_file,
+            annotations_files=annotations_files,
+            feature_groups=feature_groups,
+            target=target,
+        )
     studyset = Studyset.from_dataset(dataset)
     return Studyset._wrap(
         studyset.view.__class__(
@@ -1448,9 +1450,11 @@ def convert_sleuth_to_studyset(text_file, target="ale_2mm"):
     :obj:`~nimare.nimads.Studyset`
         Studyset object containing experiment information from ``text_file``.
     """
+    from nimare.dataset import _quiet_dataset_deprecation
     from nimare.nimads import Studyset
 
-    dataset = convert_sleuth_to_dataset(text_file, target=target)
+    with _quiet_dataset_deprecation():
+        dataset = convert_sleuth_to_dataset(text_file, target=target)
     return Studyset.from_dataset(dataset)
 
 

--- a/nimare/io.py
+++ b/nimare/io.py
@@ -361,7 +361,7 @@ def convert_nimads_to_dataset(studyset, annotation=None):
         NiMARE Dataset object containing experiment information from nimads studyset.
 
     .. warning::
-        :class:`~nimare.dataset.Dataset` is deprecated and will be removed in a future release.
+        :class:`~nimare.dataset.Dataset` is deprecated and will be removed in NiMARE 1.0.0.
         Prefer keeping data in :class:`~nimare.nimads.Studyset` form and using
         :meth:`~nimare.nimads.Studyset.view` when a Dataset-like tabular view is needed.
     """
@@ -767,8 +767,8 @@ def convert_neurosynth_to_dataset(
         Dataset object containing experiment information from text_file.
 
     .. warning::
-        :class:`~nimare.dataset.Dataset` output is deprecated and will be removed in a future
-        release. When possible, prefer :func:`~nimare.extract.fetch_neurosynth` or
+        :class:`~nimare.dataset.Dataset` output is deprecated and will be removed in NiMARE
+        1.0.0. When possible, prefer :func:`~nimare.extract.fetch_neurosynth` or
         :func:`~nimare.extract.fetch_neuroquery`, which return
         :class:`~nimare.nimads.Studyset` objects by default.
 
@@ -1399,8 +1399,8 @@ def convert_sleuth_to_dataset(text_file, target="ale_2mm"):
     """Convert Sleuth output text file into NiMARE Dataset.
 
     .. warning::
-        :class:`~nimare.dataset.Dataset` output is deprecated and will be removed in a future
-        release. Prefer :func:`~nimare.io.convert_sleuth_to_studyset`.
+        :class:`~nimare.dataset.Dataset` output is deprecated and will be removed in NiMARE
+        1.0.0. Prefer :func:`~nimare.io.convert_sleuth_to_studyset`.
 
     Parameters
     ----------
@@ -1509,8 +1509,8 @@ def convert_dataset_to_nimads_dict(
     """Convert a NiMARE Dataset to a NIMADS Studyset dictionary.
 
     .. warning::
-        :class:`~nimare.dataset.Dataset` input is deprecated and will be removed in a future
-        release. Prefer operating on :class:`~nimare.nimads.Studyset` directly, or convert once
+        :class:`~nimare.dataset.Dataset` input is deprecated and will be removed in NiMARE
+        1.0.0. Prefer operating on :class:`~nimare.nimads.Studyset` directly, or convert once
         with :func:`~nimare.io.convert_dataset_to_studyset`.
 
     Parameters
@@ -1814,8 +1814,8 @@ def convert_dataset_to_studyset(
     also be written to disk (same behavior as :func:`convert_dataset_to_nimads_dict`).
 
     .. warning::
-        :class:`~nimare.dataset.Dataset` input is deprecated and will be removed in a future
-        release. For new workflows, prefer starting from :class:`~nimare.nimads.Studyset`
+        :class:`~nimare.dataset.Dataset` input is deprecated and will be removed in NiMARE
+        1.0.0. For new workflows, prefer starting from :class:`~nimare.nimads.Studyset`
         directly.
 
     Parameters
@@ -1916,8 +1916,8 @@ def convert_neurovault_to_dataset(
     .. versionadded:: 0.0.8
 
     .. warning::
-        :class:`~nimare.dataset.Dataset` output is deprecated and will be removed in a future
-        release. Prefer :func:`~nimare.generate.create_neurovault_studyset`.
+        :class:`~nimare.dataset.Dataset` output is deprecated and will be removed in NiMARE
+        1.0.0. Prefer :func:`~nimare.generate.create_neurovault_studyset`.
 
     Parameters
     ----------

--- a/nimare/meta/cbma/ale.py
+++ b/nimare/meta/cbma/ale.py
@@ -2093,7 +2093,7 @@ class SCALE(CBMAEstimator):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         self.dataset = dataset
         self.masker = self.masker or dataset.masker

--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -47,7 +47,7 @@ class CBMAEstimator(Estimator):
 
     .. warning::
         Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed in
-        a future release. Prefer :class:`~nimare.nimads.Studyset`.
+        NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
 
     .. versionchanged:: 0.12.0
 
@@ -163,7 +163,7 @@ class CBMAEstimator(Estimator):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         validate_coordinate_spaces(self.inputs_["coordinates"])
         masker, mask_img = get_masker_mask_image(
@@ -246,7 +246,7 @@ class CBMAEstimator(Estimator):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         self.dataset = dataset
         self.masker = self.masker or dataset.masker
@@ -1281,7 +1281,7 @@ class PairwiseCBMAEstimator(CBMAEstimator):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
 
         The `fit` method is a light wrapper that runs input validation and
         preprocessing before fitting the actual model. Estimators' individual

--- a/nimare/meta/cbmr.py
+++ b/nimare/meta/cbmr.py
@@ -175,7 +175,7 @@ class CBMREstimator(Estimator):
 
     .. warning::
         Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed in
-        a future release. Prefer :class:`~nimare.nimads.Studyset`.
+        NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
 
     .. versionadded:: 0.1.0
 
@@ -601,7 +601,7 @@ class CBMREstimator(Estimator):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         masker, mask_img = get_masker_mask_image(
             self.masker,
@@ -648,7 +648,7 @@ class CBMREstimator(Estimator):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         init_weight_kwargs = {
             "groups": self.groups,

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -144,7 +144,7 @@ class IBMAEstimator(Estimator):
 
     .. warning::
         Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed in
-        a future release. Prefer :class:`~nimare.nimads.Studyset`.
+        NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
 
     .. versionchanged:: 0.21.0
 
@@ -253,7 +253,7 @@ class IBMAEstimator(Estimator):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         masker, mask_img = get_masker_mask_image(self.masker, dataset=dataset)
 

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -186,7 +186,7 @@ class KernelTransformer(NiMAREBase):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         if return_type not in ("sparse", "array", "image", "summary_array"):
             raise ValueError(

--- a/nimare/meta/kernel.py
+++ b/nimare/meta/kernel.py
@@ -16,7 +16,7 @@ from joblib import Memory
 from scipy import sparse as sp_sparse
 
 from nimare.base import NiMAREBase
-from nimare.dataset import Dataset
+from nimare.dataset import Dataset, _warn_dataset_input
 from nimare.meta.utils import (
     compute_ale_ma,
     compute_kda_ma,
@@ -205,7 +205,11 @@ class KernelTransformer(NiMAREBase):
                 # but has different affine, from original IJK.
                 coordinates[["i", "j", "k"]] = mm2vox(dataset[["x", "y", "z"]], mask.affine)
         else:
-            if not isinstance(dataset, Dataset):
+            if isinstance(dataset, Dataset):
+                # Kernels read a Dataset directly rather than normalising it, so the
+                # deprecation notice has to be raised here instead.
+                _warn_dataset_input()
+            else:
                 dataset = normalize_collection(dataset)
 
             masker = dataset.masker if not masker else masker

--- a/nimare/studyset/normalize.py
+++ b/nimare/studyset/normalize.py
@@ -17,13 +17,19 @@ def normalize_collection(collection):
     A :class:`~nimare.dataset.Dataset` is converted here, at the boundary, so
     that nothing downstream has to know about it. ``Dataset`` is deprecated; the
     conversion is correctness-first, not speed-first.
+
+    Passing a ``Dataset`` emits a :class:`FutureWarning`. Nearly every algorithm
+    entry point warns from here; the exception is
+    :meth:`~nimare.meta.kernel.KernelTransformer.transform`, which reads a ``Dataset``
+    without normalising it and so raises the notice itself.
     """
-    from nimare.dataset import Dataset
+    from nimare.dataset import Dataset, _warn_dataset_input
     from nimare.studyset.studyset import Studyset
 
     if isinstance(collection, Studyset):
         return collection
     if isinstance(collection, Dataset):
+        _warn_dataset_input()
         return Studyset.from_dataset(collection)
     if isinstance(collection, (dict, str)):
         return Studyset(collection)

--- a/nimare/tests/test_dataset.py
+++ b/nimare/tests/test_dataset.py
@@ -11,7 +11,11 @@ import pytest
 
 import nimare
 from nimare import dataset
+from nimare.dataset import _quiet_dataset_deprecation
+from nimare.generate import create_coordinate_dataset, create_coordinate_studyset
+from nimare.meta.kernel import MKDAKernel
 from nimare.nimads import Studyset
+from nimare.studyset import normalize_collection
 from nimare.tests.utils import get_test_data_path
 from nimare.utils import load_json
 
@@ -225,3 +229,89 @@ def test_posneg_warning():
     assert isinstance(dset_posneg, nimare.dataset.Dataset)
     assert isinstance(dset_pos, nimare.dataset.Dataset)
     assert isinstance(dset_neg, nimare.dataset.Dataset)
+
+
+# ---------------------------------------------------------------------------
+# Deprecation: Dataset is removed in NiMARE 1.0.0
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def _pain_source():
+    """Raw NIMADS-ish dict for the NIDM pain dataset."""
+    return load_json(op.join(get_test_data_path(), "nidm_pain_dset.json"))
+
+
+def test_instantiating_a_dataset_warns(_pain_source):
+    """Constructing a Dataset points the user at Studyset."""
+    with pytest.warns(FutureWarning, match=r"Dataset is deprecated and will be removed in NiMARE"):
+        dset = dataset.Dataset(_pain_source)
+
+    assert isinstance(dset, dataset.Dataset)
+
+
+def test_dataset_deprecation_blames_the_caller(_pain_source):
+    """The warning points at user code, not at nimare/dataset.py."""
+    with pytest.warns(FutureWarning) as record:
+        dataset.Dataset(_pain_source)
+
+    assert op.basename(record[0].filename) == "test_dataset.py"
+
+
+def test_passing_a_dataset_to_an_algorithm_warns(_pain_source):
+    """Every algorithm entry point goes through normalize_collection, which warns."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        dset = dataset.Dataset(_pain_source)
+
+    with pytest.warns(FutureWarning, match=r"Passing a Dataset to a NiMARE algorithm"):
+        normalize_collection(dset)
+
+
+def test_kernel_transformer_warns_on_a_dataset(_pain_source):
+    """Kernels read a Dataset directly, so they raise the notice themselves."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        dset = dataset.Dataset(_pain_source)
+
+    with pytest.warns(FutureWarning, match=r"Passing a Dataset to a NiMARE algorithm"):
+        MKDAKernel().transform(dset, return_type="array")
+
+
+def test_passing_a_studyset_to_an_algorithm_is_quiet(_pain_source):
+    """The supported input must not warn."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        studyset = Studyset.from_dataset(dataset.Dataset(_pain_source))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        assert normalize_collection(studyset) is studyset
+
+
+def test_studyset_native_helpers_do_not_warn():
+    """A Dataset built only as an internal stepping stone stays invisible."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", FutureWarning)
+        _, studyset = create_coordinate_studyset(n_studies=3, sample_size=10, seed=42)
+
+    assert isinstance(studyset, Studyset)
+
+
+def test_dataset_producing_helpers_still_warn():
+    """Asking for a Dataset by name warns, even through a factory function."""
+    with pytest.warns(FutureWarning, match=r"Dataset is deprecated and will be removed in NiMARE"):
+        _, dset = create_coordinate_dataset(n_studies=3, sample_size=10, seed=42)
+
+    assert isinstance(dset, dataset.Dataset)
+
+
+def test_quiet_dataset_deprecation_restores_state(_pain_source):
+    """The internal silencer is scoped, not sticky."""
+    with _quiet_dataset_deprecation():
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            dataset.Dataset(_pain_source)
+
+    with pytest.warns(FutureWarning):
+        dataset.Dataset(_pain_source)

--- a/nimare/tests/test_dataset.py
+++ b/nimare/tests/test_dataset.py
@@ -218,6 +218,7 @@ def test_posneg_warning():
     # Test Warning is not raised if there are only positive or negative z-stat
     with warnings.catch_warnings():
         warnings.simplefilter("error")
+        warnings.filterwarnings("ignore", category=FutureWarning)  # Dataset deprecation
         dset_pos = dataset.Dataset(data_pos_zstats)
         dset_neg = dataset.Dataset(data_neg_zstats)
 

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -113,7 +113,7 @@ class ImageTransformer(NiMAREBase):
 
     .. warning::
         Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed in
-        a future release. Prefer :class:`~nimare.nimads.Studyset`.
+        NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
 
     .. versionadded:: 0.0.9
 
@@ -151,7 +151,7 @@ class ImageTransformer(NiMAREBase):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         dataset = normalize_collection(dataset)
 
@@ -516,7 +516,7 @@ class ImagesToCoordinates(NiMAREBase):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         dataset = normalize_collection(dataset)
 
@@ -709,7 +709,7 @@ class StandardizeField(NiMAREBase):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         dataset = normalize_collection(dataset)
 

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -1134,7 +1134,7 @@ def _add_metadata_to_dataframe(
 
     .. warning::
         Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed in
-        a future release. Prefer passing a :class:`~nimare.nimads.Studyset` when possible.
+        NiMARE 1.0.0. Prefer passing a :class:`~nimare.nimads.Studyset` when possible.
     """
     dataframe = dataframe.copy()
     metadata_fields = [metadata_field] if isinstance(metadata_field, str) else list(metadata_field)

--- a/nimare/workflows/cbma.py
+++ b/nimare/workflows/cbma.py
@@ -95,7 +95,7 @@ class CBMAWorkflow(Workflow):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         LGR.info("Performing meta-analysis...")
         results = self.estimator.fit(dataset, drop_invalid=drop_invalid)
@@ -171,7 +171,7 @@ class PairwiseCBMAWorkflow(Workflow):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         LGR.info("Performing meta-analysis...")
         results = self.estimator.fit(dataset1, dataset2, drop_invalid=drop_invalid)

--- a/nimare/workflows/ibma.py
+++ b/nimare/workflows/ibma.py
@@ -92,7 +92,7 @@ class IBMAWorkflow(Workflow):
 
         .. warning::
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
-            in a future release. Prefer :class:`~nimare.nimads.Studyset`.
+            in NiMARE 1.0.0. Prefer :class:`~nimare.nimads.Studyset`.
         """
         dataset = normalize_collection(dataset)
 

--- a/nimare/workflows/macm.py
+++ b/nimare/workflows/macm.py
@@ -24,7 +24,7 @@ def macm_workflow(
     """Perform MACM with ALE algorithm.
 
     .. warning::
-        The legacy Dataset-file workflow is deprecated and will be removed in a future release.
+        The legacy Dataset-file workflow is deprecated and will be removed in NiMARE 1.0.0.
         Prefer loading a :class:`~nimare.nimads.Studyset` directly and using
         :meth:`~nimare.nimads.Studyset.get_studies_by_mask` plus
         :meth:`~nimare.nimads.Studyset.slice` before fitting an estimator.


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Prepare the Dataset API for removal in NiMARE 1.0.0 by warning users consistently and guiding them toward Studyset-based workflows.

Enhancements:
- Add runtime deprecation warnings for Dataset construction and use as algorithm input, directing users to the Studyset API and identifying user call sites.
- Suppress deprecation warnings for internal Dataset conversion paths that return Studyset objects while preserving warnings for Dataset-producing APIs.
- Update user-facing API documentation to state that Dataset support will be removed in NiMARE 1.0.0.

Documentation:
- Update Dataset-related deprecation notices throughout the API documentation and docstrings to specify removal in NiMARE 1.0.0 and recommend Studyset workflows.

Tests:
- Add coverage for Dataset deprecation warnings, caller attribution, supported Studyset behavior, internal conversion suppression, and warning-state restoration.