### PR TITLE
Refuse an image-based meta-analysis of fewer than two analyses

### DIFF
--- a/nimare/diagnostics.py
+++ b/nimare/diagnostics.py
@@ -44,6 +44,29 @@ POSTAIL_LBL = "PositiveTail"  # Label assigned to positive tail clusters
 NEGTAIL_LBL = "NegativeTail"  # Label assigned to negative tail clusters
 
 
+def _estimator_min_analyses(estimator):
+    """Return the fewest analyses ``estimator`` will fit, or None if it declares no floor.
+
+    Read off the estimator so a diagnostic refitting over subsets cannot drift from it.
+    CBMA estimators declare none, which turns off every check that consults this.
+    """
+    floor = getattr(estimator, "_min_analyses", None)
+    return None if floor is None else int(floor)
+
+
+def _refit_group_sizes(estimator):
+    """Return the size of each set of analyses a diagnostic would refit over.
+
+    One entry for a single-sample estimator, two for a pairwise one, which renames
+    ``inputs_["id"]`` to ``id1`` and ``id2`` as it collects each group.
+    """
+    return [
+        len(estimator.inputs_[key])
+        for key in ("id", "id1", "id2")
+        if key in getattr(estimator, "inputs_", {})
+    ]
+
+
 def _tail_mappings():
     """Return tail/sign mappings for consistent diagnostics labeling."""
     tail_to_sign = {"positive": POSTAIL_LBL, "negative": NEGTAIL_LBL}
@@ -782,6 +805,10 @@ class Diagnostics(NiMAREBase):
 class Jackknife(Diagnostics):
     """Run a jackknife analysis on a meta-analysis result.
 
+    .. versionchanged:: 0.21.0
+
+        * Raise :obj:`ValueError` when the result is too small to refit without one analysis.
+
     .. versionchanged:: 0.1.2
 
         * Support for pairwise meta-analyses.
@@ -805,6 +832,48 @@ class Jackknife(Diagnostics):
     summary statistics by the summary statistics from the original meta-analysis, and finally
     averaging the resulting proportion values across all voxels in each cluster.
     """
+
+    def _check_enough_analyses_to_drop_one(self, result):
+        """Refuse a result too small to refit without one of its analyses.
+
+        Parameters
+        ----------
+        result : :obj:`~nimare.results.MetaResult`
+            The result about to be jackknifed.
+
+        Raises
+        ------
+        ValueError
+            If dropping one analysis would leave the estimator below its own floor.
+        """
+        estimator = result.estimator
+        floor = _estimator_min_analyses(estimator)
+        if floor is None:
+            return
+
+        group_sizes = _refit_group_sizes(estimator)
+        if not group_sizes:
+            return
+
+        n_analyses = min(group_sizes)
+        minimum = floor + 1
+        if n_analyses >= minimum:
+            return
+
+        raise ValueError(
+            f"{type(self).__name__} needs at least {minimum} analyses, but this result was "
+            f"fitted on {n_analyses}: it refits the estimator without each analysis in turn, "
+            f"and {type(estimator).__name__} needs at least {floor}."
+        )
+
+    def transform(self, result):
+        """Refuse a result too small to leave one analysis out of, then run the jackknife.
+
+        Takes and returns what :meth:`Diagnostics.transform` does; see there for the tables
+        and maps added to ``result``.
+        """
+        self._check_enough_analyses_to_drop_one(result)
+        return super().transform(result)
 
     def _leave_one_out_values(self, expid, sign, result, target_value_map, image_cache=None):
         """Refit the Estimator without ``expid`` and return voxelwise proportional reductions.
@@ -1026,6 +1095,11 @@ class ResampledStability(NiMAREBase):
     input dataset and then characterizing the stability of the resulting
     meta-analytic map's voxelwise and/or clusterwise significance.
     Based on the implementation in :footcite:t:`Frahm_Monimu_Hoffstaedter`.
+
+    .. versionchanged:: 0.21.0
+
+        * Raise :obj:`ValueError` when a replicate would keep fewer analyses than the
+          estimator will fit.
 
     Parameters
     ----------
@@ -1334,6 +1408,15 @@ class ResampledStability(NiMAREBase):
 
         all_ids = list(result.estimator.inputs_["id"])
         subsets, target_n_used = self._resolve_subsets(len(all_ids))
+
+        # The retained size, not the total, so every policy is covered and not just leave_1_out.
+        floor = _estimator_min_analyses(result.estimator)
+        if floor is not None and target_n_used < floor:
+            raise ValueError(
+                f"resampling_policy={self.resampling_policy!r} keeps {target_n_used} of "
+                f"{len(all_ids)} analyses per replicate, but "
+                f"{type(result.estimator).__name__} needs at least {floor}."
+            )
 
         if isinstance(result.estimator, CBMAEstimator):
             stability_map = self._cbma_subset_stability(result, subsets, target_n_used)

--- a/nimare/diagnostics.py
+++ b/nimare/diagnostics.py
@@ -50,21 +50,7 @@ def _estimator_min_analyses(estimator):
     Read off the estimator so a diagnostic refitting over subsets cannot drift from it.
     CBMA estimators declare none, which turns off every check that consults this.
     """
