### PR TITLE
Raise on an id that Studyset.slice cannot resolve

### DIFF
--- a/nimare/studyset/columns.py
+++ b/nimare/studyset/columns.py
@@ -31,8 +31,14 @@ __all__ = [
     "ID_COLS",
     "LabelNamer",
     "is_missing",
+    "join_names",
+    "missing_names",
     "sorted_lookup",
+    "sorted_ranges",
 ]
+
+# How many names an error message lists before it starts counting instead.
+MAX_NAMED = 10
 
 
 class Dict8:
@@ -123,22 +129,46 @@ def is_missing(value):
     return value is None or (isinstance(value, float) and value != value)
 
 
+def sorted_ranges(sorted_keys, wanted):
+    """Return ``(starts, stops)``: the run of ``sorted_keys`` equal to each wanted value.
+
+    Empty where the value is absent, and longer than one element where
+    ``sorted_keys`` repeats it.
+    """
+    sorted_keys = np.asarray(sorted_keys)
+    wanted = np.asarray(wanted)
+    return (
+        np.searchsorted(sorted_keys, wanted, side="left"),
+        np.searchsorted(sorted_keys, wanted, side="right"),
+    )
+
+
 def sorted_lookup(sorted_keys, wanted):
     """Return ``(pos, found)`` for ``wanted`` against ``sorted_keys``.
 
     ``pos`` is where each wanted value sits in ``sorted_keys``; ``found`` says
-    whether it is actually there. The guard against running off the end and
-    matching the wrong neighbour is fiddly enough that three sites had their own
-    copy of it.
+    whether it is actually there. Callers that want every match of a repeated
+    key rather than the first want :func:`sorted_ranges` instead.
     """
-    sorted_keys = np.asarray(sorted_keys)
-    wanted = np.asarray(wanted)
-    n = len(sorted_keys)
-    pos = np.searchsorted(sorted_keys, wanted)
-    if not n:
-        return pos, np.zeros(len(wanted), dtype=bool)
-    found = (pos < n) & (sorted_keys[np.minimum(pos, n - 1)] == wanted)
-    return pos, found
+    starts, stops = sorted_ranges(sorted_keys, wanted)
+    return starts, stops > starts
+
+
+def missing_names(requested, present):
+    """Return the requested names ``present`` lacks, in the order asked, deduplicated."""
+    return [name for name in dict.fromkeys(requested) if name not in present]
+
+
+def join_names(names):
+    """Join ``names`` for an error message, counting the tail beyond ``MAX_NAMED``.
+
+    An id list can be thousands long, and a message reproducing all of them
+    cannot be read.
+    """
+    shown = ", ".join(map(str, names[:MAX_NAMED]))
+    if len(names) > MAX_NAMED:
+        shown += f", ... and {len(names) - MAX_NAMED} more"
+    return shown
 
 
 @dataclass

--- a/nimare/studyset/studyset.py
+++ b/nimare/studyset/studyset.py
@@ -19,7 +19,7 @@ import pandas as pd
 
 from nimare.studyset import blocks as _blocks
 from nimare.studyset import edit, requirements
-from nimare.studyset.columns import ID_COLS
+from nimare.studyset.columns import ID_COLS, join_names, missing_names
 from nimare.studyset.io import from_nimads, from_parquet, to_nimads_dict, write_nimads
 from nimare.studyset.io.parquet import write_parquet
 from nimare.studyset.layout import harmonize_space
@@ -394,10 +394,9 @@ class Studyset:
 
     def _label_block_for(self, labels, annotation=None):
         block = _blocks.label_block_for(self._view, annotation)
-        known = set(block.labels.tolist())
-        missing = [label for label in labels if label not in known]
+        missing = missing_names(labels, set(block.labels.tolist()))
         if missing:
-            raise ValueError(f"Missing label(s): {', '.join(map(str, missing))}")
+            raise ValueError(f"Missing label(s): {join_names(missing)}")
         return block
 
     def get_labels(self, ids=None):
@@ -413,28 +412,32 @@ class Studyset:
 
     def get_studies_by_label(self, labels=None, label_threshold=0.001, annotation=None):
         """Full analysis ids whose labels reach the threshold."""
