### PR TITLE
Let MetaResult.save leave the input images out of the file

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,6 +42,7 @@ For more information about the components of coordinate-based meta-analysis in N
    :template: class.rst
 
    results.MetaResult
+   results.DroppedInput
 
 
 .. _api_correct_ref:

--- a/nimare/base.py
+++ b/nimare/base.py
@@ -162,6 +162,18 @@ class NiMAREBase(CacheMixin, metaclass=ABCMeta):
     #: written into ``inputs_``; values are ``(kind, field)`` pairs.
     _required_inputs = {}
 
+    def _image_input_fields(self):
+        """Return the ``_required_inputs`` entries declared as images.
+
+        Returns
+        -------
+        :obj:`dict`
+            ``{inputs_ key: image field}``, in ``_required_inputs`` order.
+        """
+        return {
+            name: field for name, (kind, field) in self._required_inputs.items() if kind == "image"
+        }
+
     def _collect_inputs(self, dataset, drop_invalid=True):
         """Search for, and validate, required inputs as necessary.
 

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -273,9 +273,7 @@ class IBMAEstimator(Estimator):
             # A dictionary to collect data, to be further reduced by the liberal mask.
             self.inputs_["data_bags"] = {}
 
-        image_names = [
-            name for name, (type_, _) in self._required_inputs.items() if type_ == "image"
-        ]
+        image_names = list(self._image_input_fields())
         for name in image_names:
             # Mask required input images using either the dataset's mask or the estimator's.
             temp_arr = self._mask_images(masker, mask_img, self.inputs_[name])
@@ -639,9 +637,7 @@ class IBMAEstimator(Estimator):
 
         # Calculate the correlation matrix on the first image-based input,
         # which is the map the dependence acts on.
-        image_names = [
-            name for name, (type_, _) in self._required_inputs.items() if type_ == "image"
-        ]
+        image_names = list(self._image_input_fields())
         if not image_names:
             return
         maps = self.inputs_[image_names[0]]

--- a/nimare/results.py
+++ b/nimare/results.py
@@ -21,6 +21,113 @@ from nimare.utils import (
 LGR = logging.getLogger(__name__)
 
 
+class DroppedInput:
+    """Stand-in for an input image array dropped by :meth:`MetaResult.save`.
+
+    .. versionadded:: 0.21.0
+
+    Parameters
+    ----------
+    key : :obj:`str`
+        The ``estimator.inputs_`` key whose array was dropped.
+
+    Raises
+    ------
+    RuntimeError
+        On any read of the placeholder, naming the key and the flag that removed it.
+    """
+
+    def __init__(self, key):
+        self._key = key
+
+    def _raise(self, *args, **kwargs):
+        """Report the dropped key and how to get the array back."""
+        raise RuntimeError(
+            f"estimator.inputs_['{self._key}'] was dropped when this MetaResult was saved "
+            "with with_inputs=False, so the operations that read the input images -- "
+            "reporting, and Monte Carlo FWE correction of an image-based meta-analysis -- "
+            "cannot run on it. Refit the estimator to rebuild the inputs, or save the "
+            "result again with with_inputs=True."
+        )
+
+    def __getattr__(self, name):
+        """Raise on any public attribute lookup, such as ``.shape``."""
+        # Private and dunder names pass through so that pickle and copy can still probe
+        # the placeholder for ``__reduce_ex__``, ``__deepcopy__`` and the like.
+        if name.startswith("_"):
+            raise AttributeError(name)
+        self._raise()
+
+    __array__ = _raise
+    __getitem__ = _raise
+    __iter__ = _raise
+    __len__ = _raise
+
+    def __repr__(self):
+        """Show the dropped key."""
+        return f"DroppedInput({self._key!r})"
+
+
+def _shell(result, **overrides):
+    """Build a result carrying ``result``'s attributes, bypassing ``__init__``.
+
+    ``__init__`` deep-copies the estimator, rebuilds the masker and re-derives the
+    citations from the description, none of which a result built from an already-built
+    one needs.
+
+    Parameters
+    ----------
+    result : :class:`MetaResult`
+        The result to take attributes from.
+    overrides
+        Attributes to set in place of ``result``'s.
+
+    Returns
+    -------
+    :class:`MetaResult`
+        A new result of ``result``'s class.
+    """
+    new = object.__new__(type(result))
+    new.__dict__.update(result.__dict__)
+    new.__dict__.update(overrides)
+    return new
+
+
+def _drop_input_images(estimator):
+    """Return a shallow copy of ``estimator`` with its input image arrays replaced.
+
+    The keys replaced are the ones ``_required_inputs`` declares as images, plus the
+    ``"data_bags"`` derived from them. The rest of ``inputs_`` is small and is kept; the
+    diagnostics need ``inputs_["id"]`` to enumerate the studies they refit.
+
+    Parameters
+    ----------
+    estimator : :class:`~nimare.base.Estimator`
+        A fitted estimator.
+
+    Returns
+    -------
+    :class:`~nimare.base.Estimator`
+        A shallow copy carrying :class:`DroppedInput` placeholders, or ``estimator``
+        unchanged when it declares no image inputs.
+    """
+    inputs = getattr(estimator, "inputs_", None)
+    if not inputs:
+        return estimator
+
+    keys = set(estimator._image_input_fields())
+    keys.add("data_bags")
+    keys &= set(inputs)
+    if not keys:
+        return estimator
+
+    stripped = copy.copy(estimator)
+    stripped.inputs_ = {
+        key: (DroppedInput(key) if key in keys else value) for key, value in inputs.items()
+    }
+    return stripped
+
+
 class MetaResult(NiMAREBase):
     """Base class for meta-analytic results.
 
