### PR TITLE
[FIX] warn unsigned p to z

### DIFF
--- a/nimare/tests/test_transforms.py
+++ b/nimare/tests/test_transforms.py
@@ -97,89 +97,56 @@ def test_resolve_transforms_warns_on_multiple_group_sample_sizes(testdata_ibma, 
     assert "one-sample" in caplog.text
 
 
-def _p_map(masker, rng=None):
-    """Write a p map over the masker's voxels, as an image object."""
-    rng = np.random.RandomState(0) if rng is None else rng
-    n_voxels = masker.transform(masker.mask_img).size
-    return masker.inverse_transform(rng.uniform(1e-4, 1.0, size=n_voxels))
-
-
-@pytest.mark.parametrize("target", ["z", "t", "g"])
-def test_resolve_transforms_warns_when_z_comes_from_a_p_map(testdata_ibma, caplog, target):
-    """A p map has no direction, so the z it yields is unsigned. Convert, but say so.
-
-    The warning has to survive the recursion as well: 't', 'g' and the rest reach z first,
-    and inherit its missing sign.
-    """
-    masker = testdata_ibma.masker
-    available = {"p": _p_map(masker), "sample_sizes": [20]}
-
-    with caplog.at_level(logging.WARNING, logger="nimare.transforms"):
-        img = transforms.resolve_transforms(target, available, masker)
-
-    assert img is not None
-    assert "unsigned" in caplog.text
-    assert "p map" in caplog.text
-    if target == "z":
-        values = masker.transform(img)
-        assert (values[np.isfinite(values)] >= 0).all()
-
-
-def test_resolve_transforms_takes_the_sign_from_t_without_a_sample_size(testdata_ibma, caplog):
-    """A t map with no sample size cannot set the magnitude, but it can still set the sign."""
+@pytest.mark.parametrize(
+    "sources,warns",
+    [(("t", "p", "sample_sizes"), False), (("t", "p"), False), (("p",), True)],
+)
+def test_resolve_transforms_z_from_p_takes_any_sign_on_offer(
+    testdata_ibma, caplog, sources, warns
+):
+    """Only a p map with no t beside it yields an unsigned z, and only that case warns."""
     masker = testdata_ibma.masker
     rng = np.random.RandomState(1)
     n_voxels = masker.transform(masker.mask_img).size
     t_values = rng.normal(size=n_voxels)
-    t_values[:3] = [0.0, 5.0, -5.0]
+    t_values[0] = 0.0
     p_values = rng.uniform(1e-4, 0.9, size=n_voxels)
-    available = {
+    data = {
         "t": masker.inverse_transform(t_values),
         "p": masker.inverse_transform(p_values),
+        "sample_sizes": [20],
     }
+    expected = {
+        ("t", "p", "sample_sizes"): transforms.t_to_z(t_values, 19),
+        ("t", "p"): np.sign(t_values) * transforms.p_to_z(p_values),
+        ("p",): transforms.p_to_z(p_values),
+    }[sources]
 
     with caplog.at_level(logging.WARNING, logger="nimare.transforms"):
-        img = transforms.resolve_transforms("z", available, masker)
+        img = transforms.resolve_transforms("z", {k: data[k] for k in sources}, masker)
 
-    z = masker.transform(img).squeeze()
-    assert np.allclose(z, np.sign(t_values) * transforms.p_to_z(p_values), atol=1e-4)
-    assert (z < 0).any()
-    # A t of exactly 0 has no direction to give, and is a p of 1, whose z is 0 regardless.
-    assert z[0] == 0
-    # The map is signed, so the warning reserved for unsigned ones must stay quiet.
-    assert "unsigned" not in caplog.text
-
-
-def test_resolve_transforms_does_not_warn_when_z_comes_from_a_t_map(testdata_ibma, caplog):
-    """The t path keeps the sign, so it must stay quiet. This is the asymmetry being fixed."""
-    row = testdata_ibma.images.iloc[0]
-
-    with caplog.at_level(logging.WARNING, logger="nimare.transforms"):
-        img = transforms.resolve_transforms(
-            "z", {"t": row["t"], "sample_sizes": [20]}, testdata_ibma.masker
-        )
-
-    assert img is not None
-    assert "unsigned" not in caplog.text
+    np.testing.assert_allclose(masker.transform(img).squeeze(), expected, atol=1e-4)
+    assert ("unsigned" in caplog.text) is warns
 
 
 def test_transform_images_names_the_analysis_in_the_unsigned_warning(
     testdata_ibma, caplog, tmp_path
 ):
-    """Name the analysis, so a studyset of many maps says which one lost its sign."""
+    """A studyset of many maps has to say which one lost its sign."""
     masker = testdata_ibma.masker
     p_file = str(tmp_path / "p.nii.gz")
-    _p_map(masker).to_filename(p_file)
-    images_df = pd.DataFrame({"id": ["study1-1"], "p": [p_file]})
+    n_voxels = masker.transform(masker.mask_img).size
+    masker.inverse_transform(np.full(n_voxels, 0.05)).to_filename(p_file)
 
     with caplog.at_level(logging.WARNING, logger="nimare.transforms"):
-        new_images_df = transforms.transform_images(
-            images_df, target="z", masker=masker, out_dir=str(tmp_path)
+        transforms.transform_images(
+            pd.DataFrame({"id": ["study1-1"], "p": [p_file]}),
+            target="z",
+            masker=masker,
+            out_dir=str(tmp_path),
         )
 
-    assert new_images_df["z"].notnull().all()
     assert "study1-1: " in caplog.text
-    assert "unsigned" in caplog.text
 
 
 def test_transform_images(testdata_ibma):

--- a/nimare/tests/test_transforms.py
+++ b/nimare/tests/test_transforms.py
@@ -6,6 +6,7 @@ import time
 
 import nibabel as nib
 import numpy as np
+import pandas as pd
 import pytest
 from pymare.stats import log_chi2_sf
 from scipy import stats
@@ -94,6 +95,66 @@ def test_resolve_transforms_warns_on_multiple_group_sample_sizes(testdata_ibma, 
         )
 
     assert "one-sample" in caplog.text
+
+
+def _p_map(masker, rng=None):
+    """Write a p map over the masker's voxels, as an image object."""
+    rng = np.random.RandomState(0) if rng is None else rng
+    n_voxels = masker.transform(masker.mask_img).size
+    return masker.inverse_transform(rng.uniform(1e-4, 1.0, size=n_voxels))
+
+
+@pytest.mark.parametrize("target", ["z", "t", "g"])
+def test_resolve_transforms_warns_when_z_comes_from_a_p_map(testdata_ibma, caplog, target):
+    """A p map has no direction, so the z it yields is unsigned. Convert, but say so.
+
+    The warning has to survive the recursion as well: 't', 'g' and the rest reach z first,
+    and inherit its missing sign.
+    """
+    masker = testdata_ibma.masker
+    available = {"p": _p_map(masker), "sample_sizes": [20]}
+
+    with caplog.at_level(logging.WARNING, logger="nimare.transforms"):
+        img = transforms.resolve_transforms(target, available, masker)
+
+    assert img is not None
+    assert "unsigned" in caplog.text
+    assert "p map" in caplog.text
+    if target == "z":
+        values = masker.transform(img)
+        assert (values[np.isfinite(values)] >= 0).all()
+
+
+def test_resolve_transforms_does_not_warn_when_z_comes_from_a_t_map(testdata_ibma, caplog):
+    """The t path keeps the sign, so it must stay quiet. This is the asymmetry being fixed."""
+    row = testdata_ibma.images.iloc[0]
+
+    with caplog.at_level(logging.WARNING, logger="nimare.transforms"):
+        img = transforms.resolve_transforms(
+            "z", {"t": row["t"], "sample_sizes": [20]}, testdata_ibma.masker
+        )
+
+    assert img is not None
+    assert "unsigned" not in caplog.text
+
+
+def test_transform_images_names_the_analysis_in_the_unsigned_warning(
+    testdata_ibma, caplog, tmp_path
+):
+    """Name the analysis, so a studyset of many maps says which one lost its sign."""
+    masker = testdata_ibma.masker
+    p_file = str(tmp_path / "p.nii.gz")
+    _p_map(masker).to_filename(p_file)
+    images_df = pd.DataFrame({"id": ["study1-1"], "p": [p_file]})
+
+    with caplog.at_level(logging.WARNING, logger="nimare.transforms"):
+        new_images_df = transforms.transform_images(
+            images_df, target="z", masker=masker, out_dir=str(tmp_path)
+        )
+
+    assert new_images_df["z"].notnull().all()
+    assert "study1-1: " in caplog.text
+    assert "unsigned" in caplog.text
 
 
 def test_transform_images(testdata_ibma):

--- a/nimare/tests/test_transforms.py
+++ b/nimare/tests/test_transforms.py
@@ -125,6 +125,31 @@ def test_resolve_transforms_warns_when_z_comes_from_a_p_map(testdata_ibma, caplo
         assert (values[np.isfinite(values)] >= 0).all()
 
 
+def test_resolve_transforms_takes_the_sign_from_t_without_a_sample_size(testdata_ibma, caplog):
+    """A t map with no sample size cannot set the magnitude, but it can still set the sign."""
+    masker = testdata_ibma.masker
+    rng = np.random.RandomState(1)
+    n_voxels = masker.transform(masker.mask_img).size
+    t_values = rng.normal(size=n_voxels)
+    t_values[:3] = [0.0, 5.0, -5.0]
+    p_values = rng.uniform(1e-4, 0.9, size=n_voxels)
+    available = {
+        "t": masker.inverse_transform(t_values),
+        "p": masker.inverse_transform(p_values),
+    }
+
+    with caplog.at_level(logging.WARNING, logger="nimare.transforms"):
+        img = transforms.resolve_transforms("z", available, masker)
+
+    z = masker.transform(img).squeeze()
+    assert np.allclose(z, np.sign(t_values) * transforms.p_to_z(p_values), atol=1e-4)
+    assert (z < 0).any()
+    # A t of exactly 0 has no direction to give, and is a p of 1, whose z is 0 regardless.
+    assert z[0] == 0
+    # The map is signed, so the warning reserved for unsigned ones must stay quiet.
+    assert "unsigned" not in caplog.text
+
+
 def test_resolve_transforms_does_not_warn_when_z_comes_from_a_t_map(testdata_ibma, caplog):
     """The t path keeps the sign, so it must stay quiet. This is the asymmetry being fixed."""
     row = testdata_ibma.images.iloc[0]

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -273,7 +273,7 @@ def transform_images(images_df, target, masker, metadata_df=None, out_dir=None, 
                     available_data[k] = v
 
         # Get converted data
-        img = resolve_transforms(target, available_data, new_masker, id_=id_)
+        img = resolve_transforms(target, available_data, new_masker)
         if img is not None:
             if overwrite or not op.isfile(new_file):
                 img.to_filename(new_file)
@@ -291,14 +291,13 @@ def transform_images(images_df, target, masker, metadata_df=None, out_dir=None, 
     return new_images_df
 
 
-def resolve_transforms(target, available_data, masker, id_=None):
+def resolve_transforms(target, available_data, masker):
     """Determine and apply the appropriate transforms to a target image type from available data.
 
     .. versionchanged:: 0.21.0
 
         * [FIX] Take the sign from a t map when converting a p map without a sample size.
         * [ENH] Warn when ``z`` is converted from a p map with no sign available.
-        * [ENH] Accept ``id_``, to name the analysis in that warning.
 
     .. versionchanged:: 0.0.8
 
@@ -320,8 +319,6 @@ def resolve_transforms(target, available_data, masker, id_=None):
         Masker used to convert images to arrays and back. Preferably, this mask
         should cover the full acquisition matrix (rather than an ROI), given
         that the calculated images will be saved and used for the full Dataset.
-    id_ : :obj:`str` or None, optional
-        Identifier of the analysis, used to name it in warnings. Default is None.
 
     Returns
     -------
@@ -355,7 +352,9 @@ def resolve_transforms(target, available_data, masker, id_=None):
                 t = masker.transform(available_data["t"])
                 z = np.sign(t) * z
             else:
-                prefix = f"{id_}: " if id_ is not None else ""
+                # transform_images builds available_data from the whole images_df row,
+                # so the analysis id is already here to name in the warning.
+                prefix = f"{available_data['id']}: " if "id" in available_data else ""
                 LGR.warning(
                     f"{prefix}Deriving 'z' from a p map, with nothing in the analysis to "
                     "give the direction. A p-value carries no sign, so the result is "
@@ -369,7 +368,7 @@ def resolve_transforms(target, available_data, masker, id_=None):
         return z
     elif target == "t":
         # will return none given no transform/target exists
-        temp = resolve_transforms("z", available_data, masker, id_=id_)
+        temp = resolve_transforms("z", available_data, masker)
         if temp is not None:
             available_data["z"] = temp
 
@@ -385,7 +384,7 @@ def resolve_transforms(target, available_data, masker, id_=None):
         # All three start from t and the sample size. t itself resolves from z, so a
         # studyset holding only z maps can still reach a standardized effect size.
         if "t" not in available_data.keys():
-            temp = resolve_transforms("t", available_data, masker, id_=id_)
+            temp = resolve_transforms("t", available_data, masker)
             if temp is not None:
                 available_data["t"] = temp
 
@@ -414,12 +413,12 @@ def resolve_transforms(target, available_data, masker, id_=None):
     elif target == "beta":
         if "t" not in available_data.keys():
             # will return none given no transform/target exists
-            temp = resolve_transforms("t", available_data, masker, id_=id_)
+            temp = resolve_transforms("t", available_data, masker)
             if temp is not None:
                 available_data["t"] = temp
 
         if "varcope" not in available_data.keys():
-            temp = resolve_transforms("varcope", available_data, masker, id_=id_)
+            temp = resolve_transforms("varcope", available_data, masker)
             if temp is not None:
                 available_data["varcope"] = temp
 

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -363,7 +363,8 @@ def resolve_transforms(target, available_data, masker, id_=None):
                 LGR.warning(
                     f"{prefix}Deriving 'z' from a p map, with nothing in the analysis to "
                     "give the direction. A p-value carries no sign, so the result is "
-                    "unsigned. This will be invalid input for signed tests (like Stouffers and Fishers)."
+                    "unsigned. "
+                    "This will be invalid input for signed tests (like Stouffers)."
                 )
         else:
             return None

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -273,7 +273,7 @@ def transform_images(images_df, target, masker, metadata_df=None, out_dir=None, 
                     available_data[k] = v
 
         # Get converted data
-        img = resolve_transforms(target, available_data, new_masker)
+        img = resolve_transforms(target, available_data, new_masker, id_=id_)
         if img is not None:
             if overwrite or not op.isfile(new_file):
                 img.to_filename(new_file)
@@ -291,8 +291,13 @@ def transform_images(images_df, target, masker, metadata_df=None, out_dir=None, 
     return new_images_df
 
 
-def resolve_transforms(target, available_data, masker):
+def resolve_transforms(target, available_data, masker, id_=None):
     """Determine and apply the appropriate transforms to a target image type from available data.
+
+    .. versionchanged:: 0.21.0
+
+        * [ENH] Warn when ``z`` is derived from a p map, because that ``z`` is unsigned.
+        * [ENH] Accept ``id_``, so that warning can name the analysis it came from.
 
     .. versionchanged:: 0.0.8
 
@@ -314,12 +319,21 @@ def resolve_transforms(target, available_data, masker):
         Masker used to convert images to arrays and back. Preferably, this mask
         should cover the full acquisition matrix (rather than an ROI), given
         that the calculated images will be saved and used for the full Dataset.
+    id_ : :obj:`str` or None, optional
+        Identifier of the analysis the data belong to. Used only to name the analysis in
+        warnings. Default is None.
 
     Returns
     -------
     img_like or None
         Image object with the desired data type, if it can be generated.
         Otherwise, None.
+
+    Notes
+    -----
+    A ``z`` map derived from a p map is unsigned, since a p-value does not record the
+    direction of its effect, and so is anything derived from it in turn (``t``, ``beta``,
+    ``d``, ``g``). That conversion is still performed, but it warns.
     """
     if target in available_data.keys():
         LGR.warning(f"Target '{target}' already available.")
@@ -333,13 +347,22 @@ def resolve_transforms(target, available_data, masker):
         elif "p" in available_data.keys():
             p = masker.transform(available_data["p"])
             z = p_to_z(p)
+            prefix = f"{id_}: " if id_ is not None else ""
+            LGR.warning(
+                f"{prefix}Deriving 'z' from a p map. A p-value carries no direction, so "
+                "the result is unsigned: every voxel is positive. In a signed test "
+                "(Stouffers, Fishers) this analysis then contributes positive evidence "
+                "only, whichever way its contrast ran, and biases the pooled result "
+                "towards it. Supply a z map, or a t map with a sample size, to keep the "
+                "sign."
+            )
         else:
             return None
         z = masker.inverse_transform(z.squeeze())
         return z
     elif target == "t":
         # will return none given no transform/target exists
-        temp = resolve_transforms("z", available_data, masker)
+        temp = resolve_transforms("z", available_data, masker, id_=id_)
         if temp is not None:
             available_data["z"] = temp
 
@@ -355,7 +378,7 @@ def resolve_transforms(target, available_data, masker):
         # All three start from t and the sample size. t itself resolves from z, so a
         # studyset holding only z maps can still reach a standardized effect size.
         if "t" not in available_data.keys():
-            temp = resolve_transforms("t", available_data, masker)
+            temp = resolve_transforms("t", available_data, masker, id_=id_)
             if temp is not None:
                 available_data["t"] = temp
 
@@ -384,12 +407,12 @@ def resolve_transforms(target, available_data, masker):
     elif target == "beta":
         if "t" not in available_data.keys():
             # will return none given no transform/target exists
-            temp = resolve_transforms("t", available_data, masker)
+            temp = resolve_transforms("t", available_data, masker, id_=id_)
             if temp is not None:
                 available_data["t"] = temp
 
         if "varcope" not in available_data.keys():
-            temp = resolve_transforms("varcope", available_data, masker)
+            temp = resolve_transforms("varcope", available_data, masker, id_=id_)
             if temp is not None:
                 available_data["varcope"] = temp
 

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -297,8 +297,8 @@ def resolve_transforms(target, available_data, masker, id_=None):
     .. versionchanged:: 0.21.0
 
         * [FIX] Take the sign from a t map when converting a p map without a sample size.
-        * [ENH] Warn when ``z`` is derived from a p map with no sign available anywhere.
-        * [ENH] Accept ``id_``, so that warning can name the analysis it came from.
+        * [ENH] Warn when ``z`` is converted from a p map with no sign available.
+        * [ENH] Accept ``id_``, to name the analysis in that warning.
 
     .. versionchanged:: 0.0.8
 
@@ -321,8 +321,7 @@ def resolve_transforms(target, available_data, masker, id_=None):
         should cover the full acquisition matrix (rather than an ROI), given
         that the calculated images will be saved and used for the full Dataset.
     id_ : :obj:`str` or None, optional
-        Identifier of the analysis the data belong to. Used only to name the analysis in
-        warnings. Default is None.
+        Identifier of the analysis, used to name it in warnings. Default is None.
 
     Returns
     -------
@@ -332,11 +331,10 @@ def resolve_transforms(target, available_data, masker, id_=None):
 
     Notes
     -----
-    A p-value does not record the direction of its effect, so a ``z`` derived from a p map
-    and nothing else is unsigned, as is anything derived from it in turn (``t``, ``beta``,
-    ``d``, ``g``). That conversion is still performed, but it warns. A t map in the same
-    analysis supplies the direction even when it is missing the sample size the magnitude
-    would need, and the sign is taken from it instead, silently.
+    A p-value has no direction, so a ``z`` converted from a p map alone is unsigned, as is
+    anything converted from it in turn (``t``, ``beta``, ``d``, ``g``). That conversion is
+    performed anyway, and warns. A t map in the same analysis supplies the sign even when
+    it lacks the sample size its magnitude would need.
     """
     if target in available_data.keys():
         LGR.warning(f"Target '{target}' already available.")
@@ -351,11 +349,9 @@ def resolve_transforms(target, available_data, masker, id_=None):
             p = masker.transform(available_data["p"])
             z = p_to_z(p)
             if "t" in available_data.keys():
-                # Reached only without a sample size, so the t map cannot set the
-                # magnitude, but it still carries the direction, which p does not, so take
-                # the sign from it rather than return an unsigned map. Where t is
-                # exactly 0 the voxel goes to 0: sign(0) is 0, and a t of 0 is a p of 1,
-                # whose z is 0 anyway, so the two agree. Non-finite t propagates.
+                # Only reachable without a sample size, so p sets the magnitude and t
+                # sets the sign. A t of exactly 0 zeroes the voxel, which is also the z of
+                # the p of 1 that such a t implies.
                 t = masker.transform(available_data["t"])
                 z = np.sign(t) * z
             else:
@@ -364,7 +360,8 @@ def resolve_transforms(target, available_data, masker, id_=None):
                     f"{prefix}Deriving 'z' from a p map, with nothing in the analysis to "
                     "give the direction. A p-value carries no sign, so the result is "
                     "unsigned. "
-                    "This will be invalid input for signed tests (like Stouffers)."
+                    "This will be invalid input for signed tests (like Stouffers). "
+                    "P-values are read as two-tailed."
                 )
         else:
             return None

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -363,12 +363,7 @@ def resolve_transforms(target, available_data, masker, id_=None):
                 LGR.warning(
                     f"{prefix}Deriving 'z' from a p map, with nothing in the analysis to "
                     "give the direction. A p-value carries no sign, so the result is "
-                    "unsigned: every voxel is positive. In a signed test (Stouffers, "
-                    "Fishers) this analysis then contributes positive evidence only, "
-                    "whichever way its contrast ran. The p-values are read as two-tailed "
-                    "as well, so a one-tailed p map comes out with the wrong magnitude. "
-                    "Supply a z map, or a t map: with a sample size it sets the "
-                    "magnitude, without one it still sets the sign."
+                    "unsigned. This will be invalid input for signed tests (like Stouffers and Fishers)."
                 )
         else:
             return None

--- a/nimare/transforms.py
+++ b/nimare/transforms.py
@@ -296,7 +296,8 @@ def resolve_transforms(target, available_data, masker, id_=None):
 
     .. versionchanged:: 0.21.0
 
-        * [ENH] Warn when ``z`` is derived from a p map, because that ``z`` is unsigned.
+        * [FIX] Take the sign from a t map when converting a p map without a sample size.
+        * [ENH] Warn when ``z`` is derived from a p map with no sign available anywhere.
         * [ENH] Accept ``id_``, so that warning can name the analysis it came from.
 
     .. versionchanged:: 0.0.8
@@ -331,9 +332,11 @@ def resolve_transforms(target, available_data, masker, id_=None):
 
     Notes
     -----
-    A ``z`` map derived from a p map is unsigned, since a p-value does not record the
-    direction of its effect, and so is anything derived from it in turn (``t``, ``beta``,
-    ``d``, ``g``). That conversion is still performed, but it warns.
+    A p-value does not record the direction of its effect, so a ``z`` derived from a p map
+    and nothing else is unsigned, as is anything derived from it in turn (``t``, ``beta``,
+    ``d``, ``g``). That conversion is still performed, but it warns. A t map in the same
+    analysis supplies the direction even when it is missing the sample size the magnitude
+    would need, and the sign is taken from it instead, silently.
     """
     if target in available_data.keys():
         LGR.warning(f"Target '{target}' already available.")
@@ -347,15 +350,26 @@ def resolve_transforms(target, available_data, masker, id_=None):
         elif "p" in available_data.keys():
             p = masker.transform(available_data["p"])
             z = p_to_z(p)
-            prefix = f"{id_}: " if id_ is not None else ""
-            LGR.warning(
-                f"{prefix}Deriving 'z' from a p map. A p-value carries no direction, so "
-                "the result is unsigned: every voxel is positive. In a signed test "
-                "(Stouffers, Fishers) this analysis then contributes positive evidence "
-                "only, whichever way its contrast ran, and biases the pooled result "
-                "towards it. Supply a z map, or a t map with a sample size, to keep the "
-                "sign."
-            )
+            if "t" in available_data.keys():
+                # Reached only without a sample size, so the t map cannot set the
+                # magnitude, but it still carries the direction, which p does not, so take
+                # the sign from it rather than return an unsigned map. Where t is
+                # exactly 0 the voxel goes to 0: sign(0) is 0, and a t of 0 is a p of 1,
+                # whose z is 0 anyway, so the two agree. Non-finite t propagates.
+                t = masker.transform(available_data["t"])
+                z = np.sign(t) * z
+            else:
+                prefix = f"{id_}: " if id_ is not None else ""
+                LGR.warning(
+                    f"{prefix}Deriving 'z' from a p map, with nothing in the analysis to "
+                    "give the direction. A p-value carries no sign, so the result is "
+                    "unsigned: every voxel is positive. In a signed test (Stouffers, "
+                    "Fishers) this analysis then contributes positive evidence only, "
+                    "whichever way its contrast ran. The p-values are read as two-tailed "
+                    "as well, so a one-tailed p map comes out with the wrong magnitude. "
+                    "Supply a z map, or a t map: with a sample size it sets the "
+                    "magnitude, without one it still sets the sign."
+                )
         else:
             return None
         z = masker.inverse_transform(z.squeeze())


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Preserve available sign information during p-to-z conversion and clearly warn when converted z maps are unsigned.

Bug Fixes:
- Preserve the direction of z maps converted from p maps when a corresponding t map is available, even without sample-size information.
- Warn when converting p maps without directional information would produce unsigned z values, including the affected analysis identifier.

Documentation:
- Document the behavior and limitations of p-to-z conversions when directional information is unavailable.

Tests:
- Add coverage for signed and unsigned p-to-z conversions and analysis-specific warnings.