-        masks = self._label_masks(labels, label_threshold, annotation)
-        return list(self.ids[masks.all(axis=0)])
+        return list(self.ids[self._label_masks(labels, label_threshold, annotation).all(axis=0)])
 
     def get_analyses_by_label(self, labels=None, label_threshold=0.001, annotation=None):
         """Short analysis ids whose labels reach the threshold."""
-        return self._short_ids(self.get_studies_by_label(labels, label_threshold, annotation))
+        keep = self._label_masks(labels, label_threshold, annotation).all(axis=0)
+        return list(self._view.short_keys[keep].astype(str))
 
-    def get_studies_by_mask(self, mask):
-        """Full analysis ids with at least one focus inside ``mask``."""
+    def _analyses_in_mask(self, mask):
+        """This selection, narrowed to analyses with at least one focus in ``mask``."""
         from nilearn.image import load_img
 
         from nimare.utils import _mask_img_to_bool
 
         if self.store.n_points == 0:
-            return []
+            return self._view.select(np.zeros(len(self._view), dtype=bool))
         mask = load_img(mask)
         flagged = self._view.points_in_mask(_mask_img_to_bool(mask), mask.affine)
-        return list(self._view.analyses_with_points(flagged).keys.astype(str))
+        return self._view.analyses_with_points(flagged)
+
+    def get_studies_by_mask(self, mask):
+        """Full analysis ids with at least one focus inside ``mask``."""
+        return list(self._analyses_in_mask(mask).keys.astype(str))
 
     def get_analyses_by_mask(self, mask):
-        """Return the short ids of analyses with at least one focus in ``mask``."""
-        return self._short_ids(self.get_studies_by_mask(mask))
+        """Short analysis ids with at least one focus inside ``mask``."""
+        return list(self._analyses_in_mask(mask).short_keys.astype(str))
 
     def get_studies_by_coordinate(self, xyz, r=20):
         """Full analysis ids with a focus within ``r`` mm of any of ``xyz``."""
@@ -459,22 +462,8 @@ class Studyset:
             hit = np.unique(groups[distances <= r])
         else:
             hit = np.unique(groups[np.argsort(distances)[:n]])
-        return self._short_ids(block.group_keys[hit])
-
-    def _short_ids(self, full_ids):
-        """The declared analysis id of each full ``"<study id>-<analysis id>"`` id.
-
-        Looked up, not split off the full id, because either half may itself
-        contain a hyphen.
-        """
-        store = self.store
-        short = dict(
-            zip(
-                np.asarray(store.analysis_full_key).astype(str).tolist(),
-                np.asarray(store.analysis_key).astype(str).tolist(),
-            )
-        )
-        return [short[str(i)] for i in full_ids]
+        # hit indexes the coordinate block's groups, which are this selection.
+        return list(self._view.short_keys[hit].astype(str))
 
     def _frame_field(self, frame, field, what):
         """Field names in ``frame``, or one field's values."""

--- a/nimare/studyset/studyset.py
+++ b/nimare/studyset/studyset.py
@@ -286,7 +286,35 @@ class Studyset:
 
     # -------------------------------------------------------------- selection
     def slice(self, ids=None, *, analyses=None, filter_level="analysis"):
-        """Return a studyset with only the requested ids."""
+        """Return a studyset with only the requested ids.
+
+        .. versionchanged:: 0.21.0
+
+            An id naming nothing raises instead of being ignored.
+
+        Parameters
+        ----------
+        ids : :obj:`str` or array_like of :obj:`str`
+            Analysis ids, or study ids when ``filter_level="study"``. An
+            analysis may be named by its full ``"<study id>-<analysis id>"`` id,
+            which :attr:`ids` lists, or by its analysis id alone. A short id
+            shared by several analyses selects all of them.
+        analyses : array_like of :obj:`str`, optional
+            An alias for ``ids``.
+        filter_level : {"analysis", "study"}, default="analysis"
+            Which level ``ids`` names.
+
+        Returns
+        -------
+        :class:`~nimare.studyset.Studyset`
+            A studyset holding only the named analyses.
+
+        Raises
+        ------
+        :obj:`ValueError`
+            If any id names nothing in this studyset, naming the ids that
+            failed. An empty ``ids`` is not an error.
+        """
         if ids is None and analyses is not None:
             ids = analyses
         elif ids is None:
@@ -298,15 +326,24 @@ class Studyset:
         return self.filter_ids(ids)
 
     def filter_ids(self, ids):