@@ -156,6 +263,41 @@ class MetaResult(NiMAREBase):
                 return squeeze_image(self.masker.inverse_transform([m]))
         return m
 
+    def save(self, filename, compress=True, with_inputs=True):
+        """Pickle the MetaResult to the provided file.
+
+        .. versionchanged:: 0.21.0
+
+            Added the ``with_inputs`` parameter.
+
+        Parameters
+        ----------
+        filename : :obj:`str`
+            File to which the result will be saved.
+        compress : :obj:`bool`, optional
+            If True, the file will be compressed with gzip. Otherwise, the
+            uncompressed version will be saved. Default = True.
+        with_inputs : :obj:`bool`, optional
+            Whether to write the estimator's input images into the file. Default = True.
+            False replaces them with :class:`DroppedInput` placeholders, which for an
+            image-based result is most of the file.
+
+            The maps, tables, masker, corrector and study ids are unaffected, so
+            ``get_map``, ``save_maps``, ``save_tables``, ``copy``, the Bonferroni and FDR
+            corrections and the diagnostics all still work; the diagnostics re-read the
+            images from disk for each refit. :func:`~nimare.reports.base.run_reports` and
+            ``FWECorrector(method="montecarlo")`` on an image-based estimator do not: they
+            read the input arrays, and raise when they reach a placeholder.
+        """
+        if with_inputs:
+            super().save(filename, compress=compress)
+            return
+
+        # A shell, not a copy: sharing the maps and tables avoids duplicating them in
+        # order to write a smaller file.
+        stripped = _shell(self, estimator=_drop_input_images(self.estimator))
+        NiMAREBase.save(stripped, filename, compress=compress)
+
     def save_maps(self, output_dir=".", prefix="", prefix_sep="_", names=None):
         """Save results to files.
 
@@ -248,17 +390,12 @@ class MetaResult(NiMAREBase):
 
     def copy(self):
         """Return copy of result object."""
-        new = object.__new__(MetaResult)
-        # Deep copy the estimator so that corrected results can update estimator state
-        # without mutating the original MetaResult or estimator.
-        new.estimator = copy.deepcopy(self.estimator)
-        new.corrector = self.corrector
-        new.diagnostics = self.diagnostics
-        new.masker = self.masker
-        new.maps = copy.deepcopy(self.maps)
-        new.tables = copy.deepcopy(self.tables)
-        new.metadata = {}
-        # Bypass the description_ setter (which re-parses bibtex on every call).
-        # Both attributes are already computed and neither changes after fit.
-        new._set_description(self.description_)
-        return new
+        return _shell(
+            self,
+            # Deep copy the estimator so that corrected results can update estimator state
+            # without mutating the original MetaResult or estimator.
+            estimator=copy.deepcopy(self.estimator),
+            maps=copy.deepcopy(self.maps),
+            tables=copy.deepcopy(self.tables),
+            metadata={},
+        )

--- a/nimare/tests/test_results.py
+++ b/nimare/tests/test_results.py
@@ -1,0 +1,108 @@
+"""Test nimare.results."""
+
+import os
+
+import numpy as np
+import pytest
+
+from nimare.correct import FDRCorrector, FWECorrector
+from nimare.diagnostics import Jackknife
+from nimare.meta.cbma.mkda import MKDADensity
+from nimare.meta.ibma import PermutedOLS, Stouffers
+from nimare.reports.base import run_reports
+from nimare.results import DroppedInput, MetaResult
+
+
+class _SubResult(MetaResult):
+    """Stand-in for the MetaResult subclasses estimators may return."""
+
+
+@pytest.fixture(scope="module")
+def ibma_result(testdata_ibma):
+    """Return a corrected image-based result to save and reload."""
+    return FDRCorrector(method="indep").transform(Stouffers().fit(testdata_ibma))
+
+
+def test_save_with_inputs_round_trips_the_input_arrays(tmp_path, ibma_result):
+    """The default save keeps the inputs it always kept."""
+    filename = os.path.join(tmp_path, "full.pkl.gz")
+    ibma_result.save(filename)
+    inputs = MetaResult.load(filename).estimator.inputs_
+
+    assert set(inputs) == set(ibma_result.estimator.inputs_)
+    assert np.array_equal(inputs["z_maps"], ibma_result.estimator.inputs_["z_maps"])
+
+
+def test_save_without_inputs_drops_only_the_image_arrays(tmp_path, ibma_result):
+    """The flag empties the image keys, shrinks the file, and leaves the caller's copy."""
+    subclassed = ibma_result.copy()
+    subclassed.__class__ = _SubResult
+
+    full = os.path.join(tmp_path, "full.pkl.gz")
+    lean = os.path.join(tmp_path, "lean.pkl.gz")
+    subclassed.save(full)
+    subclassed.save(lean, with_inputs=False)
+    loaded = _SubResult.load(lean)
+
+    assert os.path.getsize(lean) < 0.5 * os.path.getsize(full)
+    assert isinstance(loaded, _SubResult)
+    assert isinstance(loaded.estimator.inputs_["z_maps"], DroppedInput)
+    assert isinstance(loaded.estimator.inputs_["data_bags"], DroppedInput)
+    assert set(loaded.estimator.inputs_) == set(ibma_result.estimator.inputs_)
+    assert list(loaded.estimator.inputs_["id"]) == list(ibma_result.estimator.inputs_["id"])
+    assert isinstance(subclassed.estimator.inputs_["z_maps"], np.ndarray)
+
+
+def test_result_without_inputs_still_serves_maps_and_diagnostics(tmp_path, ibma_result):
+    """Everything that does not read the input arrays survives the drop."""
+    filename = os.path.join(tmp_path, "lean.pkl.gz")
+    ibma_result.save(filename, with_inputs=False)
+    loaded = MetaResult.load(filename)
+
+    assert loaded.get_map("z") is not None
+    loaded.save_maps(output_dir=os.path.join(tmp_path, "maps"))
+    loaded.copy()
+    FDRCorrector(method="indep").transform(loaded)
+
+    # The jackknife refits from the images on disk, so it needs the ids but not the arrays.
+    diagnosed = Jackknife(target_image="z_corr-FDR_method-indep", target_threshold=0.5).transform(
+        loaded
+    )
+    assert any("Jackknife" in name for name in diagnosed.tables)
+
+
+def test_report_of_a_result_without_inputs_reports_the_drop(tmp_path, ibma_result):
+    """Reporting reads the input maps, so it works on a whole file and says why on a lean one."""
+    full = os.path.join(tmp_path, "full.pkl.gz")
+    lean = os.path.join(tmp_path, "lean.pkl.gz")
+    ibma_result.save(full)
+    ibma_result.save(lean, with_inputs=False)
+
+    run_reports(MetaResult.load(full), os.path.join(tmp_path, "report"))
+    with pytest.raises(RuntimeError, match="z_maps.*with_inputs=False"):
+        run_reports(MetaResult.load(lean), os.path.join(tmp_path, "lean_report"))
+
+
+def test_montecarlo_correction_without_inputs_reports_the_drop(tmp_path, testdata_ibma):
+    """Monte Carlo FWE refits from the input arrays, so it reports the drop too."""
+    result = PermutedOLS().fit(testdata_ibma)
+    full = os.path.join(tmp_path, "full.pkl.gz")
+    lean = os.path.join(tmp_path, "lean.pkl.gz")
+    result.save(full)
+    result.save(lean, with_inputs=False)
+
+    corrector = FWECorrector(method="montecarlo", n_iters=5)
+    assert corrector.transform(MetaResult.load(full)).maps
+    with pytest.raises(RuntimeError, match="beta_maps.*with_inputs=False"):
+        corrector.transform(MetaResult.load(lean))
+
+
+def test_save_without_inputs_leaves_coordinate_results_alone(tmp_path, testdata_cbma):
+    """A coordinate-based estimator declares no image inputs, so nothing is dropped."""
+    result = MKDADensity(null_method="approximate").fit(testdata_cbma)
+    filename = os.path.join(tmp_path, "lean.pkl.gz")
+    result.save(filename, with_inputs=False)
+    inputs = MetaResult.load(filename).estimator.inputs_
+
+    assert not any(isinstance(value, DroppedInput) for value in inputs.values())
+    assert list(inputs["id"]) == list(result.estimator.inputs_["id"])

