### PR TITLE
Estimate the null correlation per pair of images

### DIFF
--- a/nimare/meta/ibma.py
+++ b/nimare/meta/ibma.py
@@ -21,13 +21,13 @@ except ImportError:
     from nilearn._utils.niimg_conversions import check_same_fov
 
 from pymare.estimators.estimators import SMALL_SAMPLE_CORRECTIONS, WEIGHT_SCHEMES
-from pymare.stats import estimate_null_correlation
+from pymare.stats import estimate_null_correlation, undo_centering_shrinkage
 
 from nimare import _version
 from nimare.estimator import Estimator
 from nimare.meta._dependence import DependenceModel, hashable_label
 from nimare.meta._permutation import _empirical_max_p, _permuted_ols
-from nimare.meta.utils import _liberal_mask_bags, _liberal_mask_values
+from nimare.meta.utils import _liberal_mask_bags, _liberal_mask_values, _usable
 from nimare.transforms import d_to_g, p_to_z, t_to_d, t_to_nlogp, t_to_z
 from nimare.utils import (
     _check_ncores,
@@ -137,6 +137,90 @@ def _fill_doc(cls):
 
     cls.__doc__ = "\n".join(lines)
     return cls
+
+
+def _null_correlation(maps, groups):
+    """Estimate the null correlation between images that share no set of valid voxels.
+
+    Parameters
+    ----------
+    maps : :obj:`numpy.ndarray` of shape (K, V)
+        One masked image per row.
+    groups : :obj:`numpy.ndarray` of shape (K,)
+        Group codes, one per image.
+
+    Returns
+    -------
+    None or :obj:`numpy.ndarray` of shape (K, K)
+        The estimated correlation matrix, or None when no pair of images has two voxels
+        both are valid at.
+
+    Notes
+    -----
+    Real NeuroVault maps carry an exact 0 where they have no coverage, and no two of them
+    need cover the same voxels: on a 22-image staging studyset, 20.8% of the values are
+    structural zeros and *no* voxel is valid in every image. Correlating all of them anyway
+    correlates those placeholders, and centering is what makes that bite -- where two images
+    are both uncovered their residuals are both minus the across-image mean, so they track
+    each other perfectly. The bias runs in whichever direction the coverage pattern points:
+    with a shared signal of twice the noise sd, a true correlation of 0 between images
+    sharing a field of view is estimated at 0.67, while a true 0.5 between images with
+    independent fields of view is estimated at 0.10.
+
+    So each entry is estimated on the voxels where its own two images are both valid,
+    rather than one voxel set being imposed on every entry.
+
+    * The result is not guaranteed positive semi-definite, but neither is
+      :func:`~pymare.stats.estimate_null_correlation`'s, which is indefinite on 9 of 14 real
+      staging studysets. The combination tests read within-group blocks only, and
+      :func:`~pymare.stats.undo_centering_shrinkage` floors each block's mean correlation at
+      ``-1/(size - 1)``, which keeps every block sum non-negative.
+    * A pair with fewer than two shared voxels is left at zero. Those entries are never
+      read: a liberal-mask bag holds only images valid over the same voxels, so two images
+      that share none never appear in one fit.
+    * Centering over the images valid at each voxel, rather than over all K, shrinks the
+      residual correlations by more than the bias correction inverts, so this is biased
+      toward zero where coverage is sparse: about -0.05 at 70% coverage and -0.21 at 30%.
+      Inverting the shrinkage at the depth actually centered over would recover most of it,
+      but that derivation belongs in :func:`~pymare.stats.estimate_null_correlation`.
+    """
+    valid = _usable(maps)
+    if valid.all():
+        # Nothing to delete pairwise, which is where the aggressive-mask path always lands.
+        return estimate_null_correlation(maps, groups=groups)
+
+    # Strip the shared signal, as estimate_null_correlation does, but per voxel over the
+    # images valid there. Uncovered entries are zeroed so the sums below can be matrix
+    # products; the validity weights keep them out of every count.
+    counts = valid.sum(axis=0)
+    totals = np.where(valid, maps, 0.0).sum(axis=0, dtype=float)
+    means = np.divide(totals, counts, out=np.zeros_like(totals), where=counts > 0)
+    residuals = np.where(valid, np.asarray(maps, dtype=float) - means, 0.0)
+
+    # Pairwise-complete correlation for every pair at once. pandas.DataFrame.corr does the
+    # same thing in one call and agrees to 1.5e-14, but its Cython pair loop costs 6.7x
+    # these matrix products at 22 images and 20.7x at 100 (8.9 s against 0.43 s), since only
+    # these reach BLAS.
+    weights = valid.astype(float)
+    pair_voxels = weights @ weights.T
+    sums = residuals @ weights.T
+    squares = (residuals * residuals) @ weights.T
+    cross = residuals @ residuals.T
+    with np.errstate(invalid="ignore", divide="ignore"):
+        pair_means = sums / pair_voxels
+        covariance = cross / pair_voxels - pair_means * pair_means.T
+        variance = squares / pair_voxels - pair_means * pair_means
+        corr = covariance / np.sqrt(variance * variance.T)
+
+    estimable = np.isfinite(corr) & (pair_voxels >= 2)
+    if not estimable[~np.eye(corr.shape[0], dtype=bool)].any():
+        return None
+
+    corr = np.where(estimable, corr, 0.0)
+    # The two triangles are one quantity over one voxel set, so they differ only by rounding.
+    corr = np.clip((corr + corr.T) / 2.0, -1.0, 1.0)
+    np.fill_diagonal(corr, 1.0)
+    return undo_centering_shrinkage(corr, groups)
 
 
 class IBMAEstimator(Estimator):
@@ -300,14 +384,7 @@ class IBMAEstimator(Estimator):
         # them are. Both masking strategies intersect over inputs for that reason -- and for
         # the liberal path it also keeps the per-input bag lists aligned, since a varcope
         # blanked above would otherwise cut its maps into different bags from its betas.
-        #
-        # isfinite rather than ~isnan: an infinite value is not a usable statistic either,
-        # and it survives an isnan check. Input maps do carry them -- a t map divided by a
-        # zero standard error, say -- and one would otherwise reach PyMARE and turn a whole
-        # bag's output into NaN.
-        validity = np.logical_and.reduce(
-            [np.isfinite(self.inputs_[name]) & (self.inputs_[name] != 0) for name in image_names]
-        )
+        validity = np.logical_and.reduce([_usable(self.inputs_[name]) for name in image_names])
 
         if self.aggressive_mask:
             # Further reduce image-based inputs to remove "bad" voxels
@@ -646,28 +723,21 @@ class IBMAEstimator(Estimator):
             return
         maps = self.inputs_[image_names[0]]
 
-        # Correlate only where every image has a usable value. A single NaN makes
-        # np.corrcoef return NaN for that image's whole row, which estimate_null_correlation
-        # reads as zero correlation. The aggressive mask already guarantees this; the liberal
-        # path does not.
-        finite_voxels = np.all(np.isfinite(maps), axis=0)
-        if finite_voxels.sum() < 2:
+        # Correlating the raw maps measures how much studies agree, not how dependent they
+        # are: every map carries the same activation, so studies independent by construction
+        # still come out correlated. The shared signal is stripped first, which is what
+        # Brown's method and Stouffer's inflation term require, and the groups let the
+        # shrinkage that centering induces be inverted.
+        corr_matrix = _null_correlation(maps, self.inputs_["contrast_names"])
+        if corr_matrix is None:
             LGR.warning(
-                "Fewer than two voxels have a valid value in every image, so the null "
-                "correlation between the %d image(s) cannot be estimated. They are still "
-                "grouped, but the reference distribution will not be inflated for the "
-                "correlation within a group, so p-values may be anti-conservative.",
+                "No two of the %d image(s) have two voxels both are valid at, so the null "
+                "correlation between them cannot be estimated. They are still grouped, but "
+                "the reference distribution will not be inflated for the correlation within "
+                "a group, so p-values may be anti-conservative.",
                 n_studies,
             )
             return
-        maps = maps[:, finite_voxels]
-
-        # Correlating the raw maps measures how much studies agree, not how dependent they
-        # are: every map carries the same activation, so studies independent by construction
-        # still come out correlated. estimate_null_correlation strips the shared signal
-        # first, which is what Brown's method and Stouffer's inflation term require, and the
-        # groups let it invert the shrinkage that centering induces.
-        corr_matrix = estimate_null_correlation(maps, groups=self.inputs_["contrast_names"])
         self.inputs_["corr_matrix"] = corr_matrix
 
         off_diagonal = corr_matrix[~np.eye(corr_matrix.shape[0], dtype=bool)]
@@ -815,6 +885,8 @@ class Fishers(IBMAEstimator):
 
         * New parameter: ``groupby``, identifying images contributed by the same participants.
         * The ``dof`` map now counts independent groups rather than images.
+        * The null correlation between images is estimated per pair, on the voxels both are
+          valid at, rather than on the voxels every image is valid at.
 
     Requires z-statistic images, but will be extended to work with t-statistic images as well.
 
@@ -956,6 +1028,8 @@ class Stouffers(IBMAEstimator):
 
         * New parameter: ``groupby``, identifying images contributed by the same participants.
         * The ``dof`` map now counts independent groups rather than images.
+        * The null correlation between images is estimated per pair, on the voxels both are
+          valid at, rather than on the voxels every image is valid at.
 
     Requires z-statistic images.
 

--- a/nimare/meta/utils.py
+++ b/nimare/meta/utils.py
@@ -594,6 +594,17 @@ def _calculate_cluster_measures(arr3d, threshold, conn, tail="upper"):
     return max_size, max_mass
 
 
+def _usable(data):
+    """Return which entries of an image array are usable statistics.
+
+    isfinite rather than ~isnan: an infinite value is not a usable statistic either, and it
+    survives an isnan check. Input maps do carry them -- a t map divided by a zero standard
+    error, say -- and one would otherwise reach PyMARE and turn a whole model's output into
+    NaN. Zero is the placeholder a NeuroVault map carries where it has no coverage.
+    """
+    return np.isfinite(data) & (data != 0)
+
+
 def _liberal_mask_bags(mask):
     """Group voxels by which studies cover them.
 
@@ -666,7 +677,7 @@ def _apply_liberal_mask(data, validity=None):
     data : (S x V) :class:`numpy.ndarray`
         2D numpy array (S x V) of images, where S is study and V is voxel.
     validity : None or (S x V) :class:`numpy.ndarray` of :obj:`bool`, optional
-        Which entries of ``data`` are usable. Default is those that are neither NaN nor zero.
+        Which entries of ``data`` are usable. Default is :func:`_usable` of ``data``.
 
     Returns
     -------
@@ -687,8 +698,7 @@ def _apply_liberal_mask(data, validity=None):
     them rather than repeated per input.
 
     """
-    # isfinite, not ~isnan: an infinite value is not a usable statistic either.
-    mask = np.isfinite(data) & (data != 0) if validity is None else np.asarray(validity)
+    mask = _usable(data) if validity is None else np.asarray(validity)
     bags = _liberal_mask_bags(mask)
 
     return (

--- a/nimare/tests/test_meta_ibma_dependence.py
+++ b/nimare/tests/test_meta_ibma_dependence.py
@@ -9,9 +9,9 @@ import pytest
 from nilearn.maskers import NiftiMasker
 
 from nimare.meta import ibma
-from nimare.meta.ibma import _null_correlation
 from nimare.meta._dependence import DependenceModel
 from nimare.meta._permutation import _permuted_ols
+from nimare.meta.ibma import _null_correlation
 from nimare.meta.utils import _apply_liberal_mask
 from nimare.transforms import z_to_p
 

--- a/nimare/tests/test_meta_ibma_dependence.py
+++ b/nimare/tests/test_meta_ibma_dependence.py
@@ -9,6 +9,7 @@ import pytest
 from nilearn.maskers import NiftiMasker
 
 from nimare.meta import ibma
+from nimare.meta.ibma import _null_correlation
 from nimare.meta._dependence import DependenceModel
 from nimare.meta._permutation import _permuted_ols
 from nimare.meta.utils import _apply_liberal_mask
@@ -1144,3 +1145,44 @@ def test_permutation_batches_stay_within_their_memory_budget(use_weights, monkey
     # Slack for the null array and bookkeeping, but nowhere near the threefold overshoot an
     # undercounted budget produced.
     assert max(peaks) < 2 * budget
+
+
+def test_null_correlation_matches_pymare_when_nothing_is_missing():
+    """Complete data must keep giving exactly what PyMARE's own estimator gave."""
+    rng = np.random.RandomState(0)
+    maps = rng.normal(size=(4, 4000)) + 2.0 * rng.normal(size=4000)
+    groups = np.array([0, 0, 1, 1])
+
+    assert np.array_equal(
+        _null_correlation(maps, groups),
+        pymare.stats.estimate_null_correlation(maps, groups=groups),
+    )
+
+
+def test_null_correlation_ignores_the_zeros_that_stand_for_missing_coverage():
+    """A shared coverage hole is a shared constant, which centering makes look correlated.
+
+    Images 0 and 1 are independent but share a field of view and a strong shared signal.
+    """
+    rng = np.random.RandomState(0)
+    maps = rng.normal(size=(4, 4000)) + 2.0 * rng.normal(size=4000)
+    groups = np.array([0, 0, 1, 1])
+    holed = maps.copy()
+    holed[:2, :2000] = 0.0
+
+    complete = _null_correlation(maps, groups)[0, 1]
+    every_voxel = pymare.stats.estimate_null_correlation(holed, groups=groups)[0, 1]
+    pairwise = _null_correlation(holed, groups)[0, 1]
+
+    assert abs(complete) < 0.05
+    assert every_voxel > 0.6
+    assert abs(pairwise) < 0.25
+
+
+def test_null_correlation_gives_up_when_no_two_images_overlap():
+    """Two images that share no valid voxel leave nothing to estimate a correlation from."""
+    maps = np.ones((2, 400))
+    maps[0, 200:] = 0.0
+    maps[1, :200] = 0.0
+
+    assert _null_correlation(maps, np.array([0, 0])) is None


### PR DESCRIPTION
Real NeuroVault maps carry an exact 0 where they have no coverage, so _preprocess_dependence's isfinite test excluded nothing: on all 41 combination-test runs over 14 staging studysets it kept 100% of the mask, and on one of them 20.8% of the values correlated were structural zeros with no voxel valid in every image.

Centering is what makes that bite. Where two images are both uncovered their residuals are both minus the across-image mean, so they track each other perfectly, and the bias follows the coverage pattern rather than the truth. Against synthetic ground truth with a shared signal of twice the noise sd, a true 0 between images sharing a field of view came out at 0.67 and a true 0.5 between images with independent fields of view at 0.10; pairwise deletion recovered every configuration to within 0.07.

Downstream this moves 17 to 8015 surviving voxels per studyset at BH q=0.05, and cuts blocks that cancel outright from 56 to 32 of 3746. Per-bag estimation was measured and rejected: the median bag on a 22-image studyset holds 8 voxels and 11 images, 7.2% of its group blocks hit the correlation floor, and it aborted 88 of 475 fits.

Complete data still goes through pymare.stats.estimate_null_correlation unchanged, so the aggressive-mask path and full-coverage studysets are bit-identical.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Estimate coverage-aware null correlations to improve dependence adjustment for incompletely covered image sets.

New Features:
- Estimate null correlations pairwise using only voxels where each image pair has valid coverage.

Bug Fixes:
- Prevent structural zero values representing uncovered regions from biasing dependence estimates and downstream p-values.

Enhancements:
- Preserve the existing PyMARE correlation path for complete data while applying coverage-aware estimates to incomplete datasets.
- Centralize usable-statistic detection for finite, nonzero image values.

Documentation:
- Document pairwise null-correlation estimation for Fisher and Stouffer IBMA methods.

Tests:
- Add coverage for complete-data compatibility, structural-zero handling, and non-overlapping image pairs.