-        """Keep the named analyses. Full ids or short analysis ids both work."""
+        """Keep the named analyses, by full id or short analysis id.
+
+        Raises :obj:`ValueError` naming any id that matches nothing.
+        """
         return Studyset._wrap(self._view.select_keys(ids))
 
     def filter_study_ids(self, study_ids):
-        """Return a studyset with only the requested studies."""
+        """Return a studyset with only the requested studies.
+
+        Raises :obj:`ValueError` naming any id that matches nothing.
+        """
         return Studyset._wrap(self._view.select_studies(study_ids))
 
     def exclude_study_ids(self, study_ids):
-        """Return a studyset without the requested studies."""
+        """Return a studyset without the requested studies.
+
+        An id matching nothing is not an error.
+        """
         return Studyset._wrap(self._view.select_studies(study_ids, exclude=True))
 
     def filter_annotations(self, labels, threshold=0.001, match="all", annotation=None):
@@ -381,10 +418,7 @@ class Studyset:
 
     def get_analyses_by_label(self, labels=None, label_threshold=0.001, annotation=None):
         """Short analysis ids whose labels reach the threshold."""
-        return [
-            str(i).rsplit("-", 1)[-1]
-            for i in self.get_studies_by_label(labels, label_threshold, annotation)
-        ]
+        return self._short_ids(self.get_studies_by_label(labels, label_threshold, annotation))
 
     def get_studies_by_mask(self, mask):
         """Full analysis ids with at least one focus inside ``mask``."""
@@ -399,8 +433,8 @@ class Studyset:
         return list(self._view.analyses_with_points(flagged).keys.astype(str))
 
     def get_analyses_by_mask(self, mask):
-        """Return the full ids of analyses with at least one focus in ``mask``."""
-        return [str(i).rsplit("-", 1)[-1] for i in self.get_studies_by_mask(mask)]
+        """Return the short ids of analyses with at least one focus in ``mask``."""
+        return self._short_ids(self.get_studies_by_mask(mask))
 
     def get_studies_by_coordinate(self, xyz, r=20):
         """Full analysis ids with a focus within ``r`` mm of any of ``xyz``."""
@@ -425,7 +459,22 @@ class Studyset:
             hit = np.unique(groups[distances <= r])
         else:
             hit = np.unique(groups[np.argsort(distances)[:n]])
-        return [str(k).rsplit("-", 1)[-1] for k in block.group_keys[hit]]
+        return self._short_ids(block.group_keys[hit])
+
+    def _short_ids(self, full_ids):
+        """The declared analysis id of each full ``"<study id>-<analysis id>"`` id.
+
+        Looked up, not split off the full id, because either half may itself
+        contain a hyphen.
+        """
+        store = self.store
+        short = dict(
+            zip(
+                np.asarray(store.analysis_full_key).astype(str).tolist(),
+                np.asarray(store.analysis_key).astype(str).tolist(),
+            )
+        )
+        return [short[str(i)] for i in full_ids]
 
     def _frame_field(self, frame, field, what):
         """Field names in ``frame``, or one field's values."""

--- a/nimare/studyset/studyset.py
+++ b/nimare/studyset/studyset.py
@@ -420,7 +420,7 @@ class Studyset:
         return list(self._view.short_keys[keep].astype(str))
 
     def _analyses_in_mask(self, mask):
-        """This selection, narrowed to analyses with at least one focus in ``mask``."""
+        """Studies filtered with at least one focus in ``mask``."""
         from nilearn.image import load_img
 
         from nimare.utils import _mask_img_to_bool

--- a/nimare/studyset/view.py
+++ b/nimare/studyset/view.py
@@ -22,10 +22,13 @@ from typing import Optional
 import numpy as np
 
 from nimare.studyset import layout
-from nimare.studyset.columns import sorted_lookup
+from nimare.studyset.layout import ranges_to_indices
 from nimare.studyset.store import derived
 
 __all__ = ["Context", "View"]
+
+# How many unresolved ids an error names before it starts counting instead.
+_MAX_NAMED = 10
 
 
 @functools.lru_cache(maxsize=None)
@@ -139,25 +142,80 @@ class View:
             idx = self.index[idx]
         return View(self.store, idx, self.point_mask, self.context)
 
