### PR TITLE
Drop an input image that has no usable voxel

### DIFF
--- a/nimare/estimator.py
+++ b/nimare/estimator.py
@@ -26,6 +26,10 @@ class Estimator(NiMAREBase):
         a future release. Prefer :class:`~nimare.nimads.Studyset`.
     """
 
+    #: The ``drop_invalid`` ``fit`` was called with, for the validity that can only be
+    #: judged in ``_preprocess_input``, once the data are loaded.
+    _drop_invalid = True
+
     def __init__(
         self,
         memory=Memory(location=None, verbose=0),
@@ -87,8 +91,8 @@ class Estimator(NiMAREBase):
         dataset : :obj:`~nimare.nimads.Studyset` or :obj:`~nimare.dataset.Dataset`
             Collection object to analyze.
         drop_invalid : :obj:`bool`, optional
-            Whether to automatically ignore any studies without the required data or not.
-            Default is True.
+            Whether to automatically ignore any studies without the required data, or with
+            data that cannot be used, such as an all-zero image. Default is True.
 
         Returns
         -------
@@ -110,6 +114,7 @@ class Estimator(NiMAREBase):
         call `fit`.
         """
         dataset = normalize_collection(dataset)
+        self._drop_invalid = drop_invalid
         self._collect_inputs(dataset, drop_invalid=drop_invalid)
         self._preprocess_input(dataset)
         maps, tables, description = self._cache(self._fit, func_memory_level=1)(dataset)

--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -156,6 +156,7 @@ class IBMAEstimator(Estimator):
           estimators. It was previously swallowed by ``**kwargs`` and had no effect.
         - Unrecognized keyword arguments now raise :obj:`TypeError` instead of being logged
           and ignored.
+        - An image with no usable voxel is dropped and named; ``drop_invalid=False`` raises.
 
     .. versionchanged:: 0.2.1
 
@@ -185,6 +186,10 @@ class IBMAEstimator(Estimator):
     #: averaged; ``"warn"`` where the bias is real but unquantified; None where it does not
     #: apply.
     _voxel_averaging = "warn"
