### PR TITLE
Fix default FDR correction being silently skipped in discrete decoders (#1119)

### DIFF
--- a/nimare/decode/discrete.py
+++ b/nimare/decode/discrete.py
@@ -165,7 +165,7 @@ class BrainMapDecoder(Decoder):
         features=None,
         frequency_threshold=0.001,
         u=0.05,
-        correction="fdr_bh",
+        correction="bh",
     ):
         self.feature_group = feature_group
         self.features = features
@@ -224,7 +224,7 @@ def brainmap_decode(
     features=None,
     frequency_threshold=0.001,
     u=0.05,
-    correction="fdr_bh",
+    correction="bh",
 ):
     """Perform image-to-text decoding for discrete inputs according to the BrainMap method.
 
@@ -460,7 +460,7 @@ class NeurosynthDecoder(Decoder):
         frequency_threshold=0.001,
         prior=0.5,
         u=0.05,
-        correction="fdr_bh",
+        correction="bh",
     ):
         self.feature_group = feature_group
         self.features = features
@@ -522,7 +522,7 @@ def neurosynth_decode(
     frequency_threshold=0.001,
     prior=0.5,
     u=0.05,
-    correction="fdr_bh",
+    correction="bh",
 ):
     """Perform discrete functional decoding according to Neurosynth's meta-analytic method.
 

--- a/nimare/tests/test_decode_discrete.py
+++ b/nimare/tests/test_decode_discrete.py
@@ -9,6 +9,51 @@ import pytest
 from nimare.decode import discrete
 
 
+def _make_synthetic_decode_data():
+    """Build synthetic coordinates/annotations for decode regression tests.
+
+    Uses enough studies (n=12, 6 selected) that per-feature counts clear the
+    rare-feature threshold used internally by brainmap_decode, so BH correction
+    actually changes the resulting p-values instead of being masked by other
+    filtering.
+    """
+    n = 12
+    ids = [f"s{i}" for i in range(n)]
+    coordinates = pd.DataFrame({"id": ids, "x": range(n), "y": range(n), "z": range(n)})
+    a = [1, 1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 0]
+    b = [1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0]
+    annotations = pd.DataFrame({"id": ids, "a": a, "b": b})
+    return coordinates, annotations, ids
+
+
+@pytest.mark.parametrize("decode_fn", [discrete.neurosynth_decode, discrete.brainmap_decode])
+def test_discrete_decode_default_correction_matches_bh(decode_fn):
+    """Default ``correction`` must apply BH FDR correction, not silently skip it.
+
+    Regression test: both ``neurosynth_decode`` and ``brainmap_decode`` default to
+    ``correction="fdr_bh"``, but the correction dispatch only recognizes ``"bh"``,
+    ``"by"``, and ``"bonferroni"``. That mismatch meant the default silently fell
+    through to no correction at all, identical to ``correction=None``.
+    """
+    coordinates, annotations, ids = _make_synthetic_decode_data()
+    kwargs = {
+        "coordinates": coordinates,
+        "annotations": annotations,
+        "ids": ids[:6],
+        "features": ["a", "b"],
+    }
+    columns = ["pForward", "pReverse"]
+
+    default_df = decode_fn(**kwargs)
+    uncorrected_df = decode_fn(**kwargs, correction=None)
+    bh_df = decode_fn(**kwargs, correction="bh")
+
+    # The default must actually apply correction, i.e. differ from uncorrected...
+    assert not uncorrected_df[columns].equals(default_df[columns])
+    # ...and must match explicitly requesting "bh", since that's the documented default.
+    pd.testing.assert_frame_equal(default_df[columns], bh_df[columns])
+
+
 def test_neurosynth_decode(testdata_laird):
     """Smoke test for discrete.neurosynth_decode."""
     ids = testdata_laird.ids[:5]


### PR DESCRIPTION
Fixes #1119.

## Root cause

`BrainMapDecoder`, `NeurosynthDecoder`, `brainmap_decode`, and `neurosynth_decode` all default to `correction="fdr_bh"`, and their docstrings say "Default is 'bh' (Benjamini-Hochberg FDR correction)". But the actual multiple-comparisons dispatch inside `brainmap_decode`/`neurosynth_decode` is:

```python
if correction in ("bh", "by"):
    nlogp_corr_fi = nlogp_fdr(nlogp_fi, method=correction)
    ...
elif correction == "bonferroni":
    ...
else:
    nlogp_corr_fi = nlogp_fi
    nlogp_corr_ri = nlogp_ri
```

`"fdr_bh"` doesn't match `"bh"`/`"by"`/`"bonferroni"`, so it falls into the `else` branch and silently returns uncorrected p-values — identical to `correction=None` — even though FDR correction is the documented default.

Reproduced with the exact script from the issue: `neurosynth_decode(**kwargs)` (default) and `neurosynth_decode(**kwargs, correction=None)` produced identical p-values.

## Fix

Change the default from `"fdr_bh"` to `"bh"` in all four places (`BrainMapDecoder.__init__`, `brainmap_decode`, `NeurosynthDecoder.__init__`, `neurosynth_decode`) so the default actually matches the value the dispatch logic (and the docstrings) already expect.

## Tests

Added `test_discrete_decode_default_correction_matches_bh`, parametrized over both `neurosynth_decode` and `brainmap_decode`, using a synthetic 12-study dataset sized so BH correction actually changes the resulting p-values (small samples get zeroed out by the existing rare-feature filter before correction can matter). Asserts the default output equals `correction="bh"` and differs from `correction=None`.

Verified this test fails against the unfixed code (`default == uncorrected`, exactly the reported bug) for both functions, and passes after the fix. Full `nimare/tests/test_decode_discrete.py`: 10 passed, 0 failures (pre-existing `FutureWarning`/`RuntimeWarning`s in other tests are unrelated, present on unmodified `main` too).

## Summary by Sourcery

Apply the documented Benjamini-Hochberg FDR correction by default in discrete decoding and verify the behavior with regression tests.

Bug Fixes:
- Ensure discrete BrainMap and Neurosynth decoders apply Benjamini-Hochberg FDR correction by default instead of silently returning uncorrected results.

Tests:
- Add regression coverage confirming default discrete decoding matches explicit BH correction and differs from uncorrected decoding.