### PR TITLE
[FIX] Drop a dependence group that cancels instead of failing the run

### DIFF
--- a/nimare/meta/_dependence.py
+++ b/nimare/meta/_dependence.py
@@ -106,6 +106,24 @@ class DependenceModel:
         """Number of independent units backing the inference."""
         return int(self.group_order.size)
 
+    def group_rows(self):
+        """Yield ``(label, rows)`` for every group, in :attr:`group_order`.
+
+        The enumeration PyMARE's combination tests run over the labels they are handed, so a
+        per-group quantity computed here describes the block PyMARE will aggregate.
+
+        Yields
+        ------
+        label : :obj:`object`
+            The block label.
+        rows : :obj:`numpy.ndarray`
+            Row indices of that block's images, into this grouping rather than the full
+            dataset; :attr:`image_indices` translates them back.
+        """
+        codes, labels = self._encoded_blocks
+        for index, label in enumerate(labels):
+            yield label, np.flatnonzero(codes == index)
+
     @property
     def supports_inference(self):
         """Whether there are at least two independent units to compare.

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -113,6 +113,41 @@ _REMOVED_PARAMETERS = {
 }
 
 
+#: Variance at or below which a dependence group's aggregated z statistic carries no
+#: information, because its images cancel. Matches the floor PyMARE's combination tests
+#: refuse to aggregate below, so a group is excluded here before PyMARE raises on it. Not a
+#: statistical threshold: it screens out exact cancellation and nothing else.
+_CANCELLATION_FLOOR = 1e-12
+
+#: How close an empirical correlation must be to -1 to count as a sign-flipped duplicate. A
+#: float-error tolerance, not a warning band.
+_MIRROR_TOLERANCE = 1e-6
+
+
+def _mirrored_pairs(values):
+    """Return the row pairs of ``values`` that are exact mirror images of each other.
+
+    Parameters
+    ----------
+    values : :obj:`numpy.ndarray` of shape (K, V)
+        Image data, one row per image.
+
+    Returns
+    -------
+    :obj:`list` of :obj:`tuple`
+        ``(i, j)`` row pairs, ``i < j``, whose *empirical* correlation is -1 to within
+        :data:`_MIRROR_TOLERANCE`. Empirical rather than estimated-null: a mirror pair
+        correlates -1 however much signal it shares, while its estimated null correlation is
+        pulled well away from -1 by that shared signal.
+    """
+    with np.errstate(invalid="ignore", divide="ignore"):
+        empirical = np.corrcoef(values)
+
+    # np.corrcoef reports NaN against a constant row, which is not a mirror image.
+    mirrored = np.isfinite(empirical) & (empirical <= -1.0 + _MIRROR_TOLERANCE)
+    return list(zip(*np.nonzero(np.triu(mirrored, k=1))))
+
+
 def _fill_doc(cls):
     """Substitute the shared blocks of :data:`_DOC_DICT` into a class docstring.
 
@@ -178,6 +213,11 @@ class IBMAEstimator(Estimator):
     #: do. Cluster-robust standard errors are distribution-free, so estimating a whole-brain
     #: correlation for the meta-regression estimators would produce something nothing reads.
     _requires_corr_matrix = False
+
+    #: The label each integer group code in ``inputs_["contrast_names"]`` stands for, so a
+    #: warning can name the study rather than the code. Filled in by
+    #: :meth:`_preprocess_dependence`.
+    _group_labels = {}
 
     #: How this estimator reacts to a masker that averages across voxels (e.g. a
     #: :class:`~nilearn.maskers.NiftiLabelsMasker`) rather than only selecting them.
@@ -421,6 +461,74 @@ class IBMAEstimator(Estimator):
         model = DependenceModel(self.inputs_["contrast_names"])
         return model if study_mask is None else model.for_images(study_mask)
 