--- a/nimare/workflows/ibma.py
+++ b/nimare/workflows/ibma.py
@@ -97,12 +97,7 @@ class IBMAWorkflow(Workflow):
         dataset = normalize_collection(dataset)
 
         # Calculate missing images. Possible targets: {"z", "p", "beta", "varcope"}.
-        # Infer from self.estimator._required_inputs
-        targets = [
-            target
-            for _, (type_, target) in self.estimator._required_inputs.items()
-            if type_ == "image"
-        ]
+        targets = list(self.estimator._image_input_fields().values())
         xformer = ImageTransformer(target=targets)
         dataset = xformer.transform(dataset)
 


### PR DESCRIPTION
For an image-based meta-analysis, estimator.inputs_ is most of a pickled MetaResult: on twenty maps over the 2mm MNI mask it is 29.3 MB of a 36.5 MB pickle (80%), and 88% of the gzipped file, because the input maps are stored once as z_maps and again as the per-bag copies _preprocess_input derives from them. All of it is a second copy of NIfTIs that are still on disk.

It cannot come out by default, and it cannot come out via __getstate__. Loading a result and reading its inputs back is something three supported operations do: run_reports plots the input maps and their correlation matrix, PermutedOLS.correct_fwe_montecarlo refits from inputs_["beta_maps"], and the diagnostics enumerate studies from inputs_["id"]. And pickling is how NiMARE deep-copies an estimator -- both MetaResult.__init__ and MetaResult.copy go through copy.deepcopy -- so an estimator __getstate__ that dropped the inputs would break the first Corrector.transform, not just a later load.