-    def select_keys(self, keys, *, allow_short=True):
-        """Narrow to the named analyses, by full id or short analysis id."""
-        wanted = np.unique(np.asarray([str(k) for k in np.atleast_1d(keys)], dtype=str))
+    def select_keys(self, keys, *, allow_short=True, strict=True):
+        """Narrow to the named analyses, by full id or short analysis id.
+
+        Parameters
+        ----------
+        keys : :obj:`str` or array_like of :obj:`str`
+            Analysis ids, each a full ``"<study id>-<analysis id>"`` id or the
+            analysis id on its own.
+        allow_short : :obj:`bool`, default=True
+            Whether an analysis id on its own may be matched.
+        strict : :obj:`bool`, default=True
+            Whether to raise on an id matching no analysis in this selection.
+
+        Raises
+        ------
+        :obj:`ValueError`
+            If ``strict`` and any id matches nothing. The error names them.
+        """
+        requested = [str(k) for k in np.atleast_1d(keys)]
+        wanted = np.unique(np.asarray(requested, dtype=str))
         rows = _resolve_key_rows(self.store, wanted, allow_short=allow_short)
         keep = np.isin(self.index, rows)
+        if strict:
+            self._require_keys(requested, self.index[keep], allow_short=allow_short)
         return self.select(keep)
 
+    def _require_keys(self, requested, rows, *, allow_short=True):
+        """Raise unless every requested id names one of ``rows``."""
+        store = self.store
+        present = set()
+        if len(rows):
+            present.update(_as_str(store.analysis_full_key[rows]).tolist())
+            if allow_short:
+                present.update(_as_str(store.analysis_key[rows]).tolist())
+        missing = _unresolved(requested, present)
+        if missing:
+            raise _unresolved_error(
+                "analysis",
+                missing,
+                "Analyses are matched on their full '<study id>-<analysis id>' id, which "
+                "Studyset.ids lists, or on the analysis id alone.",
+            )
+
     def drop_keys(self, keys):
-        """Narrow to everything except the named analyses."""
+        """Narrow to everything except the named analyses.
+
+        An id matching nothing is not an error: it is absent from the result
+        either way.
+        """
         wanted = np.unique(np.asarray([str(k) for k in np.atleast_1d(keys)], dtype=str))
         rows = _resolve_key_rows(self.store, wanted, allow_short=True)
         return self.select(~np.isin(self.index, rows))
 
-    def select_studies(self, study_keys, *, exclude=False):
-        """Narrow by parent study."""
+    def select_studies(self, study_keys, *, exclude=False, strict=True):
+        """Narrow by parent study.
+
+        ``strict`` raises on a study id with no analyses in this selection. It
+        does not apply to ``exclude``, for the reason given on :meth:`drop_keys`.
+        """
         store = self.store
-        wanted = np.asarray([str(k) for k in np.atleast_1d(study_keys)], dtype=str)
-        hit = np.isin(store.study_key.astype(str), wanted)
+        requested = [str(k) for k in np.atleast_1d(study_keys)]
+        wanted = np.asarray(requested, dtype=str)
+        hit = np.isin(_as_str(store.study_key), wanted)
         per_analysis = hit[store.study_idx[self.index]]
+        if strict and not exclude:
+            rows = self.index[per_analysis]
+            present = set(_as_str(store.study_key[store.study_idx[rows]]).tolist())
+            missing = _unresolved(requested, present)
+            if missing:
+                raise _unresolved_error(
+                    "study",
+                    missing,
+                    "Studies are matched on their own id, which Studyset.study_ids lists.",
+                )
         return self.select(~per_analysis if exclude else per_analysis)
 
     def select_points(self, mask):
@@ -310,7 +368,11 @@ class View:
 
 
 def _resolve_key_rows(store, wanted, *, allow_short=True):
-    """Rows whose full id -- or short analysis id -- is in ``wanted``."""
+    """Every row whose full id -- or declared analysis id -- is in ``wanted``.
+
+    NIMADS does not require an analysis id to be unique across studies, so a
+    short id can name several rows and all of them are returned.
+    """
     cache = derived(store)
     rows = []
     kinds = ("full", "short") if allow_short else ("full",)
@@ -318,20 +380,38 @@ def _resolve_key_rows(store, wanted, *, allow_short=True):
         key = ("sorted_keys", kind)
         got = cache.get(key)
         if got is None:
-            if kind == "full":
-                keys = store.analysis_full_key.astype(str)
-            else:
-                keys = np.asarray(
-                    [str(k).rsplit("-", 1)[-1] for k in store.analysis_full_key], dtype=str
-                )
+            source = store.analysis_full_key if kind == "full" else store.analysis_key
+            keys = _as_str(source)
             order = np.argsort(keys, kind="stable")
             got = (keys[order], order)
             cache[key] = got
         keys, order = got
         if not len(keys):
             continue
-        pos, ok = sorted_lookup(keys, wanted)
-        rows.append(order[pos[ok]])
+        starts = np.searchsorted(keys, wanted, side="left")
+        stops = np.searchsorted(keys, wanted, side="right")
+        positions, _ = ranges_to_indices(starts, stops)
+        rows.append(order[positions])
     if not rows:
         return np.empty(0, dtype=np.int64)
     return np.unique(np.concatenate(rows))
+
+
+def _as_str(values):
+    """``values`` as a string array, tolerating a store with no analyses."""
+    if values is None:
+        return np.empty(0, dtype=str)
+    return np.asarray(values).astype(str)
+
+
+def _unresolved(requested, present):
+    """The requested ids that ``present`` does not contain, in the order asked."""
+    return [key for key in dict.fromkeys(requested) if key not in present]
+
+
+def _unresolved_error(kind, missing, hint):
+    """A :class:`ValueError` naming the ids that resolved to nothing."""
+    shown = ", ".join(missing[:_MAX_NAMED])
+    if len(missing) > _MAX_NAMED:
+        shown += f", ... and {len(missing) - _MAX_NAMED} more"
+    return ValueError(f"No {kind} in this studyset matches: {shown}. {hint}")

--- a/nimare/studyset/view.py
+++ b/nimare/studyset/view.py
@@ -22,13 +22,10 @@ from typing import Optional
 import numpy as np
 
 from nimare.studyset import layout
-from nimare.studyset.layout import ranges_to_indices
+from nimare.studyset.columns import join_names, missing_names, sorted_ranges
 from nimare.studyset.store import derived
 
 __all__ = ["Context", "View"]
-
-# How many unresolved ids an error names before it starts counting instead.
-_MAX_NAMED = 10
 
 
 @functools.lru_cache(maxsize=None)
@@ -104,6 +101,15 @@ class View:
         return got
 
     @property
+    def short_keys(self):
+        """The analysis ids the selected analyses declare, without their study."""
+        got = self._cache.get("short_keys")
+        if got is None:
+            got = self.store.analysis_key[self.index]
+            self._cache["short_keys"] = got
+        return got
+
+    @property
     def study_keys(self):
         """Unique study ids of the selected analyses."""
         got = self._cache.get("study_keys")
@@ -171,18 +177,15 @@ class View:
     def _require_keys(self, requested, rows, *, allow_short=True):
         """Raise unless every requested id names one of ``rows``."""
         store = self.store
-        present = set()
-        if len(rows):
-            present.update(_as_str(store.analysis_full_key[rows]).tolist())
-            if allow_short:
-                present.update(_as_str(store.analysis_key[rows]).tolist())
-        missing = _unresolved(requested, present)
+        present = set(store.analysis_full_key[rows].astype(str).tolist())
+        if allow_short:
+            present.update(store.analysis_key[rows].astype(str).tolist())
+        missing = missing_names(requested, present)
         if missing:
-            raise _unresolved_error(
-                "analysis",
-                missing,
-                "Analyses are matched on their full '<study id>-<analysis id>' id, which "
-                "Studyset.ids lists, or on the analysis id alone.",
+            raise ValueError(
+                f"No analysis in this studyset matches: {join_names(missing)}. Analyses are "
+                "matched on their full '<study id>-<analysis id>' id, which Studyset.ids "
+                "lists, or on the analysis id alone."
             )
 
     def drop_keys(self, keys):
@@ -204,17 +207,16 @@ class View:
         store = self.store
         requested = [str(k) for k in np.atleast_1d(study_keys)]
         wanted = np.asarray(requested, dtype=str)
-        hit = np.isin(_as_str(store.study_key), wanted)
+        hit = np.isin(store.study_key.astype(str), wanted)
         per_analysis = hit[store.study_idx[self.index]]
         if strict and not exclude:
             rows = self.index[per_analysis]
-            present = set(_as_str(store.study_key[store.study_idx[rows]]).tolist())
-            missing = _unresolved(requested, present)
+            present = set(store.study_key[store.study_idx[rows]].astype(str).tolist())
+            missing = missing_names(requested, present)
             if missing:
-                raise _unresolved_error(
-                    "study",
-                    missing,
-                    "Studies are matched on their own id, which Studyset.study_ids lists.",
+                raise ValueError(
+                    f"No study in this studyset matches: {join_names(missing)}. Studies are "
+                    "matched on their own id, which Studyset.study_ids lists."
                 )
         return self.select(~per_analysis if exclude else per_analysis)
 
@@ -381,37 +383,15 @@ def _resolve_key_rows(store, wanted, *, allow_short=True):
         got = cache.get(key)
         if got is None:
             source = store.analysis_full_key if kind == "full" else store.analysis_key
-            keys = _as_str(source)
+            keys = source.astype(str)
             order = np.argsort(keys, kind="stable")
             got = (keys[order], order)
             cache[key] = got
         keys, order = got
         if not len(keys):
             continue
-        starts = np.searchsorted(keys, wanted, side="left")
-        stops = np.searchsorted(keys, wanted, side="right")
-        positions, _ = ranges_to_indices(starts, stops)
+        positions, _ = layout.ranges_to_indices(*sorted_ranges(keys, wanted))
         rows.append(order[positions])
     if not rows:
         return np.empty(0, dtype=np.int64)
     return np.unique(np.concatenate(rows))
-
-
-def _as_str(values):
-    """``values`` as a string array, tolerating a store with no analyses."""
-    if values is None:
-        return np.empty(0, dtype=str)
-    return np.asarray(values).astype(str)
-
-
-def _unresolved(requested, present):
-    """The requested ids that ``present`` does not contain, in the order asked."""
-    return [key for key in dict.fromkeys(requested) if key not in present]
-
-
-def _unresolved_error(kind, missing, hint):
-    """A :class:`ValueError` naming the ids that resolved to nothing."""
-    shown = ", ".join(missing[:_MAX_NAMED])
-    if len(missing) > _MAX_NAMED:
-        shown += f", ... and {len(missing) - _MAX_NAMED} more"
-    return ValueError(f"No {kind} in this studyset matches: {shown}. {hint}")

--- a/nimare/tests/test_studyset_store.py
+++ b/nimare/tests/test_studyset_store.py
@@ -524,3 +524,86 @@ def test_with_annotations_df_adds_alongside_by_default(store):
 
     assert {annotation.id for annotation in out.annotations} == before | {"extra_set"}
     assert out.annotations_df["extra"].tolist() == [1.0] * len(studyset)
+
+
+def selection_document():
+    """Ids that exercise every way selection can miss: hyphens and repeats."""
+    return {
+        "id": "ss",
+        "name": "ss",
+        "studies": [
+            {
+                "id": study,
+                "name": study,
+                "analyses": [
+                    {
+                        "id": analysis,
+                        "name": analysis,
+                        "points": [{"id": f"p{i}", "coordinates": xyz, "space": "MNI"}],
+                    }
+                    # "a-b" is hyphenated, and "plain" is declared by both studies,
+                    # which NIMADS permits.
+                    for i, (analysis, xyz) in enumerate(analyses)
+                ],
+            }
+            for study, analyses in (
+                ("mixed", (("a-b", [1.0, 2.0, 3.0]), ("plain", [4.0, 5.0, 6.0]))),
+                ("other", (("plain", [7.0, 8.0, 9.0]),)),
+            )
+        ],
+    }
+
+
+def test_slice_raises_on_an_unresolvable_analysis_id():
+    """Check that an id naming no analysis is an error, not an empty studyset."""
+    studyset = Studyset(selection_document())
+
+    # A list that mostly resolves is the dangerous case: the result looks right.
+    with pytest.raises(ValueError) as excinfo:
+        studyset.slice(analyses=["a-b", "nope", "also-nope"])
+    message = str(excinfo.value)
+    assert "nope" in message and "also-nope" in message and "a-b" not in message
+
+    # Long lists are counted rather than named in full.
+    with pytest.raises(ValueError, match=r"and 5 more"):
+        studyset.slice(analyses=[f"nope-{i}" for i in range(15)])
+
+    # Asking for nothing is not an error: no id failed to resolve.
+    assert len(studyset.slice(analyses=[])) == 0
+
+
+def test_slice_raises_on_an_id_outside_this_studyset():
+    """Check that an id held by the store but already sliced away still raises."""
+    kept = Studyset(selection_document()).slice(analyses=["mixed-a-b"])
+
+    with pytest.raises(ValueError, match="other-plain"):
+        kept.slice(analyses=["other-plain"])
+
+
+def test_slice_raises_on_an_unresolvable_study_id():
+    """Check that the study level reports an unresolvable id, but excluding does not."""
+    studyset = Studyset(selection_document())
+
+    with pytest.raises(ValueError, match="nope"):
+        studyset.slice(["nope"], filter_level="study")
+    assert len(studyset.exclude_study_ids(["nope"])) == 3
+
+
+def test_a_hyphenated_short_analysis_id_is_looked_up_not_split():
+    """Check that a hyphenated analysis id is reachable by the id it declares."""
+    studyset = Studyset(selection_document())
+
+    assert list(studyset.slice(analyses=["a-b"]).ids) == ["mixed-a-b"]
+    # "b" is what splitting the full id on its last hyphen produces, and it is
+    # not an id of anything, so the short ids the query helpers hand back can be
+    # fed straight back to slice.
+    with pytest.raises(ValueError, match=r"matches: b\."):
+        studyset.slice(analyses=["b"])
+    assert studyset.get_analyses_by_coordinate([1.0, 2.0, 3.0], r=1) == ["a-b"]
+
+
+def test_a_short_analysis_id_selects_every_analysis_that_declares_it():
+    """Check that a short id shared across studies keeps all of its analyses."""
+    studyset = Studyset(selection_document())
+
+    assert list(studyset.slice(analyses=["plain"]).ids) == ["mixed-plain", "other-plain"]


### PR DESCRIPTION
slice() returned an empty studyset for an id that named nothing, so a typo, an id from a different studyset and an id already sliced away were all indistinguishable from "these analyses genuinely have no data". The partially-resolvable case was worse than the wholly unresolvable one: a list where one id is wrong came back with a plausible-looking subset and nothing said an analysis had gone missing. Selecting is a request for the analyses named, so any id naming none of them now raises ValueError, and the error names the ids that failed rather than just the count.

Resolution is checked against the studyset in hand, not the store behind it, so slicing a sub-studyset with an id belonging to a sibling raises too. Excluding is left alone -- exclude_study_ids() and View.drop_keys() still ignore an id that matches nothing, because what they were asked to remove is absent from the result either way.

Two ways the short analysis id was unreachable, both from deriving it as full_id.rsplit("-", 1)[-1] instead of reading the analysis_key the store already carries:

- a hyphenated analysis id: "mixed-a-b" derived to "b", so the analysis could not be selected by the id it declares, and the short ids handed back by get_analyses_by_label/_mask/_coordinate could not be fed back into slice(). Left unfixed, raising would have turned a silent miss into a confident error on an id that is genuinely there.
- the positional ids generated for a document that declares none: "analysis-0" derived to "0".

Resolving a short id also kept only the first matching row. NIMADS does not require an analysis id to be unique across studies -- the bundled pain studyset calls every analysis "1" -- so selecting on one silently dropped every match after the first, and an accurate report of which ids resolved needs all of them anyway. Range lookup replaces the first-match one, matching the stance already documented on note_row_resolver.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Enforce accurate, studyset-local identifier resolution when selecting analyses and studies.

New Features:
- Make analysis and study selection reject identifiers that do not resolve within the current Studyset, with errors identifying missing ids.
- Support selecting all analyses that share a short analysis id, including hyphenated ids and ids returned by query helpers.

Bug Fixes:
- Correct short-id resolution for hyphenated analysis identifiers and documents without declared analysis ids.
- Prevent silently dropping duplicate short-id matches during selection.

Enhancements:
- Preserve permissive behavior for exclusion operations while improving missing-name formatting and lookup utilities.

Documentation:
- Document strict selection behavior, supported identifier forms, duplicate short-id matching, and exclusion semantics.

Tests:
- Add coverage for unresolved analysis and study ids, sliced-away ids, long missing-id lists, hyphenated ids, and repeated short ids.