+    def _group_name(self, code):
+        """Return a human-readable name for one integer group code."""
+        return str(self._group_labels.get(code, code))
+
+    def _image_names(self, indices):
+        """Return the ids of the images at ``indices``, as a comma-separated string."""
+        ids = self.inputs_["id"]
+        return ", ".join(str(ids[index]) for index in indices)
+
+    def _screen_dependence_groups(self, study_mask, corr, stat_maps):
+        """Judge each dependence group of one model before it is handed to PyMARE.
+
+        Parameters
+        ----------
+        study_mask : :obj:`numpy.ndarray` of shape (K,)
+            Indices into ``inputs_["id"]`` of the images this model is fitted over.
+        corr : :obj:`numpy.ndarray` of shape (N, N)
+            The estimated null correlation between every image, as ``inputs_["corr_matrix"]``
+            holds it.
+        stat_maps : :obj:`numpy.ndarray` of shape (K, V)
+            The image data this model is fitted over, in ``study_mask`` order.
+
+        Returns
+        -------
+        cancelling : :obj:`list` of :obj:`tuple`
+            ``(code, images, variance)`` for every group whose images cancel. ``images``
+            indexes ``inputs_["id"]``.
+        mirrored : :obj:`list` of :obj:`tuple`
+            ``(code, image_i, image_j)`` for every pair of images in a *surviving* group
+            that are exact mirror images of each other.
+
+        Notes
+        -----
+        Per model, because a group's membership is. Under a liberal mask a two-image group
+        can only cancel where both images are valid, and is a lone contrast elsewhere.
+
+        The two verdicts read different correlations. Cancellation is decided on the
+        estimated null correlation, since that is the matrix PyMARE aggregates the group
+        with; a sign-flipped duplicate is decided on the empirical one, which is what says
+        two uploads are the same contrast both ways round. See :func:`_mirrored_pairs`.
+        """
+        dependence = self._dependence(study_mask)
+        if not dependence.has_dependence:
+            return [], []
+
+        sub_corr = corr[np.ix_(study_mask, study_mask)]
+        cancelling, mirrored = [], []
+        for code, rows in dependence.group_rows():
+            if rows.size < 2:
+                # A group of one is aggregated as itself, with variance 1 by definition.
+                continue
+
+            # Mirrors StoufferCombinationTest._group_statistics, which computes this and
+            # then raises rather than returning it. Kept in step by
+            # test_cancellation_floor_still_matches_pymare.
+            block = sub_corr[np.ix_(rows, rows)]
+            variance = float(block.sum() / rows.size**2)
+            if not np.isfinite(variance) or variance <= _CANCELLATION_FLOOR:
+                cancelling.append((code, study_mask[rows], variance))
+                continue
+
+            mirrored.extend(
+                (code, study_mask[rows[i]], study_mask[rows[j]])
+                for i, j in _mirrored_pairs(stat_maps[rows])
+            )
+
+        return cancelling, mirrored
+
     def _resolve_masker(self, dataset):
         """Adopt the dataset's masker when none was supplied, and check it is usable here."""
         self.masker = self.masker or dataset.masker
@@ -468,6 +576,10 @@ class IBMAEstimator(Estimator):
         ``map_names`` -- into full-length voxel maps. Voxels no model covers come back NaN,
         the same way out-of-mask voxels already did.
 
+        Where a correlation matrix is passed through -- the combination tests, and only
+        them -- :meth:`_screen_dependence_groups` screens each model first, and a dependence
+        group whose images cancel is excluded from that model.
+
         Parameters
         ----------
         input_names : :obj:`list` of :obj:`str`
@@ -486,18 +598,49 @@ class IBMAEstimator(Estimator):
         n_voxels = self.inputs_[input_names[0]].shape[1]
         maps = {name: np.full(n_voxels, np.nan, dtype=float) for name in map_names}
 
+        corr = kwargs.get("corr")
         n_skipped = 0
+        n_models = 0
+        dropped, mirrored = {}, {}
         for study_mask, voxel_mask, arrays in self._model_bags(input_names):