So this is an opt-in on save, and it drops as little as it can. The keys emptied are the ones the estimator declares as images in _required_inputs plus the data_bags derived from them; the ids, sample sizes, contrast labels, correlation matrix and aggressive mask stay, since they are small and the jackknife needs the ids to enumerate the studies it refits from disk. A result saved this way still serves get_map, save_maps, save_tables, copy, Bonferroni and FDR correction, and Jackknife and FocusCounter, which re-read the images themselves. It is 17% of the full file on the pain test set and 12% at 2mm.

What it no longer serves is reporting and Monte Carlo FWE correction. Rather than let those fail with a KeyError several frames in, the dropped values are replaced by a DroppedInput placeholder that raises on any read and names the key and the flag that removed it. A coordinate-based estimator declares no image inputs, so nothing is dropped from one.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Allow MetaResult files to be saved without image inputs while clearly limiting operations that require those images.

New Features:
- Add an opt-in `with_inputs=False` save mode that produces smaller MetaResult files by omitting image-based estimator inputs while preserving other metadata and outputs.

Bug Fixes:
- Replace omitted inputs with explicit placeholders that provide actionable errors for reporting and Monte Carlo FWE correction instead of delayed missing-key failures.

Enhancements:
- Centralize image-input discovery across estimators, preprocessing, workflows, and result serialization.
- Preserve supported map, table, correction, copying, and diagnostic operations for results saved without input images.

Documentation:
- Document the new save option, retained capabilities, and operations unavailable when image inputs are omitted.

Tests:
- Add coverage for full and reduced save round trips, supported operations, informative failures, and unchanged coordinate-based results.