+
+    #: Which collected images ``_drop_empty_images`` kept, or None. ``groupby`` labels given
+    #: as a sequence are positional, so nothing else narrows them alongside the images.
+    _images_kept = None
 
     def __init__(
         self,
@@ -257,6 +262,9 @@ class IBMAEstimator(Estimator):
         """
         masker, mask_img = get_masker_mask_image(self.masker, dataset=dataset)
 
+        # Whatever a previous fit dropped says nothing about this one.
+        self._images_kept = None
+
         # Reserve the key for the correlation matrix
         self.inputs_["corr_matrix"] = None
 
@@ -309,6 +317,14 @@ class IBMAEstimator(Estimator):
             [np.isfinite(self.inputs_[name]) & (self.inputs_[name] != 0) for name in image_names]
         )
 
+        # Neither masking strategy notices an image with no usable voxel: the aggressive mask
+        # intersects its empty row into every output map, and the liberal mask leaves it out
+        # of every bag while it keeps its row in inputs_.
+        usable = validity.any(axis=1)
+        if not usable.all():
+            self._drop_empty_images(usable, image_names)
+            validity = validity[usable]
+
         if self.aggressive_mask:
             # Further reduce image-based inputs to remove "bad" voxels
             # (voxels with zeros or NaNs in any studies)
@@ -330,6 +346,59 @@ class IBMAEstimator(Estimator):
                 ]
 
         self._preprocess_dependence(dataset)
+
+    def _drop_empty_images(self, keep, image_names):
+        """Drop the input images that hold no usable voxel, and realign every input to them.
+
+        Parameters
+        ----------
+        keep : :obj:`numpy.ndarray`
+            Boolean, one entry per collected image, False where every voxel is unusable.
+        image_names : :obj:`list` of :obj:`str`
+            The ``inputs_`` keys holding masked image arrays.
+
+        Raises
+        ------
+        ValueError
+            If ``drop_invalid`` is False, or if no image would be left.
+
+        Notes
+        -----
+        Narrowing ``studyset_`` and collecting from it again is what keeps ``inputs_``,
+        ``blocks_`` and ``studyset_`` describing the same analyses. The masked arrays are
+        carried across so that no image is read off disk twice.
+        """
+        ids = np.asarray(self.inputs_["id"], dtype=str)
+        n_total = ids.size
+        dropped = ", ".join(ids[~keep])
+        n_dropped = n_total - int(keep.sum())
+
+        if not self._drop_invalid:
+            raise ValueError(
+                f"{n_dropped} of {n_total} images have no voxel with a usable value in every "
+                f"required input, so they can contribute nothing: {dropped}. Pass "
+                "drop_invalid=True to drop them and analyse the rest."
+            )
+
+        if not keep.any():
+            raise ValueError(
+                f"None of the {n_total} images have a voxel with a usable value in every "
+                f"required input, so there is nothing to meta-analyse: {dropped}."
+            )
+
+        LGR.warning(
+            "Dropping %d of %d image(s) with no voxel holding a usable value in every "
+            "required input: %s.",
+            n_dropped,
+            n_total,
+            dropped,
+        )
+
+        arrays = {name: self.inputs_[name][keep] for name in image_names}
+        self._images_kept = keep
+        self.studyset_ = self.studyset_.select_analyses(keep)
+        self._collect_inputs(self.studyset_)
+        self.inputs_.update(arrays)
 
     def _load_image(self, filename, mask_img):
         """Load one input image, resampling it only if its FOV differs from the mask's."""
@@ -572,6 +641,10 @@ class IBMAEstimator(Estimator):
 
         if self.groupby is not None and self.groupby is not False:  # explicit labels
             labels = [hashable_label(v) for v in np.asarray(self.groupby).ravel()]
+            kept = self._images_kept
+            if kept is not None and len(labels) == kept.size:
+                # One label per collected image, so a dropped image takes its label with it.
+                labels = [label for label, keep in zip(labels, kept) if keep]
             if len(labels) != len(self.inputs_["id"]):
                 raise ValueError(
                     f"groupby must contain one label per image: expected "

--- a/nimare/studyset/studyset.py
+++ b/nimare/studyset/studyset.py
@@ -315,7 +315,7 @@ class Studyset:
             raise ValueError("match must be 'all' or 'any'")
         masks = self._label_masks(labels, threshold, annotation)
         keep = masks.all(axis=0) if match == "all" else masks.any(axis=0)
-        return Studyset._wrap(self._view.select(keep))
+        return self.select_analyses(keep)
 
     def filter_metadata(self, field, op, value):
         """Keep analyses whose metadata ``field`` satisfies ``op value``."""
@@ -327,7 +327,11 @@ class Studyset:
         keep = _OPS[op](frame[field], value)
         if not isinstance(keep, pd.Series):
             keep = pd.Series(keep, index=frame.index)
-        return Studyset._wrap(self._view.select(keep.fillna(False).to_numpy(dtype=bool)))
+        return self.select_analyses(keep.fillna(False).to_numpy(dtype=bool))
+
+    def select_analyses(self, mask):
+        """Keep the analyses a boolean mask -- or an array of positions -- selects."""
+        return Studyset._wrap(self._view.select(mask))
 
     def select_points(self, point_mask):
         """Keep a subset of foci and every analysis."""

--- a/nimare/tests/test_meta_ibma.py
+++ b/nimare/tests/test_meta_ibma.py
@@ -3,6 +3,7 @@
 import logging
 import os.path as op
 
+import nibabel as nib
 import numpy as np
 import pytest
 from nilearn.image import concat_imgs
@@ -437,3 +438,93 @@ def test_combination_tests_report_no_evidence_as_zero(estimator):
     assert z_map[2] > 3
     assert z_map[3] > 0 and z_map[4] < 0
     assert np.isclose(z_map[3], -z_map[4])
+
+
+_EMPTY_SHAPE = (6, 7, 6)
+_EMPTY_AFFINE = np.diag([2.0, 2.0, 2.0, 1.0])
+
+
+def _write_nifti(path, data):
+    """Write ``data`` as a NIfTI at ``path`` and return the path."""
+    nib.save(nib.Nifti1Image(np.asarray(data, dtype=np.float32), _EMPTY_AFFINE), str(path))
+    return str(path)
+
+
+def _studyset_with_empty_images(tmp_path, empty, studies=("s0", "s0", "s0", "s1", "s2")):
+    """Return ``(studyset, mask)``: one z map per entry of ``studies``, zeroed at ``empty``."""
+    rng = np.random.RandomState(42)
+    analyses = {}
+    for i, study_id in enumerate(studies):
+        data = np.zeros(_EMPTY_SHAPE) if i in empty else rng.normal(1.0, 1.0, _EMPTY_SHAPE)
+        path = _write_nifti(tmp_path / f"z{i}.nii.gz", data)
+        analyses.setdefault(study_id, []).append((f"a{i}", path))
+
+    payload = {
+        "id": "ss",
+        "name": "ss",
+        "studies": [
+            {
+                "id": study_id,
+                "analyses": [
+                    {
+                        "id": analysis_id,
+                        "metadata": {"sample_sizes": [20]},
+                        "images": [{"value_type": "Z map", "filename": path, "space": "MNI"}],
+                    }
+                    for analysis_id, path in entries
+                ],
+            }
+            for study_id, entries in analyses.items()
+        ],
+    }
+    mask = _write_nifti(tmp_path / "mask.nii.gz", np.ones(_EMPTY_SHAPE))
+    return nimare.nimads.Studyset(payload), mask
+
+
+@pytest.mark.parametrize("aggressive_mask", [True, False], ids=["aggressive", "liberal"])
+def test_an_image_with_no_usable_voxel_is_dropped(tmp_path, caplog, aggressive_mask):
+    """An image that contributes nowhere must not be counted as an input, under either mask."""
+    studyset, mask = _studyset_with_empty_images(tmp_path, empty={2})
+
+    # use_sample_size adds a metadata input, so the drop has a second input to realign.
+    meta = ibma.Stouffers(mask=mask, aggressive_mask=aggressive_mask, use_sample_size=True)
+    with caplog.at_level(logging.WARNING, logger="nimare.meta.ibma"):
+        results = meta.fit(studyset)
+
+    assert "s0-a2" in caplog.text
+    assert [str(id_) for id_ in meta.inputs_["id"]] == ["s0-a0", "s0-a1", "s1-a3", "s2-a4"]
+    assert meta.inputs_["z_maps"].shape[0] == 4
+    assert len(meta.inputs_["contrast_names"]) == 4
+    assert len(meta.inputs_["sample_sizes"]) == 4
+    assert list(meta.studyset_.ids) == [str(id_) for id_ in meta.inputs_["id"]]
+    # Without the drop, the aggressive mask intersects the empty row into every map.
+    assert np.any(np.isfinite(results.maps["z"]))
+
+
+@pytest.mark.parametrize(
+    "empty,fit_kwargs,match",
+    [
+        ({2}, {"drop_invalid": False}, "s0-a2"),
+        (set(range(5)), {}, "nothing to meta-analyse"),
+    ],
+    ids=["not-asked-for", "nothing-left"],
+)
+def test_dropping_an_empty_image_is_refused(tmp_path, empty, fit_kwargs, match):
+    """Refuse when the caller did not ask for a drop, or when the drop leaves nothing."""
+    studyset, mask = _studyset_with_empty_images(tmp_path, empty=empty)
+
+    with pytest.raises(ValueError, match=match):
+        ibma.Stouffers(mask=mask).fit(studyset, **fit_kwargs)
+
+
+def test_dropping_an_empty_image_narrows_explicit_groupby_labels(tmp_path):
+    """Labels given to ``groupby`` are positional, so a dropped image drops its label."""
+    studyset, mask = _studyset_with_empty_images(
+        tmp_path, empty={1}, studies=("s0", "s0", "s1", "s2")
+    )
+
+    meta = ibma.Stouffers(mask=mask, groupby=["x", "x", "y", "y"])
+    meta.fit(studyset)
+
+    assert [str(id_) for id_ in meta.inputs_["id"]] == ["s0-a0", "s1-a2", "s2-a3"]
+    assert list(meta.inputs_["contrast_names"]) == [0, 1, 1]


### PR DESCRIPTION
An entirely zero upload -- 2 of 242 maps in one real Neurostore staging studyset -- reached the estimator with no warning of any kind, and did harm either way the mask was built. With aggressive_mask=True it emptied the intersection over every image by itself, so every output map came back NaN and the only signal was a voxel count that never named the map responsible. With aggressive_mask=False it joined no liberal-mask bag, so it changed no number in the result, but it still held a row in inputs_["id"] and a slot in contrast_names: anything reporting what the meta-analysis rested on counted an analysis that contributed nothing anywhere.

_preprocess_input already computed the array the check needs, since `validity` is exactly where each image has a usable value in every required input; it simply never asked whether a whole image was empty. Ask it, and drop the image the way any other unusable input is dropped, naming it in the warning. Under drop_invalid=False, raise instead -- that flag already means "do not silently narrow my inputs" -- and raise as well when the drop would leave nothing to meta-analyse.

The check has to live here rather than at input collection: emptiness is a property of the voxels, which collection deliberately never reads, so moving it there would mean loading, resampling and masking every image inside the studyset layer and then doing it again in the estimator.

Dropping here means several parallel structures must stay aligned, so rather than filtering each in turn the drop narrows studyset_ and re-collects from it, which realigns inputs_["id"], the metadata inputs and blocks_ by construction; only the already-masked image arrays are carried across, so nothing is read off disk twice. Studyset gains select_analyses for the positional narrowing that needs. groupby labels given as a sequence are the one input the re-collection cannot reach -- they are positional, not part of the studyset -- so the drop records which images survived and _resolve_group_labels narrows them to match, instead of failing its own length check.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Prevent images with no usable voxels from contributing to meta-analyses while preserving input alignment and clear failure behavior.

Bug Fixes:
- Drop input images with no usable voxels before meta-analysis and identify them in warnings.
- Raise an error when invalid-image dropping is disabled or when removing unusable images leaves no analyses to process.
- Keep image IDs, metadata, contrasts, studysets, and positional group labels aligned after invalid images are removed.

Enhancements:
- Add positional analysis selection support to Studyset for consistent narrowing of collected analyses.

Documentation:
- Document that unusable images, including all-zero images, are ignored by default and that disabling invalid-input dropping raises an error.

Tests:
- Add coverage for unusable images under aggressive and liberal masking, refusal cases, and positional group-label alignment.