+            n_models += 1
+
+            if corr is not None:
+                # study_mask is filtered alongside the data because everything derived from
+                # it -- the weights passed to PyMARE, the dof written back -- must keep
+                # describing the fit that actually happened.
+                cancelling, pairs = self._screen_dependence_groups(study_mask, corr, arrays[0])
+                for code, images, variance in cancelling:
+                    record = dropped.setdefault(
+                        code, {"images": images, "models": 0, "voxels": 0, "variance": variance}
+                    )
+                    record["images"] = np.union1d(record["images"], images)
+                    record["models"] += 1
+                    record["voxels"] += arrays[0].shape[1]
+
+                if cancelling:
+                    keep = ~np.isin(
+                        study_mask, np.concatenate([images for _, images, _ in cancelling])
+                    )
+                    study_mask = study_mask[keep]
+                    arrays = [values[keep] for values in arrays]
+
+                for code, first, second in pairs:
+                    mirrored.setdefault((int(first), int(second)), code)
+
             if not self._dependence(study_mask).supports_inference:
                 # Every image here comes from one group, so there is no independent
                 # replication to estimate a variance from. Leave the voxels NaN rather than
-                # report a statistic the data cannot support.
+                # report a statistic the data cannot support. Also catches a model the
+                # drop above left with one group.
                 n_skipped += 1
                 continue
 
             results = self._fit_model(*arrays, study_mask=study_mask, **kwargs)
             for name, values in zip(map_names, results):
                 maps[name][voxel_mask] = values
+
+        self._report_screened_groups(dropped, mirrored, n_models)
 
         if n_skipped:
             LGR.warning(
@@ -508,6 +651,38 @@ class IBMAEstimator(Estimator):
             )
 
         return maps
