### PR TITLE
[FIX] Drop None-valued Corrector kwargs and validate the rest against the m…

### DIFF
--- a/nimare/correct.py
+++ b/nimare/correct.py
@@ -12,6 +12,7 @@ from nimare.stats import nlogp_bonferroni, nlogp_fdr
 from nimare.transforms import nlogp_to_z
 from nimare.utils import (
     DEFAULT_FLOAT_DTYPE,
+    _acceptable_kwargs,
     _clip_p_values,
     _minimum_positive_float,
     _nlogp_to_logp_values,
@@ -25,17 +26,32 @@ class Corrector(NiMAREBase):
 
     .. versionadded:: 0.0.3
 
+    .. versionchanged:: 0.21.0
+
+        ``None``-valued keyword arguments are dropped, and the rest are validated in
+        :meth:`transform` against the correction method that will receive them.
+
+    Parameters
+    ----------
+    **kwargs
+        Keyword arguments for the correction method. Ones set to ``None`` are dropped, so an
+        unset parameter defers to that method's own default.
     """
 
     # The name of the method that must be implemented in an Estimator class
     # in order to override the default correction method.
     _correction_method = None
 
+    # Named ``__init__`` parameters to forward to an Estimator-implemented correction method,
+    # which cannot read them off ``self`` the way the Corrector's own methods do.
+    _estimator_parameters = ()
+
     # Maps that must be available in the MetaResult instance
     _required_maps = ("p",)
 
-    def __init__(self):
-        pass
+    def __init__(self, **kwargs):
+        # A ``None`` is an unset parameter, not a request to override a default with nothing.
+        self.parameters = {k: v for k, v in kwargs.items() if v is not None}
 
     @abstractproperty
     def _name_suffix(self):
@@ -101,6 +117,48 @@ class Corrector(NiMAREBase):
                     f"{type(self)} requires '{rm}' maps to be present in the MetaResult, "
                     "but none were found."
                 )
+
+    def _estimator_kwargs(self):
+        """Return the keywords for an Estimator-implemented correction method.
+
+        The stored ``**kwargs``, plus ``_estimator_parameters``. The latter are absorbed by
+        the constructor signature, so they never reach ``self.parameters`` and an Estimator
+        would otherwise run at its own default however the caller set them.
+        """
+        kwargs = dict(self.parameters)
+        for name in self._estimator_parameters:
+            value = getattr(self, name)
+            if value is not None:
+                kwargs[name] = value
+
+        return kwargs
+
+    def _validate_parameters(self, correction_method, parameters):
+        """Raise if ``correction_method`` cannot accept ``parameters``.
+
+        The correction method is only known once ``transform`` has a MetaResult, so this is
+        the first point at which keywords collected by ``__init__`` can be checked.
+
+        Raises
+        ------
+        TypeError
+            Naming ``correction_method`` and the keywords it does accept. A method
+            declaring ``**kwargs`` accepts anything and is not checked.
+        """
+        # The result is passed positionally, so the first parameter is not a keyword.
+        accepted = _acceptable_kwargs(correction_method, n_positional=1)
+        if accepted is None:
+            return
+
+        unexpected = sorted(set(parameters) - set(accepted))
+        if unexpected:
+            method_name = getattr(correction_method, "__qualname__", str(correction_method))
+            raise TypeError(
+                f"{type(self).__name__}(method='{self.method}') was given "
+                f"{', '.join(repr(kwarg) for kwarg in unexpected)}, which "
+                f"{method_name} does not accept. "
+                f"Accepted keyword arguments: {', '.join(accepted) if accepted else '(none)'}."
+            )
 
     @staticmethod
     def _secondary_map_names(rm):
@@ -214,11 +272,13 @@ class Corrector(NiMAREBase):
                 "Using correction method implemented in Estimator: "
                 f"{est.__class__.__module__}.{est.__class__.__name__}.{correction_method}."
             )
-            corr_maps, corr_tables, description = getattr(est, correction_method)(
-                result, **self.parameters
-            )
+            estimator_method = getattr(est, correction_method)
+            parameters = self._estimator_kwargs()
+            self._validate_parameters(estimator_method, parameters)
+            corr_maps, corr_tables, description = estimator_method(result, **parameters)
         else:
             self._collect_inputs(result)
+            self._validate_parameters(getattr(self, correction_method), self.parameters)
             corr_maps, corr_tables, description = self._transform(result, method=correction_method)
 
         # Update corrected map names and enforce float32 outputs for map arrays.
@@ -317,6 +377,8 @@ class FWECorrector(Corrector):
         Number of cores to use for Monte Carlo correction. Default is 1.
     **kwargs
         Keyword arguments to be used by the FWE correction implementation.
+        Ones set to ``None`` are dropped; the rest must be accepted by that implementation,
+        or :meth:`transform` raises :obj:`TypeError`.
     """
 
     _correction_method = "fwe"
@@ -326,15 +388,13 @@ class FWECorrector(Corrector):
             raise ValueError(f"Unsupported FWE correction method '{method}'")
 
         if method == "montecarlo":
-            # Only override estimator defaults when values are explicitly provided.
-            # If ``n_iters`` is None, defer to the estimator's own default, which may vary
-            # across estimators (e.g., MKDAChi2 vs. CBMAEstimator).
-            if n_iters is not None:
-                kwargs["n_iters"] = n_iters
+            # ``None`` is dropped by ``Corrector.__init__``, deferring to the estimator's own
+            # default, which varies (e.g., MKDAChi2 vs. CBMAEstimator).
+            kwargs["n_iters"] = n_iters
             kwargs["n_cores"] = n_cores
 
         self.method = method
-        self.parameters = kwargs
+        super().__init__(**kwargs)
 
     @property
     def _name_suffix(self):
@@ -396,9 +456,20 @@ class FDRCorrector(Corrector):
         The FDR correction rate to use. Default is 0.05. Note that the step-up procedure
         only rescales the p-values, so this does not affect the corrected maps; it is the
         rate they are meant to be thresholded at.
+        Forwarded to an Estimator-implemented correction method, which cannot read it off
+        the Corrector; one with no ``alpha`` parameter raises rather than quietly using its
+        own rate.
+    **kwargs
+        Keyword arguments to be used by the FDR correction implementation.
+        Ones set to ``None`` are dropped; the rest must be accepted by that implementation,
+        or :meth:`transform` raises :obj:`TypeError`.
 
     Notes
     -----
+    .. versionchanged:: 0.21.0
+
+        ``alpha`` now reaches an Estimator-implemented correction method.
+
     This corrector supports a small number of internal FDR correction methods, but can also use
     special methods implemented within individual Estimators.
     To determine what methods are available for the Estimator you're using, use :meth:`inspect`.
@@ -408,11 +479,12 @@ class FDRCorrector(Corrector):
     """
 
     _correction_method = "fdr"
+    _estimator_parameters = ("alpha",)
 
     def __init__(self, method="indep", alpha=0.05, **kwargs):
         self.alpha = alpha
         self.method = method
-        self.parameters = kwargs
+        super().__init__(**kwargs)
 
     @property
     def _name_suffix(self):

--- a/nimare/tests/test_correct.py
+++ b/nimare/tests/test_correct.py
@@ -38,6 +38,156 @@ def test_FWECorrector_montecarlo_custom_parameters():
     assert corr.parameters["n_cores"] == 2
 
 
+class RecordingEstimator(DummyEstimator):
+    """Estimator stand-in that records the keywords its correction method receives."""
+
+    def __init__(self):
+        self.call = None
+
+    def _record(self, result, **kwargs):
+        self.call = kwargs
+        return {"p": np.asarray(result.maps["p"])}, {}, "Corrected."
+
+
+class TunableEstimator(RecordingEstimator):
+    """Correction methods that take the optional parameter, as ALE and MKDAChi2 do."""
+
+    def correct_fwe_montecarlo(self, result, voxel_thresh=0.001, n_iters=5000, n_cores=1):
+        """Record the keywords and return an unchanged p map."""
+        return self._record(result, voxel_thresh=voxel_thresh, n_iters=n_iters, n_cores=n_cores)
+
+    def correct_fdr_indep(self, result, alpha=0.05):
+        """Record the keywords and return an unchanged p map."""
+        return self._record(result, alpha=alpha)
+
+
+class FixedEstimator(RecordingEstimator):
+    """Correction methods that do not, as PermutedOLS takes no ``voxel_thresh``."""
+
+    def correct_fwe_montecarlo(self, result, n_iters=5000, n_cores=1):
+        """Record the keywords and return an unchanged p map."""
+        return self._record(result, n_iters=n_iters, n_cores=n_cores)
+
+    def correct_fdr_indep(self, result):
+        """Record the keywords and return an unchanged p map."""
+        return self._record(result)
+
+
+class PermissiveEstimator(RecordingEstimator):
+    """A correction method declaring ``**kwargs``, which accepts anything."""
+
+    def correct_fwe_montecarlo(self, result, **kwargs):
+        """Record the keywords and return an unchanged p map."""
+        return self._record(result, **kwargs)
+
+
+def _result(mni_mask, estimator):
+    return MetaResult(estimator, mask=mni_mask, maps={"p": _masked_values(mni_mask, 0.01)})
+
+
+@pytest.mark.parametrize(
+    ("corrector", "expected"),
+    [
+        (
+            FWECorrector(method="montecarlo", n_iters=5, n_cores=None, voxel_thresh=None),
+            {"n_iters": 5},
+        ),
+        (FDRCorrector(method="indep", alpha=0.05, voxel_thresh=None), {}),
+    ],
+    ids=["fwe", "fdr"],
+)
+def test_corrector_drops_none_valued_kwargs(corrector, expected):
+    """An unset parameter defers to the correction method's default rather than erasing it."""
+    assert corrector.parameters == expected
+
+
+@pytest.mark.parametrize(
+    ("corrector", "estimator", "expected"),
+    [
+        (
+            FWECorrector(method="montecarlo", n_iters=5, voxel_thresh=None),
+            TunableEstimator,
+            {"voxel_thresh": 0.001, "n_iters": 5, "n_cores": 1},
+        ),
+        (
+            FWECorrector(method="montecarlo", voxel_thresh=0.01, n_iters=7, n_cores=2),
+            TunableEstimator,
+            {"voxel_thresh": 0.01, "n_iters": 7, "n_cores": 2},
+        ),
+        (
+            FWECorrector(method="montecarlo", n_iters=5, anything=1),
+            PermissiveEstimator,
+            {"n_iters": 5, "n_cores": 1, "anything": 1},
+        ),
+        (FDRCorrector(method="indep", alpha=0.01), TunableEstimator, {"alpha": 0.01}),
+    ],
+    ids=["unset_defers", "set_reaches", "var_keyword", "alpha_reaches"],
+)
+def test_keywords_reaching_an_estimator_method(mni_mask, corrector, estimator, expected):
+    """A keyword arrives as given, an unset one leaves the estimator's default in place.
+
+    ``alpha`` is a named parameter rather than a stored keyword, so it reaches the estimator
+    only by being forwarded.
+    """
+    corrected = corrector.transform(_result(mni_mask, estimator()))
+
+    # ``transform`` corrects a copy, so the estimator that ran is the one it hands back.
+    assert corrected.estimator.call == expected
+
+
+@pytest.mark.parametrize(
+    ("corrector", "estimator", "unexpected", "method_name", "accepted"),
+    [
+        (
+            FWECorrector(method="montecarlo", n_iters=5, voxel_thresh=0.01),
+            FixedEstimator,
+            "'voxel_thresh'",
+            "FixedEstimator.correct_fwe_montecarlo",
+            "n_iters, n_cores",
+        ),
+        (
+            FWECorrector(method="bonferroni", voxel_thresh=0.01),
+            DummyEstimator,
+            "'voxel_thresh'",
+            "FWECorrector.correct_fwe_bonferroni",
+            "(none)",
+        ),
+        (
+            FDRCorrector(method="indep", alpha=0.01),
+            FixedEstimator,
+            "'alpha'",
+            "FixedEstimator.correct_fdr_indep",
+            "(none)",
+        ),
+    ],
+    ids=["estimator_method", "native_method", "alpha"],
+)
+def test_corrector_rejects_keywords_the_method_cannot_take(
+    mni_mask, corrector, estimator, unexpected, method_name, accepted
+):
+    """Reject with a message the built-in TypeError would not produce.
+
+    Matching on the keyword name alone passes before the check exists, since Python names
+    it too. The accepted-argument list is what tells the two apart.
+    """
+    with pytest.raises(TypeError) as excinfo:
+        corrector.transform(_result(mni_mask, estimator()))
+
+    message = str(excinfo.value)
+    assert unexpected in message
+    assert method_name in message
+    assert f"Accepted keyword arguments: {accepted}" in message
+
+
+def test_native_fdr_method_reads_alpha_off_the_corrector(mni_mask):
+    """It takes only ``nlogp``, so forwarding ``alpha`` to it would be refused."""
+    corrected = FDRCorrector(method="indep", alpha=0.01).transform(
+        _result(mni_mask, DummyEstimator())
+    )
+
+    assert "p_corr-FDR_method-indep" in corrected.maps
+
+
 def test_MetaResult_clips_tiny_analytical_p_values_to_float32_floor(mni_mask):
     """Analytical p-values below float32 resolution should be censored, not zeroed."""
     p_values = _masked_values(mni_mask)

--- a/nimare/utils.py
+++ b/nimare/utils.py
@@ -162,12 +162,38 @@ def _mask_coverage_to_null_ijk(masker, mask_coverage="brain", gm_threshold=0.1):
     return np.vstack(np.where(mask_bool)).T
 
 
+def _acceptable_kwargs(func, n_positional=0):
+    """Return the keyword names a callable accepts, or None if it accepts any.
+
+    .. versionadded:: 0.21.0
+
+    Parameters
+    ----------
+    func : :obj:`callable`
+        The callable to inspect.
+    n_positional : :obj:`int`, default=0
+        Leading parameters the caller passes positionally, which are therefore not
+        available as keywords.
+
+    Returns
+    -------
+    :obj:`list` of :obj:`str` or None
+        ``None`` when ``func`` declares ``**kwargs``, since that accepts anything.
+    """
+    params = list(inspect.signature(func).parameters.values())
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params):
+        return None
+
+    return [param.name for param in params[n_positional:]]
+
+
 def _filter_kwargs(func, kwargs):
     """Return kwargs limited to a callable's supported parameters."""