-    floor = getattr(estimator, "_min_analyses", None)
-    return None if floor is None else int(floor)
-
-
-def _refit_group_sizes(estimator):
-    """Return the size of each set of analyses a diagnostic would refit over.
-
-    One entry for a single-sample estimator, two for a pairwise one, which renames
-    ``inputs_["id"]`` to ``id1`` and ``id2`` as it collects each group.
-    """
-    return [
-        len(estimator.inputs_[key])
-        for key in ("id", "id1", "id2")
-        if key in getattr(estimator, "inputs_", {})
-    ]
+    return getattr(estimator, "_min_analyses", None)
 
 
 def _tail_mappings():
@@ -851,11 +837,9 @@ class Jackknife(Diagnostics):
         if floor is None:
             return
 
-        group_sizes = _refit_group_sizes(estimator)
-        if not group_sizes:
-            return
-
-        n_analyses = min(group_sizes)
+        # Only IBMA estimators declare a floor, and none of them is pairwise, so there is no
+        # id1/id2 pair to take the smaller of.
+        n_analyses = len(estimator.inputs_["id"])
         minimum = floor + 1
         if n_analyses >= minimum:
             return

--- a/nimare/meta/_dependence.py
+++ b/nimare/meta/_dependence.py
@@ -9,6 +9,12 @@ term -- all belong to PyMARE.
 import numpy as np
 from pymare.stats import encode_groups, group_mean
 
+#: Independent units needed to estimate a variance. One unit says nothing about how much a
+#: second sample would have differed, so every floor in the library derives from this one:
+#: :attr:`DependenceModel.supports_inference` applies it to groups, and
+#: :attr:`~nimare.meta.ibma.IBMAEstimator._min_analyses` to the analyses that form them.
+MIN_INDEPENDENT_UNITS = 2
+
 
 def hashable_label(value):
     """Return a hashable stand-in for one group label.
@@ -115,7 +121,7 @@ class DependenceModel:
         that spread: PyMARE's cluster-robust sandwich, Stouffer's between-group variance and
         the sign-flip null all reject a single block outright.
         """
-        return self.n_groups >= 2
+        return self.n_groups >= MIN_INDEPENDENT_UNITS
 
     @property
     def dof(self):

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -156,6 +156,8 @@ class IBMAEstimator(Estimator):
           estimators. It was previously swallowed by ``**kwargs`` and had no effect.
         - Unrecognized keyword arguments now raise :obj:`TypeError` instead of being logged
           and ignored.
+        - Fitting fewer than two analyses now raises :obj:`ValueError` rather than
+          returning maps that are NaN at every voxel.
 
     .. versionchanged:: 0.2.1
 
@@ -185,6 +187,9 @@ class IBMAEstimator(Estimator):
     #: averaged; ``"warn"`` where the bias is real but unquantified; None where it does not
     #: apply.
     _voxel_averaging = "warn"