+
+    def _report_screened_groups(self, dropped, mirrored, n_models):
+        """Warn once per dependence group excluded, and once per mirror pair kept.
+
+        Aggregated over the models rather than emitted in the fitting loop, so a group
+        dropped from every bag of a liberal-mask run is reported once with a count.
+        """
+        for code, record in dropped.items():
+            LGR.warning(
+                "Dependence group %s (image(s) %s) was excluded from %d of %d model(s), "
+                "covering %d voxel(s): its aggregated z statistic has variance %.3g there, "
+                "so its images cancel and carry no information. The rest were fitted. "
+                "Usually one contrast was uploaded in both directions, or the group's "
+                "contrasts partition one cohort.",
+                self._group_name(code),
+                self._image_names(record["images"]),
+                record["models"],
+                n_models,
+                record["voxels"],
+                record["variance"],
+            )
+
+        for (first, second), code in mirrored.items():
+            LGR.warning(
+                "Image %s and image %s, both in dependence group %s, correlate exactly -1: "
+                "one is the other with its sign flipped. They do not cancel, so both were "
+                "kept, but almost certainly one contrast was uploaded twice in opposite "
+                "directions.",
+                self._image_names([first]),
+                self._image_names([second]),
+                self._group_name(code),
+            )
 
     def _dof_map(self, study_mask, n_voxels, est_summary=None):
         """Return the degrees of freedom map, one value per voxel.
@@ -620,6 +795,7 @@ class IBMAEstimator(Estimator):
         # irreproducible. str() first so a mix of label types still orders.
         label_to_int = {label: i for i, label in enumerate(sorted(set(labels), key=str))}
         self.inputs_["contrast_names"] = np.array([label_to_int[label] for label in labels])
+        self._group_labels = {code: label for label, code in label_to_int.items()}
 
         dependence = self._dependence()
         if not dependence.has_dependence:
@@ -815,6 +991,8 @@ class Fishers(IBMAEstimator):
 
         * New parameter: ``groupby``, identifying images contributed by the same participants.
         * The ``dof`` map now counts independent groups rather than images.
+        * A dependence group whose images cancel is now excluded from the voxels where it
+          cancels, with a warning naming the study.
 
     Requires z-statistic images, but will be extended to work with t-statistic images as well.
 
@@ -956,6 +1134,8 @@ class Stouffers(IBMAEstimator):
 
         * New parameter: ``groupby``, identifying images contributed by the same participants.
         * The ``dof`` map now counts independent groups rather than images.
+        * A dependence group whose images cancel is now excluded from the voxels where it
+          cancels, with a warning naming the study, instead of ending the meta-analysis.
 
     Requires z-statistic images.
 

--- a/nimare/tests/test_meta_ibma_dependence.py
+++ b/nimare/tests/test_meta_ibma_dependence.py
@@ -826,6 +826,165 @@ def test_null_correlation_ignores_voxels_missing_from_any_image(estimator):
     assert np.allclose(dirty, clean, atol=0.05)
 
 
+# Cancelling dependence groups
+
+
+def _combination_estimator(cls, z_maps, codes, corr):
+    """Return a combination test with hand-built bags and a supplied correlation matrix.
+
+    ``corr`` stands in for the null correlation ``_preprocess_dependence`` would estimate, so
+    a block can be pinned at exactly the value the verdict turns on.
+    """
+    meta = _bagged_estimator(cls, {"z_maps": np.asarray(z_maps, dtype=float)}, codes=codes)
+    meta.inputs_["corr_matrix"] = np.asarray(corr, dtype=float)
+    meta._group_labels = {int(code): f"study{int(code)}" for code in np.unique(codes)}
+    meta.generate_description = False
+    return meta
+
+
+@pytest.mark.parametrize("estimator", COMBINATION_ESTIMATORS)
+def test_cancelling_group_is_dropped_per_bag_not_fatally(estimator, caplog, monkeypatch):
+    """A group whose images cancel is excluded from the bags it cancels in, and no others.
+
+    PyMARE refuses to aggregate a group whose block sums to zero, which used to end the whole
+    meta-analysis over one study's uploads. Both combination tests are run because the drop
+    is not confined to the one that raised.
+    """
+    rng = np.random.RandomState(0)
+    z_maps = rng.normal(size=(4, 8))
+    z_maps[1] = -z_maps[0]
+    # Only images 0, 2 and 3 cover voxels 6-7, so image 0's group holds two images in one bag
+    # and one in the other.
+    z_maps[1, 6:] = np.nan
+    corr = np.eye(4)
+    corr[0, 1] = corr[1, 0] = -1.0
+    meta = _combination_estimator(estimator, z_maps, [0, 0, 1, 2], corr)
+
+    masks = []
+    real = meta._fit_model
+
+    def _record(*arrays, study_mask, **kwargs):
+        masks.append(list(study_mask))
+        return real(*arrays, study_mask=study_mask, **kwargs)
+
+    monkeypatch.setattr(meta, "_fit_model", _record)
+
+    with caplog.at_level(logging.WARNING, logger="nimare.meta.ibma"):
+        maps, _, _ = meta._fit(_FakeDataset(meta.masker))
+
+    assert masks == [[2, 3], [0, 2, 3]]
+    assert np.isfinite(maps["z"]).all()
+    # Degrees of freedom count the groups actually fitted, which differ between the bags.
+    assert np.allclose(maps["dof"][:6], 1.0)
+    assert np.allclose(maps["dof"][6:], 2.0)
+
+    assert "study0" in caplog.text
+    assert "excluded from 1 of 2 model(s)" in caplog.text
+    # The group went, so it must not also be reported as a mirror pair that was kept.
+    assert "correlate exactly -1" not in caplog.text
+
+
+def test_three_way_cancellation_drops_the_whole_group(caplog):
+    """A block can sum to nothing with no pair anywhere near -1, and all three must go.
+
+    Complementary networks from one cohort do this. With three members there is no principled
+    choice of which one to remove, so the group goes as a unit -- which here leaves a single
+    group, the case the existing skip already handles.
+    """
+    rng = np.random.RandomState(1)
+    corr = np.eye(4)
+    # Sums to zero: 3 + 2 * (-0.5 - 0.5 - 0.5).
+    corr[np.ix_([0, 1, 2], [0, 1, 2])] = [
+        [1.0, -0.5, -0.5],
+        [-0.5, 1.0, -0.5],
+        [-0.5, -0.5, 1.0],
+    ]
+    meta = _combination_estimator(ibma.Stouffers, rng.normal(size=(4, 8)), [0, 0, 0, 1], corr)
+
+    with caplog.at_level(logging.WARNING, logger="nimare.meta.ibma"):
+        maps, _, _ = meta._fit(_FakeDataset(meta.masker))
+
+    # Nothing was fitted, so every one of the three went: dropping any one or two of them
+    # would have left two groups to fit.
+    assert np.isnan(maps["z"]).all()
+    assert "img0, img1, img2" in caplog.text
+    assert "single group" in caplog.text
+    assert "correlate exactly -1" not in caplog.text
+
+
+def test_perfect_mirror_that_does_not_cancel_warns_but_keeps_the_data(caplog):
+    """Two images that are exact negatives can still fit, and that is worth saying loudly.
+
+    A third member keeps the group's block sum off zero. The estimated null correlation
+    cannot see the duplicate, being pulled away from -1 by the signal the two maps share.
+    """
+    rng = np.random.RandomState(2)
+    z_maps = rng.normal(size=(4, 8))
+    z_maps[1] = -z_maps[0]
+    corr = np.eye(4)
+    corr[np.ix_([0, 1, 2], [0, 1, 2])] = [[1.0, -0.5, 0.4], [-0.5, 1.0, 0.6], [0.4, 0.6, 1.0]]
+    meta = _combination_estimator(ibma.Stouffers, z_maps, [0, 0, 0, 1], corr)
+
+    with caplog.at_level(logging.WARNING, logger="nimare.meta.ibma"):
+        maps, _, _ = meta._fit(_FakeDataset(meta.masker))
+
+    # Dropping the group would have left one image, and so no fit at all.
+    assert np.isfinite(maps["z"]).all()
+    assert "correlate exactly -1" in caplog.text
+    assert "img0" in caplog.text and "img1" in caplog.text
+
+
+def test_near_cancellation_is_left_alone_silently(caplog):
+    """Strongly anti-correlated images that neither cancel nor mirror get no warning.
+
+    Where to draw a line short of exact cancellation is a policy only the caller can set, and
+    warning about every anti-correlated pair would bury the two cases that are worth
+    reporting.
+    """
+    rng = np.random.RandomState(3)
+    z_maps = rng.normal(size=(4, 8))
+    z_maps[1] = -z_maps[0] + 0.5 * rng.normal(size=8)
+    corr = np.eye(4)
+    corr[0, 1] = corr[1, 0] = -0.99
+    meta = _combination_estimator(ibma.Stouffers, z_maps, [0, 0, 1, 2], corr)
+
+    with caplog.at_level(logging.WARNING, logger="nimare.meta.ibma"):
+        maps, _, _ = meta._fit(_FakeDataset(meta.masker))
+
+    assert -1.0 < np.corrcoef(z_maps[:2])[0, 1] < -0.8, "fixture must be near, not exact"
+    # Three groups, so nothing was dropped: a drop would leave two, and dof 1.
+    assert np.allclose(maps["dof"], 2.0)
+    assert np.isfinite(maps["z"]).all()
+    assert caplog.text == ""
+
+
+def test_cancellation_floor_still_matches_pymare():
+    """PyMARE keeps its own floor as a function local, so drift between the two is silent.
+
+    Excluding a group here only pre-empts PyMARE while everything PyMARE refuses is already
+    excluded. The value cannot be imported, so the two are pinned by behaviour instead.
+    """
+    rng = np.random.RandomState(5)
+    z_maps, weights = rng.normal(size=(4, 6)), np.ones((4, 1))
+    codes = np.array([0, 0, 1, 2])
+
+    def pymare_refuses(variance):
+        corr = np.eye(4)
+        # (2 + 2 * rho) / 4 is the block variance of a two-image group.
+        corr[0, 1] = corr[1, 0] = 2.0 * variance - 1.0
+        try:
+            pymare.estimators.StoufferCombinationTest(group_level=True).fit(
+                z=z_maps, w=weights, g=codes, corr=corr
+            )
+        except ValueError as exc:
+            return "cancel" in str(exc)
+        return False
+
+    assert pymare_refuses(ibma._CANCELLATION_FLOOR)
+    # The direction that matters: whatever NiMARE keeps, PyMARE must still accept.
+    assert not pymare_refuses(ibma._CANCELLATION_FLOOR * 1e3)
+
+
 # PermutedOLS
 
 

--- a/nimare/tests/test_meta_ibma_dependence.py
+++ b/nimare/tests/test_meta_ibma_dependence.py
@@ -959,7 +959,7 @@ def test_near_cancellation_is_left_alone_silently(caplog):
 
 
 def test_cancellation_floor_still_matches_pymare():
-    """PyMARE keeps its own floor as a function local, so drift between the two is silent.
+    """Keep the floor pinned to PyMARE's, which is a function local and so drifts silently.
 
     Excluding a group here only pre-empts PyMARE while everything PyMARE refuses is already
     excluded. The value cannot be imported, so the two are pinned by behaviour instead.


### PR DESCRIPTION
One study's uploads could end a whole image-based meta-analysis. When a group's images cancel -- their block of the estimated null correlation sums to zero -- PyMARE refuses to aggregate it and raises, naming the internal integer code and pointing the reader at "the correlation matrix supplied for this group", which the caller never supplied: NiMARE estimated it. On real staging data this fired on 3 of 16 studysets, in two shapes: an exact mirror pair (the same contrast uploaded both ways round, correlation -1), and three complementary network maps from one cohort whose pairwise correlations were unremarkable but whose 3x3 block still summed to nothing.

Screen each model before handing it to PyMARE, and exclude a group that cancels from that model rather than letting it end the run. The whole group, not one member: with three or more there is no principled choice of which to remove, and a group whose contrasts carry no joint signal has nothing to contribute either way.

Per liberal-mask bag, not per meta-analysis. A bag holds only the images valid over its voxels, so whether a group cancels is a property of the bag -- a two-image group can only cancel where both images are valid, and is a lone contrast everywhere else. Dropping globally would discard images over voxels where nothing is wrong with them.

The drop lives in _fit_over_bags, which already holds study_mask and the bag's arrays and already skips a bag left without two independent groups. Filtering study_mask alongside the data means everything derived from it -- the weights passed into PyMARE, the dof map written back -- keeps describing the fit that actually happened, which is also why this does not belong in PyMARE: PyMARE would have to return a record of what it dropped for NiMARE to re-derive both. Its guard stays as a backstop that should now never fire.

Two triggers, on two different correlations. Cancellation is judged on the estimated null correlation, because that is the matrix PyMARE aggregates the group with. A pair of images that are exact mirrors but do not cancel -- other members keep the block sum off zero -- is judged on the empirical correlation and only warned about, loudly, with the data kept: the null correlation cannot see it, since a real mirror pair sharing signal estimates near -0.94 while correlating exactly -1. Anything short of -1 that does not cancel stays silent; where to draw a line short of exact cancellation is a statistical policy only the caller can set.

Applies to Fishers as well as Stouffers, which is a judgement call worth naming: Fishers never raised here, because Brown's method rescales a cancelled block rather than dividing by it. It rescaled it as though it carried information, though, so the same exclusion is at worst neutral there and at best removes an inflated contribution -- and it keeps the verdict on a group a property of the data rather than of which combination test was chosen.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Exclude dependence groups whose estimated correlations cancel before combination testing so affected image-based meta-analyses continue with accurate per-bag results and diagnostics.

Bug Fixes:
- Prevent cancelling dependence groups from terminating image-based meta-analyses by excluding the affected group from each model or voxel bag before combination testing.
- Apply cancellation handling to both Stouffer and Fisher combination estimators while preserving valid data outside affected bags.

Enhancements:
- Add per-group screening based on estimated null-correlation variance and warnings for exact empirical sign-flipped image pairs that are retained.
- Track filtered groups when calculating fitted weights and degrees of freedom, and report affected studies, images, models, and voxels.

Documentation:
- Document that cancelling dependence groups are excluded locally with a warning rather than ending the meta-analysis.

Tests:
- Add coverage for per-bag cancellation, whole-group three-way cancellation, retained mirror-image warnings, near-cancellation silence, and alignment with PyMARE's cancellation threshold.