-    signature = inspect.signature(func)
-    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
+    accepted = _acceptable_kwargs(func)
+    if accepted is None:
         return kwargs
-    return {key: value for key, value in kwargs.items() if key in signature.parameters}
+
+    return {key: value for key, value in kwargs.items() if key in accepted}
 
 
 def _check_ncores(n_cores):


### PR DESCRIPTION
…ethod

FWECorrector and FDRCorrector collect every unrecognised keyword into ``self.parameters`` and forward it verbatim to whichever correction method ``transform`` ends up calling. Two things go wrong there.

An unset parameter arrives as ``None``, which is what the neurosynth-compose frontend sends for a field the user left blank. Storing it means the caller overrides the correction method's own default with nothing: a ``voxel_thresh`` of ``None`` crashes PermutedOLS, whose ``correct_fwe_montecarlo`` has no such argument, and quietly displaces ALE's 0.001 until it reaches ``_p_to_summarystat(None)``. Between them that was the only FWE path either estimator has. ``n_iters`` already had this rule; apply it to every keyword, in ``Corrector.__init__`` so FDR gets it too.

The keywords that remain were still only checked when Python bound them to the correction method, deep inside a run that may have taken hours to reach that point -- and not checked at all when the method is one of the Corrector's own, which take no keywords and so dropped them silently. The estimator is not known at construction, but it is by ``transform``, so validate there against the signature of the method about to be called and name it in the error. Methods declaring ``**kwargs`` accept anything and are left alone.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Make correction parameter handling defer unset values, forward configured estimator parameters, and reject unsupported keywords before correction runs.

Bug Fixes:
- Drop None-valued correction parameters so estimator defaults remain effective.
- Validate correction keywords during transform against the selected correction method and report unsupported arguments early.
- Forward FDR alpha values to estimator-implemented correction methods.

Enhancements:
- Support correction methods with **kwargs while preserving method-specific keyword validation for other callables.
- Add coverage for omitted parameters, estimator and native methods, permissive methods, and validation errors.

Documentation:
- Document None-parameter handling and transform-time validation for correction methods.