+
+    #: Fewest analyses these estimators will fit; below it every output map is NaN.
+    _min_analyses = 2
 
     def __init__(
         self,
@@ -248,6 +253,44 @@ class IBMAEstimator(Estimator):
         resample_kwargs = {k.split("resample__")[1]: v for k, v in resample_kwargs.items()}
         self._resample_kwargs.update(resample_kwargs)
 
+    def _check_enough_analyses(self, dataset):
+        """Refuse to fit fewer than :attr:`_min_analyses` analyses.
+
+        Parameters
+        ----------
+        dataset : :obj:`~nimare.nimads.Studyset` or :obj:`~nimare.dataset.Dataset`
+            The collection ``fit`` was called with. Only its analysis count is read, taken
+            before analyses lacking the required data were dropped.
+
+        Raises
+        ------
+        ValueError
+            If fewer than :attr:`_min_analyses` analyses carry the data this estimator needs.
+
+        Notes
+        -----
+        One analysis is NaN at every voxel either way: under ``aggressive_mask`` its single
+        model fails :attr:`~nimare.meta._dependence.DependenceModel.supports_inference`, and
+        otherwise :func:`~nimare.meta.utils._liberal_mask_bags` drops every bag for holding
+        fewer than two studies, leaving no skipped model to warn about.
+        """
+        n_used = len(self.inputs_["id"])
+        if n_used >= self._min_analyses:
+            return
+
+        n_submitted = len(dataset.ids)
+        dropped = ""
+        if n_submitted > n_used:
+            required = ", ".join(repr(name) for name in self._required_inputs)
+            dropped = f"; the other {n_submitted - n_used} lacked required data ({required})"
+
+        raise ValueError(
+            f"{type(self).__name__} needs at least {self._min_analyses} analyses, but "
+            f"{n_used} of the {n_submitted} submitted reached the estimator{dropped}. One "
+            "analysis has no independent replication to estimate a variance from, so every "
+            "output map would be NaN."
+        )
+
     def _preprocess_input(self, dataset):
         """Preprocess inputs to the Estimator from the Dataset as needed.
 
@@ -255,6 +298,9 @@ class IBMAEstimator(Estimator):
             Support for :class:`~nimare.dataset.Dataset` inputs is deprecated and will be removed
             in a future release. Prefer :class:`~nimare.nimads.Studyset`.
         """
+        # Before any image is loaded: the answer does not depend on their contents.
+        self._check_enough_analyses(dataset)
+
         masker, mask_img = get_masker_mask_image(self.masker, dataset=dataset)
 
         # Reserve the key for the correlation matrix

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -25,7 +25,11 @@ from pymare.stats import estimate_null_correlation
 
 from nimare import _version
 from nimare.estimator import Estimator
-from nimare.meta._dependence import DependenceModel, hashable_label
+from nimare.meta._dependence import (
+    MIN_INDEPENDENT_UNITS,
+    DependenceModel,
+    hashable_label,
+)
 from nimare.meta._permutation import _empirical_max_p, _permuted_ols
 from nimare.meta.utils import _liberal_mask_bags, _liberal_mask_values
 from nimare.transforms import d_to_g, p_to_z, t_to_d, t_to_nlogp, t_to_z
@@ -188,8 +192,9 @@ class IBMAEstimator(Estimator):
     #: apply.
     _voxel_averaging = "warn"
 
-    #: Fewest analyses these estimators will fit; below it every output map is NaN.
-    _min_analyses = 2
+    #: Fewest analyses these estimators will fit; below it every output map is NaN. An
+    #: analysis is at most one independent unit, so the floor on units is also the floor here.
+    _min_analyses = MIN_INDEPENDENT_UNITS
 
     def __init__(
         self,

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -617,6 +617,8 @@ def _liberal_mask_bags(mask):
     Each voxel's pattern is packed into bytes and handed to :func:`numpy.unique`, so the
     grouping costs one sort rather than a quadratic pairwise comparison.
     """
+    # Necessary condition for :attr:`~nimare.meta._dependence.MIN_INDEPENDENT_UNITS`, not the
+    # same count: this is studies, and a bag meeting it can still hold one group.
     MIN_STUDY_THRESH = 2
 
     # Pack each voxel's column of S booleans into ceil(S / 8) bytes, so that a whole pattern

--- a/nimare/tests/test_diagnostics.py
+++ b/nimare/tests/test_diagnostics.py
@@ -421,6 +421,45 @@ def test_jackknife_with_custom_masker_smoke(testdata_ibma):
         jackknife.transform(res)
 
 
+def test_jackknife_needs_one_more_analysis_than_the_estimator(testdata_ibma):
+    """The refit is what shrinks the studyset, so the floor is the estimator's plus one."""
+    jackknife = diagnostics.Jackknife(target_image="z", target_threshold=0.5)
+
+    with pytest.raises(ValueError) as exc_info:
+        jackknife.transform(ibma.Fishers().fit(testdata_ibma.slice(testdata_ibma.ids[:2])))
+
+    message = str(exc_info.value)
+    assert "Jackknife needs at least 3 analyses" in message
+    assert "Fishers needs at least 2" in message
+
+    results = jackknife.transform(ibma.Fishers().fit(testdata_ibma.slice(testdata_ibma.ids[:3])))
+    assert results.tables["z_diag-Jackknife_tab-counts"].shape[0] == 3
+
+
+def test_jackknife_leaves_cbma_alone(testdata_cbma_full):
+    """CBMA estimators declare no floor, so a two-experiment jackknife must still run."""
+    ids_ = sorted(set(testdata_cbma_full.coordinates["id"]))[:2]
+    res = cbma.ALE().fit(testdata_cbma_full.slice(ids_))
+    jackknife = diagnostics.Jackknife(target_image="z", target_threshold=0.1)
+
+    results = jackknife.transform(res)
+
+    assert results.tables["z_diag-Jackknife_tab-counts_tail-positive"].shape[0] == 2
+
+
+def test_resampled_stability_refuses_replicates_below_the_estimator_floor(testdata_ibma):
+    """Leaving one of two out fits each replicate on a single analysis."""
+    res = ibma.Fishers().fit(testdata_ibma.slice(testdata_ibma.ids[:2]))
+    stability = diagnostics.ResampledStability(target_image="z", resampling_policy="leave_1_out")
+
+    with pytest.raises(ValueError) as exc_info:
+        stability.transform(res)
+
+    message = str(exc_info.value)
+    assert "keeps 1 of 2 analyses per replicate" in message
+    assert "Fishers needs at least 2" in message
+
+
 def test_focuscounter_negative_tail_label_map_naming(testdata_cbma_full):
     """Ensure single-tail negative clusters are labeled as negative."""
     dset = testdata_cbma_full.slice(testdata_cbma_full.ids[:5])

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -245,6 +245,37 @@ def test_stouffers_multiple_contrasts(testdata_ibma_multiple_contrasts, aggressi
     assert z_img.shape == (10, 10, 10)
 
 
+@pytest.mark.parametrize(
+    "with_dropped,expected",
+    [
+        (False, "1 of the 1 submitted reached the estimator."),
+        (True, "1 of the 2 submitted reached the estimator; the other 1 lacked required "),
+    ],
+    ids=["nothing-dropped", "one-dropped"],
+)
+def test_ibma_refuses_fewer_than_two_analyses(testdata_ibma, with_dropped, expected):
+    """One analysis is NaN at every voxel, and the message says where the others went."""
+    images = testdata_ibma.images
+    ids_ = images.loc[images["z"].notna(), "id"].tolist()[:1]
+    if with_dropped:
+        ids_ += images.loc[images["z"].isna(), "id"].tolist()[:1]
+
+    with pytest.raises(ValueError) as exc_info:
+        ibma.Fishers().fit(testdata_ibma.slice(ids_))
+
+    message = str(exc_info.value)
+    assert "Fishers needs at least 2 analyses" in message
+    assert expected in message
+    assert ("'z_maps'" in message) is with_dropped
+
+
+def test_ibma_fits_two_analyses(testdata_ibma):
+    """The floor is two, not three."""
+    results = ibma.Fishers().fit(testdata_ibma.slice(testdata_ibma.ids[:2]))
+
+    assert np.isfinite(results.get_map("z", return_type="array")).any()
+
+
 def _z_image_paths(dataset):
     """Return the z-image paths that are actually on disk, as the estimators see them."""
     return [


### PR DESCRIPTION
Every IBMA estimator needs at least two independent units, so a fit over a single analysis returns maps that are NaN at every voxel. Nothing said so. `StudysetView.resolve` guards zero rows -- "The collection has no data for 'z_maps'" -- but nothing guarded one, and the two masking strategies both produce the NaN quietly: `aggressive_mask=True` fits one model that `DependenceModel.supports_inference` rejects, and `aggressive_mask=False` has `_liberal_mask_bags` drop every bag for holding fewer than two studies, which leaves no skipped model for `_fit_over_bags` to warn about. The caller gets a MetaResult, writes it out, and finds out later.

This came out of a Neurostore studyset of 12 analyses that lost 11 of them to missing required map types. The one that survived fit, and the answer the caller needed was "your studyset lost 11 of 12 analyses", not "the maps are NaN" -- so the message carries both counts, and names the required inputs when analyses were dropped for want of them.

The floor is on the IBMA path only. A single-experiment CBMA produces a real map rather than NaN -- ALE, MKDADensity and KDA all return finite z over one study's foci -- so there is no evidence for the same floor in `Estimator._collect_inputs`, and it would be a stricter change.

Checked before raising, so no image is loaded first: too few analyses is a property of the collection, not of what the files contain.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Require sufficient independent analyses for IBMA fitting and resampling operations to fail early instead of producing invalid results.

New Features:
- Reject image-based meta-analyses that have fewer than two usable analyses, with errors identifying dropped analyses and missing required inputs.
- Expose minimum-analysis requirements to diagnostics so jackknife and resampling workflows reject insufficient replicates.

Bug Fixes:
- Prevent IBMA fits with a single analysis from silently returning all-NaN maps.

Enhancements:
- Keep CBMA estimators exempt from the minimum-analysis check while enforcing estimator-specific floors for IBMA diagnostics.

Documentation:
- Document the new minimum-analysis behavior for IBMA fitting, jackknife, and resampled stability diagnostics.

Tests:
- Add coverage for insufficient IBMA fits, dropped required inputs, valid two-analysis fits, jackknife requirements, resampling floors, and unaffected CBMA jackknives.