### PR TITLE
Compute the CBMR observed information in closed form

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,4 +20,7 @@ jobs:
       - run: git fetch origin $GITHUB_BASE_REF:base $GITHUB_REF:pr
       - run: pip install asv virtualenv
       - run: asv machine --yes
-      - run: asv continuous base pr
+      # 1.2 rather than asv's default 1.1. The CBMR benchmarks run in single-digit
+      # milliseconds, and run-to-run spread on a shared runner is wider than 10% at that
+      # size, so 1.1 reports noise as a regression.
+      - run: asv continuous --factor 1.2 base pr

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,7 +20,5 @@ jobs:
       - run: git fetch origin $GITHUB_BASE_REF:base $GITHUB_REF:pr
       - run: pip install asv virtualenv
       - run: asv machine --yes
-      # 1.2 rather than asv's default 1.1. The CBMR benchmarks run in single-digit
-      # milliseconds, and run-to-run spread on a shared runner is wider than 10% at that
-      # size, so 1.1 reports noise as a regression.
+      # 1.2 means benches must be 20% slower to be flagged.
       - run: asv continuous --factor 1.2 base pr

--- a/benchmarks/bench_cbma.py
+++ b/benchmarks/bench_cbma.py
@@ -13,12 +13,8 @@ class TimeCBMA:
     """Time CBMA estimators."""
 
     def setup_cache(self):
-        """Build the datasets once per process, not once per timed sample.
+        """Build the datasets once per process.
 
-        asv re-runs ``setup`` before every sample. Building these costs seconds while the
-        estimators they feed run in tens of milliseconds, so setup dominated the suite's wall
-        clock without appearing in any reported number. The fixtures pickle to about 4.5 MB and
-        load in a few milliseconds, and fitting does not modify them.
         """
         dataset = nimare.dataset.Dataset(
             os.path.join(get_test_data_path(), "test_pain_dataset.json")

--- a/benchmarks/bench_cbma.py
+++ b/benchmarks/bench_cbma.py
@@ -12,25 +12,38 @@ from nimare.tests.utils import get_test_data_path
 class TimeCBMA:
     """Time CBMA estimators."""
 
-    def setup(self):
-        """
-        Setup the data.
+    def setup_cache(self):
+        """Build the datasets once per process, not once per timed sample.
 
-        Loads the dataset required for the benchmarks.
+        asv re-runs ``setup`` before every sample. Building these costs seconds while the
+        estimators they feed run in tens of milliseconds, so setup dominated the suite's wall
+        clock without appearing in any reported number. The fixtures pickle to about 4.5 MB and
+        load in a few milliseconds, and fitting does not modify them.
         """
-        self.dataset = nimare.dataset.Dataset(
+        dataset = nimare.dataset.Dataset(
             os.path.join(get_test_data_path(), "test_pain_dataset.json")
         )
-        _, self.dataset_dense = create_coordinate_dataset(
+        _, dataset_dense = create_coordinate_dataset(
             foci=60,
             n_studies=100,
             foci_percentage="100%",
             seed=123,
         )
-        self.studyset = Studyset.from_dataset(self.dataset)
-        self.studyset_dense = Studyset.from_dataset(self.dataset_dense)
+        return {
+            "dataset": dataset,
+            "dataset_dense": dataset_dense,
+            "studyset": Studyset.from_dataset(dataset),
+            "studyset_dense": Studyset.from_dataset(dataset_dense),
+        }
 
-    def time_ale(self):
+    def setup(self, data):
+        """Take the datasets from the cache."""
+        self.dataset = data["dataset"]
+        self.dataset_dense = data["dataset_dense"]
+        self.studyset = data["studyset"]
+        self.studyset_dense = data["studyset_dense"]
+
+    def time_ale(self, data):
         """
         Time the ALE estimator.
 
@@ -39,7 +52,7 @@ class TimeCBMA:
         meta = ALE()
         meta.fit(self.dataset)
 
-    def time_mkdadensity(self):
+    def time_mkdadensity(self, data):
         """
         Time the MKDADensity estimator.
 
@@ -48,14 +61,14 @@ class TimeCBMA:
         meta = MKDADensity()
         meta.fit(self.dataset)
 
-    def time_mkdadensity_studyset(self):
+    def time_mkdadensity_studyset(self, data):
         """
         Time the MKDADensity estimator on a Studyset converted from the benchmark Dataset.
         """
         meta = MKDADensity()
         meta.fit(self.studyset)
 
-    def time_mkdadensity_dense(self):
+    def time_mkdadensity_dense(self, data):
         """
         Time the MKDADensity estimator on a denser simulated dataset.
 
@@ -65,14 +78,14 @@ class TimeCBMA:
         meta = MKDADensity()
         meta.fit(self.dataset_dense)
 
-    def time_mkdadensity_dense_studyset(self):
+    def time_mkdadensity_dense_studyset(self, data):
         """
         Time the MKDADensity estimator on a dense Studyset input.
         """
         meta = MKDADensity()
         meta.fit(self.studyset_dense)
 
-    def time_kda(self):
+    def time_kda(self, data):
         """
         Time the KDA estimator.
 
@@ -81,14 +94,14 @@ class TimeCBMA:
         meta = KDA()
         meta.fit(self.dataset)
 
-    def time_kda_studyset(self):
+    def time_kda_studyset(self, data):
         """
         Time the KDA estimator on a Studyset converted from the benchmark Dataset.
         """
         meta = KDA()
         meta.fit(self.studyset)
 
-    def time_mkdachi2(self):
+    def time_mkdachi2(self, data):
         """
         Time the MKDAChi2 estimator.
 
@@ -97,14 +110,14 @@ class TimeCBMA:
         meta = MKDAChi2()
         meta.fit(self.dataset, self.dataset)
 
-    def time_mkdachi2_studyset(self):
+    def time_mkdachi2_studyset(self, data):
         """
         Time the MKDAChi2 estimator on Studyset inputs converted from the benchmark Dataset.
         """
         meta = MKDAChi2()
         meta.fit(self.studyset, self.studyset)
 
-    def time_mkdachi2_dense(self):
+    def time_mkdachi2_dense(self, data):
         """
         Time the MKDAChi2 estimator on a denser simulated dataset.
 
@@ -114,14 +127,14 @@ class TimeCBMA:
         meta = MKDAChi2()
         meta.fit(self.dataset_dense, self.dataset_dense)
 
-    def time_mkdachi2_dense_studyset(self):
+    def time_mkdachi2_dense_studyset(self, data):
         """
         Time the MKDAChi2 estimator on dense Studyset inputs.
         """
         meta = MKDAChi2()
         meta.fit(self.studyset_dense, self.studyset_dense)
 
-    def time_ale_studyset(self):
+    def time_ale_studyset(self, data):
         """
         Time the ALE estimator on a Studyset converted from the benchmark Dataset.
         """

--- a/benchmarks/benchmark_cbmr.py
+++ b/benchmarks/benchmark_cbmr.py
@@ -120,12 +120,8 @@ class _CBMRBenchmarkMixin:
     """Shared setup for CBMR benchmarks."""
 
     def setup_cache(self):
-        """Simulate the studyset once per process, not once per timed sample.
+        """Simulate the studyset once per process.
 
-        asv re-runs ``setup`` before every sample, and simulating the studyset costs seconds
-        while the benchmarks it feeds run in milliseconds. ``setup_cache`` runs once and its
-        result is pickled and handed to each sample, which is about 1.9 MB and a hundredth of a
-        second here.
         """
         return _make_studyset()
 

--- a/benchmarks/benchmark_cbmr.py
+++ b/benchmarks/benchmark_cbmr.py
@@ -119,9 +119,19 @@ def _legacy_terms(formula):
 class _CBMRBenchmarkMixin:
     """Shared setup for CBMR benchmarks."""
 
-    def setup(self):
-        """Simulate the data the benchmarks fit."""
-        self.studyset = _make_studyset()
+    def setup_cache(self):
+        """Simulate the studyset once per process, not once per timed sample.
+
+        asv re-runs ``setup`` before every sample, and simulating the studyset costs seconds
+        while the benchmarks it feeds run in milliseconds. ``setup_cache`` runs once and its
+        result is pickled and handed to each sample, which is about 1.9 MB and a hundredth of a
+        second here.
+        """
+        return _make_studyset()
+
+    def setup(self, studyset):
+        """Take the simulated studyset from the cache."""
+        self.studyset = studyset
 
     def _fit(self, formula, distribution="poisson", **overrides):
         """Fit one formula with the shared benchmark options."""
@@ -146,15 +156,15 @@ class _CBMRBenchmarkMixin:
 class TimeCBMRDistributions(_CBMRBenchmarkMixin):
     """Time each observation distribution on the same grouped design."""
 
-    def time_poisson(self):
+    def time_poisson(self, studyset):
         """Time the Poisson fit, the default and by far the cheapest."""
         self._fit("~ s(diagnosis:drug_status)")
 
-    def time_negative_binomial(self):
+    def time_negative_binomial(self, studyset):
         """Time the negative binomial fit, which adds one overdispersion parameter per group."""
         self._fit("~ s(diagnosis:drug_status)", distribution="negativebinomial", lr=1e-2)
 
-    def time_clustered_negative_binomial(self):
+    def time_clustered_negative_binomial(self, studyset):
         """Time the clustered negative binomial fit."""
         self._fit(
             "~ s(diagnosis:drug_status)",
@@ -166,19 +176,19 @@ class TimeCBMRDistributions(_CBMRBenchmarkMixin):
 class TimeCBMRDesigns(_CBMRBenchmarkMixin):
     """Time designs whose spatial-pattern counts differ, which is what drives fitting cost."""
 
-    def time_pooled(self):
+    def time_pooled(self, studyset):
         """One shared map: a single spatial pattern, the cheapest possible design."""
         self._fit("~ 1")
 
-    def time_grouped(self):
+    def time_grouped(self, studyset):
         """One map per cell: four spatial patterns."""
         self._fit("~ s(diagnosis:drug_status)")
 
-    def time_scalar_moderator(self):
+    def time_scalar_moderator(self, studyset):
         """Time a scalar moderator, which adds one coefficient and no new patterns."""
         self._fit("~ s(diagnosis:drug_status) + standardized_sample_sizes")
 
-    def time_spatial_moderator(self):
+    def time_spatial_moderator(self, studyset):
         """Time a continuous spatial term, which gives every experiment its own pattern.
 
         The expensive end of the range, and the case the old implementation needed a separate
@@ -186,7 +196,7 @@ class TimeCBMRDesigns(_CBMRBenchmarkMixin):
         """
         self._fit("~ s(diagnosis:drug_status) + s(standardized_avg_age)")
 
-    def time_sum_to_zero(self):
+    def time_sum_to_zero(self, studyset):
         """Additive spatial factors, via the sum-to-zero reparameterization."""
         self._fit("~ sz(diagnosis) + sz(drug_status)")
 
@@ -194,9 +204,9 @@ class TimeCBMRDesigns(_CBMRBenchmarkMixin):
 class TimeCBMRInference(_CBMRBenchmarkMixin):
     """Time hypothesis testing, whose cost is dominated by the covariance estimate."""
 
-    def setup(self):
+    def setup(self, studyset):
         """Fit once, then time inference against the fitted result."""
-        super().setup()
+        super().setup(studyset)
         self.result = self._fit("~ s(diagnosis:drug_status) + standardized_sample_sizes")
         if not HAS_FORMULA_CBMR:
             self.contrast_name = "DepressionYes-DepressionNo"
@@ -212,7 +222,7 @@ class TimeCBMRInference(_CBMRBenchmarkMixin):
         inference.fit(self.result)
         return inference
 
-    def time_spatial_contrast_fisher(self):
+    def time_spatial_contrast_fisher(self, studyset):
         """Time a per-voxel contrast using the Fisher-information covariance."""
         if HAS_FORMULA_CBMR:
             self.result.test("schizophrenia-Yes = schizophrenia-No", name="bench")
@@ -222,7 +232,7 @@ class TimeCBMRInference(_CBMRBenchmarkMixin):
                 t_con_moderators=False,
             )
 
-    def time_spatial_contrast_sandwich(self):
+    def time_spatial_contrast_sandwich(self, studyset):
         """Time the same contrast with a clustered sandwich covariance.
 
         The sandwich adds a meat matrix the same size as the bread, so this is the more
@@ -241,7 +251,7 @@ class TimeCBMRInference(_CBMRBenchmarkMixin):
                 t_con_moderators=False,
             )
 
-    def time_joint_contrast(self):
+    def time_joint_contrast(self, studyset):
         """Time a generalized linear hypothesis, which solves a small system per voxel."""
         if HAS_FORMULA_CBMR:
             self.result.test(
@@ -254,7 +264,7 @@ class TimeCBMRInference(_CBMRBenchmarkMixin):
                 t_con_moderators=False,
             )
 
-    def time_scalar_contrast(self):
+    def time_scalar_contrast(self, studyset):
         """Time a scalar term's test, which needs no per-voxel work at all."""
         if HAS_FORMULA_CBMR:
             self.result.test("standardized_sample_sizes = 0", name="bench")

--- a/benchmarks/benchmark_cbmr.py
+++ b/benchmarks/benchmark_cbmr.py
@@ -263,20 +263,3 @@ class TimeCBMRInference(_CBMRBenchmarkMixin):
                 t_con_groups=False,
                 t_con_moderators=self.moderator_contrast,
             )
-
-
-class TimeCBMRDiagnostics(_CBMRBenchmarkMixin):
-    """Time the moderator-effect diagnostic maps."""
-
-    def setup(self):
-        """Fit a design with a spatial moderator, which is what the diagnostics describe."""
-        super().setup()
-        self.result = self._fit("~ s(diagnosis) + s(standardized_avg_age)")
-
-    def time_moderator_effect_maps(self):
-        """Time relative-intensity and intensity-difference map generation."""
-        if HAS_FORMULA_CBMR:
-            self.result.moderator_effect_maps()
-        else:
-            inference = CBMRInference(device="cpu")
-            inference.fit(self.result)

--- a/nimare/meta/cbmr/covariance.py
+++ b/nimare/meta/cbmr/covariance.py
@@ -281,8 +281,7 @@ def is_block_diagonal(information, blocks):
     if len(blocks) < 2:
         return False
     return all(
-        np.count_nonzero(information[index])
-        == np.count_nonzero(information[np.ix_(index, index)])
+        np.count_nonzero(information[index]) == np.count_nonzero(information[np.ix_(index, index)])
         for index in blocks
     )
 
@@ -414,9 +413,7 @@ def fisher_covariance(model, information):
     cost differs. Structure is checked against the matrix, not assumed.
     """
     n_spatial = model.n_spatial
-    components = spatial_components(
-        model.predictor.patterns.loadings, model.predictor.n_bases
-    )
+    components = spatial_components(model.predictor.patterns.loadings, model.predictor.n_bases)
     # Moderators couple every spatial column through gamma, so the whole matrix separates only
     # when there are none.
     separable = not model.n_global and is_block_diagonal(information, components)
@@ -435,8 +432,10 @@ def fisher_covariance(model, information):
         if separable:
             return blockwise_inverse(information, components)
 
-        if model.n_global and len(components) > 1 and is_block_diagonal(
-            information[:n_spatial, :n_spatial], components
+        if (
+            model.n_global
+            and len(components) > 1
+            and is_block_diagonal(information[:n_spatial, :n_spatial], components)
         ):
             bordered = bordered_inverse(information, components, n_spatial)
             if bordered is not None:

--- a/nimare/meta/cbmr/covariance.py
+++ b/nimare/meta/cbmr/covariance.py
@@ -216,26 +216,35 @@ def sandwich_covariance(model, foci, meat="cluster", correction="hc1", ridge=0.0
     return bread_inverse @ meat_matrix @ bread_inverse
 
 
-# ---------------------------------------------------------------------------------------------
-# Structure of the Fisher information, and the strategies it permits.
-#
-# The information matrix's beta-beta block is ``sum_p L_pc L_pc' (B^T Sigma_p B)``, so the factor
-# ``L_pc L_pc'`` decides which entries can be nonzero at all -- independently of the
-# distribution, since it is a statement about the design. That sparsity is what the routines
-# below exploit. Each is proved at https://github.com/jdkent/cbmr-proofs.
-# ---------------------------------------------------------------------------------------------
+# The information matrix's spatial block is ``sum_p L_pc L_pc' (B^T Sigma_p B)``, so the factor
+# ``L_pc L_pc'`` decides which entries can be nonzero. That depends on the design, not on the
+# distribution. The routines below exploit it; each is proved at
+# https://github.com/jdkent/cbmr-proofs.
 
 
 def spatial_components(loadings, n_bases):
     """Return the groups of spatial parameter indices that can covary.
 
-    Two spatial columns are coupled when some pattern loads on both, since that is the only way a
-    cross term can be nonzero, and coupling is transitive -- so this is connected components over
-    the columns, seeded by each pattern's support. A cell-means factor gives one component per
-    level; a sum-to-zero term or a spatial covariate couples everything.
+    Two columns are coupled when some pattern loads on both. Coupling is transitive, so these are
+    the connected components of the columns.
 
-    Independent of the global block: this is the structure of ``D`` in the bordered form
-    ``[[D, C], [C^T, E]]``, which survives moderators even though full block diagonality does not.
+    Parameters
+    ----------
+    loadings : :obj:`numpy.ndarray`
+        Shape ``(n_patterns, n_spatial_columns)``.
+    n_bases : :obj:`int`
+        Width of the spline basis.
+
+    Returns
+    -------
+    :obj:`list` of :obj:`numpy.ndarray`
+        Index arrays into the spatial parameters.
+
+    Notes
+    -----
+    A cell-means factor gives one component per level. A sum-to-zero term or a spatial covariate
+    couples every column into one. Moderators do not enter: this describes ``D`` in the bordered
+    form ``[[D, C], [C^T, E]]``, which survives them.
     """
     n_columns = loadings.shape[1]
     parent = np.arange(n_columns)
@@ -263,12 +272,11 @@ def spatial_components(loadings, n_bases):
 
 
 def is_block_diagonal(information, blocks):
-    """Whether ``information`` really is block diagonal over ``blocks``.
+    """Return whether ``information`` is block diagonal over ``blocks``.
 
-    Nonzero *counts* rather than magnitudes: the claim being checked is that the off-block
-    entries are structurally absent, so a small-but-nonzero entry means the derivation is wrong,
-    not that the block is nearly separable. Rounding a real coupling to zero would silently
-    understate a standard error.
+    Compares nonzero counts, not magnitudes. The off-block entries should be exactly absent, so a
+    small nonzero one means the derivation is wrong. Treating it as zero would understate a
+    standard error.
     """
     if len(blocks) < 2:
         return False
@@ -282,10 +290,23 @@ def is_block_diagonal(information, blocks):
 def symmetric_condition_number(information, blocks=None):
     """Return the exact 2-norm condition number of a symmetric matrix.
 
-    For symmetric ``H`` the singular values are the absolute eigenvalues, so a symmetric
-    eigensolver replaces the SVD that ``np.linalg.cond`` forms -- exact, with no hypothesis on
-    the design, and several times faster. When ``H`` is block diagonal its spectrum is the union
-    of the blocks', so the eigensolver runs per block instead of once on the whole.
+    Parameters
+    ----------
+    information : :obj:`numpy.ndarray`
+        Symmetric matrix.
+    blocks : :obj:`list` of :obj:`numpy.ndarray`, optional
+        Blocks it is block diagonal over. Pass them to run the eigensolver per block.
+
+    Returns
+    -------
+    :obj:`float`
+        ``inf`` if the matrix is singular.
+
+    Notes
+    -----
+    A symmetric matrix's singular values are its absolute eigenvalues, so an eigensolver gives
+    the same answer as the SVD ``np.linalg.cond`` forms, several times faster. A block diagonal
+    matrix's spectrum is the union of its blocks'.
     """
     if blocks is None:
         values = np.linalg.eigvalsh(information)
@@ -298,10 +319,13 @@ def symmetric_condition_number(information, blocks=None):
 
 
 def cholesky_inverse(information):
-    """Invert a positive definite matrix from one Cholesky factor, or return None.
+    """Invert a positive definite matrix from one Cholesky factor.
 
-    ``None`` rather than an exception for a non-positive-definite matrix: that is a statement
-    about the fit, which the caller reports, not an error in this routine.
+    Returns
+    -------
+    :obj:`numpy.ndarray` or None
+        None if the matrix is not positive definite. That is a fact about the fit for the caller
+        to report, not an error here.
     """
     factor, info = lapack.dpotrf(information, lower=1, clean=1)
     if info != 0:
@@ -323,11 +347,24 @@ def blockwise_inverse(information, blocks):
 def bordered_inverse(information, blocks, n_spatial):
     """Invert ``[[D, C], [C^T, E]]`` with ``D`` block diagonal, by Schur complement.
 
-    Recovers most of the blockwise saving for a design whose spatial columns separate but which
-    carries global moderators: the cross block couples every spatial column through ``gamma``, so
-    the matrix is not block diagonal at all, but ``D`` underneath it still is. Returns None if
-    ``D`` or the Schur complement is singular, so the caller can fall back rather than propagate
-    a nonsense covariance.
+    Parameters
+    ----------
+    information : :obj:`numpy.ndarray`
+        The full matrix.
+    blocks : :obj:`list` of :obj:`numpy.ndarray`
+        Blocks of ``D``, from :func:`spatial_components`.
+    n_spatial : :obj:`int`
+        Where the border starts.
+
+    Returns
+    -------
+    :obj:`numpy.ndarray` or None
+        None if ``D`` or the Schur complement is singular, so the caller can fall back.
+
+    Notes
+    -----
+    Moderators couple every spatial column through ``gamma``, so the matrix is not block diagonal
+    even when ``D`` is. This keeps most of the blockwise saving anyway.
     """
     border = information[:n_spatial, n_spatial:]
     try:
@@ -346,25 +383,35 @@ def bordered_inverse(information, blocks, n_spatial):
 
 
 def fisher_covariance(model, information):
-    """Invert the observed information, exploiting whatever structure the design left.
+    """Invert the observed information, using whatever structure the design leaves.
 
-    A ladder, most specific rung first:
+    Parameters
+    ----------
+    model : :class:`~nimare.meta.cbmr.model.CBMRModel`
+        Fitted model, for its design and parameter counts.
+    information : :obj:`numpy.ndarray`
+        Observed Fisher information.
 
-    block diagonal
-        the spatial columns separate and there are no moderators. The spectrum is the union of
-        the blocks' and the inverse is blockwise. Only a lone cell-means factor reaches here.
-    bordered block diagonal
-        the spatial columns separate but moderators border them. The inverse still goes
-        blockwise, through a Schur complement; the condition number cannot follow, because the
-        spectrum of a bordered matrix is not the union of its parts.
-    dense
-        everything else. Still two improvements on a plain SVD-plus-LU: the condition number
-        comes from a symmetric eigensolver, and the inverse from a Cholesky factor when the
-        matrix is positive definite.
+    Returns
+    -------
+    :obj:`numpy.ndarray`
+        The inverse.
 
-    Every rung returns the same matrix and reports the same condition number to the last digit;
-    only the work differs. Structural claims are checked against the matrix in hand rather than
-    assumed.
+    Raises
+    ------
+    numpy.linalg.LinAlgError
+        If the information is singular, with advice on which setting to change.
+
+    Warns
+    -----
+    If the condition number is past what double precision can invert.
+
+    Notes
+    -----
+    Three routes, tried in order: blockwise when the spatial columns separate and there are no
+    moderators, a Schur complement when moderators border separable columns, and a dense inverse
+    otherwise. All three return the same matrix and report the same condition number; only the
+    cost differs. Structure is checked against the matrix, not assumed.
     """
     n_spatial = model.n_spatial
     loadings, n_bases = model.predictor.patterns.loadings, model.predictor.n_bases
@@ -379,9 +426,8 @@ def fisher_covariance(model, information):
             f"trusted. {_CONDITION_ADVICE}"
         )
 
-    # Every route funnels through one handler: a singular design must explain itself the same
-    # way whichever rung happened to reach it, and numpy's bare "Singular matrix" tells a user
-    # nothing about which knob to turn.
+    # One handler for every route: numpy's bare "Singular matrix" does not say which setting to
+    # change, and the message should not depend on which route hit the singularity.
     try:
         if separable:
             return blockwise_inverse(information, blocks)
@@ -406,8 +452,7 @@ def fisher_covariance(model, information):
         ) from error
 
 
-#: Repeated where a singular or ill-conditioned information matrix is reported, so a user gets
-#: the same actionable message from either path.
+#: Shared by the singular and ill-conditioned messages.
 _CONDITION_ADVICE = (
     "The design asks for more spatial detail than these foci can support. Try a coarser "
     "spline_spacing, a higher incidence_threshold, fewer s() terms, or more experiments; "

--- a/nimare/meta/cbmr/covariance.py
+++ b/nimare/meta/cbmr/covariance.py
@@ -414,11 +414,14 @@ def fisher_covariance(model, information):
     cost differs. Structure is checked against the matrix, not assumed.
     """
     n_spatial = model.n_spatial
-    loadings, n_bases = model.predictor.patterns.loadings, model.predictor.n_bases
-    blocks = spatial_components(loadings, n_bases) if not model.n_global else []
-    separable = bool(blocks) and is_block_diagonal(information, blocks)
+    components = spatial_components(
+        model.predictor.patterns.loadings, model.predictor.n_bases
+    )
+    # Moderators couple every spatial column through gamma, so the whole matrix separates only
+    # when there are none.
+    separable = not model.n_global and is_block_diagonal(information, components)
 
-    condition = symmetric_condition_number(information, blocks if separable else None)
+    condition = symmetric_condition_number(information, components if separable else None)
     if condition > 1.0 / np.finfo(float).eps:
         LGR.warning(
             f"The Fisher information matrix has condition number {condition:.3g}, past what "
@@ -430,16 +433,14 @@ def fisher_covariance(model, information):
     # change, and the message should not depend on which route hit the singularity.
     try:
         if separable:
-            return blockwise_inverse(information, blocks)
+            return blockwise_inverse(information, components)
 
-        if model.n_global:
-            spatial = spatial_components(loadings, n_bases)
-            if len(spatial) > 1 and is_block_diagonal(
-                information[:n_spatial, :n_spatial], spatial
-            ):
-                bordered = bordered_inverse(information, spatial, n_spatial)
-                if bordered is not None:
-                    return bordered
+        if model.n_global and len(components) > 1 and is_block_diagonal(
+            information[:n_spatial, :n_spatial], components
+        ):
+            bordered = bordered_inverse(information, components, n_spatial)
+            if bordered is not None:
+                return bordered
 
         inverse = cholesky_inverse(information)
         if inverse is not None:

--- a/nimare/meta/cbmr/covariance.py
+++ b/nimare/meta/cbmr/covariance.py
@@ -317,6 +317,44 @@ def symmetric_condition_number(information, blocks=None):
     return np.inf if smallest == 0 else np.abs(values).max() / smallest
 
 
+def one_norm_condition_number(information, inverse):
+    """Return the exact 1-norm condition number of a matrix whose inverse is already known.
+
+    Two O(n^2) passes, against O(n^3) for an eigendecomposition.
+
+    Parameters
+    ----------
+    information : :obj:`numpy.ndarray`
+        The matrix.
+    inverse : :obj:`numpy.ndarray`
+        Its inverse.
+
+    Returns
+    -------
+    :obj:`float`
+
+    Notes
+    -----
+    For a symmetric matrix ``kappa_2 <= kappa_1``: ``||M||_1 == ||M||_inf``, so
+    ``||M||_2 <= sqrt(||M||_1 ||M||_inf) == ||M||_1``, and the same holds for the inverse.
+    Warning on the 1-norm therefore never misses a matrix the 2-norm would have flagged. It can
+    warn on one the 2-norm would not: measured on CBMR information matrices the two differ by
+    roughly one to two orders of magnitude.
+    """
+    return float(np.abs(information).sum(axis=0).max() * np.abs(inverse).sum(axis=0).max())
+
+
+def _warn_if_ill_conditioned(n_parameters, condition, norm):
+    """Warn when the information is past what double precision can invert meaningfully."""
+    if condition > 1.0 / np.finfo(float).eps:
+        LGR.warning(
+            f"The Fisher information matrix over {n_parameters} coefficients has {norm} "
+            f"condition number {condition:.3g}, past what double precision can invert "
+            "meaningfully, so these standard errors should not be trusted. "
+            f"{_CONDITION_ADVICE}"
+        )
+
+
 def cholesky_inverse(information):
     """Invert a positive definite matrix from one Cholesky factor.
 
@@ -403,7 +441,9 @@ def fisher_covariance(model, information):
 
     Warns
     -----
-    If the condition number is past what double precision can invert.
+    If the condition number is past what double precision can invert. The message names the
+    norm: the bordered route reports the 1-norm, which is an upper bound on the 2-norm the
+    other routes report.
 
     Notes
     -----
@@ -418,28 +458,37 @@ def fisher_covariance(model, information):
     # when there are none.
     separable = not model.n_global and is_block_diagonal(information, components)
 
-    condition = symmetric_condition_number(information, components if separable else None)
-    if condition > 1.0 / np.finfo(float).eps:
-        LGR.warning(
-            f"The Fisher information matrix has condition number {condition:.3g}, past what "
-            "double precision can invert meaningfully, so these standard errors should not be "
-            f"trusted. {_CONDITION_ADVICE}"
-        )
+    # The bordered route runs first because it can report its own conditioning. A bordered
+    # matrix's spectrum is not the union of its blocks', so the 2-norm would need a full
+    # eigendecomposition of the whole matrix; the 1-norm falls out of the inverse this route
+    # already builds. bordered_inverse returns None rather than raising, so a singular matrix
+    # still reaches the shared handling below.
+    if (
+        not separable
+        and model.n_global
+        and len(components) > 1
+        and is_block_diagonal(information[:n_spatial, :n_spatial], components)
+    ):
+        bordered = bordered_inverse(information, components, n_spatial)
+        if bordered is not None:
+            _warn_if_ill_conditioned(
+                model.n_parameters, one_norm_condition_number(information, bordered), "1-norm"
+            )
+            return bordered
+
+    # Everywhere else the condition number is cheap, or the matrix is dense anyway. It is taken
+    # before the inverse so that a singular matrix is still described rather than only raising.
+    _warn_if_ill_conditioned(
+        model.n_parameters,
+        symmetric_condition_number(information, components if separable else None),
+        "2-norm",
+    )
 
     # One handler for every route: numpy's bare "Singular matrix" does not say which setting to
     # change, and the message should not depend on which route hit the singularity.
     try:
         if separable:
             return blockwise_inverse(information, components)
-
-        if (
-            model.n_global
-            and len(components) > 1
-            and is_block_diagonal(information[:n_spatial, :n_spatial], components)
-        ):
-            bordered = bordered_inverse(information, components, n_spatial)
-            if bordered is not None:
-                return bordered
 
         inverse = cholesky_inverse(information)
         if inverse is not None:

--- a/nimare/meta/cbmr/covariance.py
+++ b/nimare/meta/cbmr/covariance.py
@@ -31,6 +31,7 @@ einsum subscripts, where ``i`` indexes experiments, ``v`` voxels, ``c``/``d`` sp
 import logging
 
 import numpy as np
+from scipy.linalg import lapack
 
 from nimare.meta.cbmr.predictor import _as_dense_array
 
@@ -213,3 +214,202 @@ def sandwich_covariance(model, foci, meat="cluster", correction="hc1", ridge=0.0
         bread = bread + ridge * np.eye(n_parameters)
     bread_inverse = np.linalg.inv(bread)
     return bread_inverse @ meat_matrix @ bread_inverse
+
+
+# ---------------------------------------------------------------------------------------------
+# Structure of the Fisher information, and the strategies it permits.
+#
+# The information matrix's beta-beta block is ``sum_p L_pc L_pc' (B^T Sigma_p B)``, so the factor
+# ``L_pc L_pc'`` decides which entries can be nonzero at all -- independently of the
+# distribution, since it is a statement about the design. That sparsity is what the routines
+# below exploit. Each is proved at https://github.com/jdkent/cbmr-proofs.
+# ---------------------------------------------------------------------------------------------
+
+
+def spatial_components(loadings, n_bases):
+    """Return the groups of spatial parameter indices that can covary.
+
+    Two spatial columns are coupled when some pattern loads on both, since that is the only way a
+    cross term can be nonzero, and coupling is transitive -- so this is connected components over
+    the columns, seeded by each pattern's support. A cell-means factor gives one component per
+    level; a sum-to-zero term or a spatial covariate couples everything.
+
+    Independent of the global block: this is the structure of ``D`` in the bordered form
+    ``[[D, C], [C^T, E]]``, which survives moderators even though full block diagonality does not.
+    """
+    n_columns = loadings.shape[1]
+    parent = np.arange(n_columns)
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for row in loadings:
+        support = np.flatnonzero(row)
+        for other in support[1:]:
+            a, b = find(support[0]), find(other)
+            if a != b:
+                parent[b] = a
+
+    members = {}
+    for column in range(n_columns):
+        members.setdefault(find(column), []).append(column)
+    return [
+        np.concatenate([np.arange(c * n_bases, (c + 1) * n_bases) for c in sorted(columns)])
+        for columns in members.values()
+    ]
+
+
+def is_block_diagonal(information, blocks):
+    """Whether ``information`` really is block diagonal over ``blocks``.
+
+    Nonzero *counts* rather than magnitudes: the claim being checked is that the off-block
+    entries are structurally absent, so a small-but-nonzero entry means the derivation is wrong,
+    not that the block is nearly separable. Rounding a real coupling to zero would silently
+    understate a standard error.
+    """
+    if len(blocks) < 2:
+        return False
+    return all(
+        np.count_nonzero(information[index])
+        == np.count_nonzero(information[np.ix_(index, index)])
+        for index in blocks
+    )
+
+
+def symmetric_condition_number(information, blocks=None):
+    """Return the exact 2-norm condition number of a symmetric matrix.
+
+    For symmetric ``H`` the singular values are the absolute eigenvalues, so a symmetric
+    eigensolver replaces the SVD that ``np.linalg.cond`` forms -- exact, with no hypothesis on
+    the design, and several times faster. When ``H`` is block diagonal its spectrum is the union
+    of the blocks', so the eigensolver runs per block instead of once on the whole.
+    """
+    if blocks is None:
+        values = np.linalg.eigvalsh(information)
+    else:
+        values = np.concatenate(
+            [np.linalg.eigvalsh(information[np.ix_(index, index)]) for index in blocks]
+        )
+    smallest = np.abs(values).min()
+    return np.inf if smallest == 0 else np.abs(values).max() / smallest
+
+
+def cholesky_inverse(information):
+    """Invert a positive definite matrix from one Cholesky factor, or return None.
+
+    ``None`` rather than an exception for a non-positive-definite matrix: that is a statement
+    about the fit, which the caller reports, not an error in this routine.
+    """
+    factor, info = lapack.dpotrf(information, lower=1, clean=1)
+    if info != 0:
+        return None
+    inverse, info = lapack.dpotri(factor, lower=1)
+    if info != 0:
+        return None
+    return np.tril(inverse) + np.tril(inverse, -1).T
+
+
+def blockwise_inverse(information, blocks):
+    """Invert a block diagonal matrix one block at a time."""
+    inverse = np.zeros_like(information)
+    for index in blocks:
+        inverse[np.ix_(index, index)] = np.linalg.inv(information[np.ix_(index, index)])
+    return inverse
+
+
+def bordered_inverse(information, blocks, n_spatial):
+    """Invert ``[[D, C], [C^T, E]]`` with ``D`` block diagonal, by Schur complement.
+
+    Recovers most of the blockwise saving for a design whose spatial columns separate but which
+    carries global moderators: the cross block couples every spatial column through ``gamma``, so
+    the matrix is not block diagonal at all, but ``D`` underneath it still is. Returns None if
+    ``D`` or the Schur complement is singular, so the caller can fall back rather than propagate
+    a nonsense covariance.
+    """
+    border = information[:n_spatial, n_spatial:]
+    try:
+        d_inverse = blockwise_inverse(information[:n_spatial, :n_spatial], blocks)
+        weighted = d_inverse @ border  # D^-1 C
+        schur = information[n_spatial:, n_spatial:] - border.T @ weighted
+        schur_inverse = np.linalg.inv(schur)
+    except np.linalg.LinAlgError:
+        return None
+    inverse = np.empty_like(information)
+    inverse[:n_spatial, :n_spatial] = d_inverse + weighted @ schur_inverse @ weighted.T
+    inverse[:n_spatial, n_spatial:] = -weighted @ schur_inverse
+    inverse[n_spatial:, :n_spatial] = inverse[:n_spatial, n_spatial:].T
+    inverse[n_spatial:, n_spatial:] = schur_inverse
+    return inverse
+
+
+def fisher_covariance(model, information):
+    """Invert the observed information, exploiting whatever structure the design left.
+
+    A ladder, most specific rung first:
+
+    block diagonal
+        the spatial columns separate and there are no moderators. The spectrum is the union of
+        the blocks' and the inverse is blockwise. Only a lone cell-means factor reaches here.
+    bordered block diagonal
+        the spatial columns separate but moderators border them. The inverse still goes
+        blockwise, through a Schur complement; the condition number cannot follow, because the
+        spectrum of a bordered matrix is not the union of its parts.
+    dense
+        everything else. Still two improvements on a plain SVD-plus-LU: the condition number
+        comes from a symmetric eigensolver, and the inverse from a Cholesky factor when the
+        matrix is positive definite.
+
+    Every rung returns the same matrix and reports the same condition number to the last digit;
+    only the work differs. Structural claims are checked against the matrix in hand rather than
+    assumed.
+    """
+    n_spatial = model.n_spatial
+    loadings, n_bases = model.predictor.patterns.loadings, model.predictor.n_bases
+    blocks = spatial_components(loadings, n_bases) if not model.n_global else []
+    separable = bool(blocks) and is_block_diagonal(information, blocks)
+
+    condition = symmetric_condition_number(information, blocks if separable else None)
+    if condition > 1.0 / np.finfo(float).eps:
+        LGR.warning(
+            f"The Fisher information matrix has condition number {condition:.3g}, past what "
+            "double precision can invert meaningfully, so these standard errors should not be "
+            f"trusted. {_CONDITION_ADVICE}"
+        )
+
+    # Every route funnels through one handler: a singular design must explain itself the same
+    # way whichever rung happened to reach it, and numpy's bare "Singular matrix" tells a user
+    # nothing about which knob to turn.
+    try:
+        if separable:
+            return blockwise_inverse(information, blocks)
+
+        if model.n_global:
+            spatial = spatial_components(loadings, n_bases)
+            if len(spatial) > 1 and is_block_diagonal(
+                information[:n_spatial, :n_spatial], spatial
+            ):
+                bordered = bordered_inverse(information, spatial, n_spatial)
+                if bordered is not None:
+                    return bordered
+
+        inverse = cholesky_inverse(information)
+        if inverse is not None:
+            return inverse
+        return np.linalg.inv(information)
+    except np.linalg.LinAlgError as error:
+        raise np.linalg.LinAlgError(
+            f"The Fisher information matrix over {model.n_parameters} coefficients is singular, "
+            f"so no standard errors exist for this fit. {_CONDITION_ADVICE}"
+        ) from error
+
+
+#: Repeated where a singular or ill-conditioned information matrix is reported, so a user gets
+#: the same actionable message from either path.
+_CONDITION_ADVICE = (
+    "The design asks for more spatial detail than these foci can support. Try a coarser "
+    "spline_spacing, a higher incidence_threshold, fewer s() terms, or more experiments; "
+    "CBMRResult.describe_terms() reports the parameter budget per term."
+)

--- a/nimare/meta/cbmr/covariance.py
+++ b/nimare/meta/cbmr/covariance.py
@@ -405,14 +405,26 @@ def bordered_inverse(information, blocks, n_spatial):
     """
     border = information[:n_spatial, n_spatial:]
     try:
-        d_inverse = blockwise_inverse(information[:n_spatial, :n_spatial], blocks)
-        weighted = d_inverse @ border  # D^-1 C
+        # Keep the inverse of D as blocks. Building it densely would allocate n_spatial^2 to
+        # hold mostly zeros, and every product below would then walk them: forming D^-1 C
+        # blockwise costs sum(|block|^2 Q) instead of n_spatial^2 Q.
+        pieces = [np.linalg.inv(information[np.ix_(index, index)]) for index in blocks]
+        weighted = np.empty_like(border)  # D^-1 C
+        for index, piece in zip(blocks, pieces):
+            weighted[index] = piece @ border[index]
         schur = information[n_spatial:, n_spatial:] - border.T @ weighted
         schur_inverse = np.linalg.inv(schur)
     except np.linalg.LinAlgError:
         return None
+
     inverse = np.empty_like(information)
-    inverse[:n_spatial, :n_spatial] = d_inverse + weighted @ schur_inverse @ weighted.T
+    # The leading block is D^-1 plus a rank-Q update. The update is dense, so it is written
+    # first and the diagonal blocks added into it, which needs one n_spatial^2 array rather
+    # than one for D^-1 and another for the sum.
+    leading = weighted @ schur_inverse @ weighted.T
+    for index, piece in zip(blocks, pieces):
+        leading[np.ix_(index, index)] += piece
+    inverse[:n_spatial, :n_spatial] = leading
     inverse[:n_spatial, n_spatial:] = -weighted @ schur_inverse
     inverse[n_spatial:, :n_spatial] = inverse[:n_spatial, n_spatial:].T
     inverse[n_spatial:, n_spatial:] = schur_inverse

--- a/nimare/meta/cbmr/distributions.py
+++ b/nimare/meta/cbmr/distributions.py
@@ -30,7 +30,6 @@ import numpy as np
 
 from nimare.meta.cbmr._torch import torch
 from nimare.meta.cbmr.predictor import (
-    _as_dense_array,
     _as_tensor,
     poisson_log_likelihood,
 )
@@ -101,8 +100,9 @@ def _pattern_quantities(predictor, spatial_coef, global_coef, foci):
     log_intensity = predictor.log_intensity_by_pattern(spatial_coef)
     moderator = predictor.moderator_effect(global_coef).to(spatial_coef.dtype)
     foci_per_voxel = _as_tensor(predictor.patterns.marginal_by_pattern(foci), spatial_coef.dtype)
+    # foci.sum works on both a sparse matrix and an array, so the grid is never materialised.
     foci_per_experiment = _as_tensor(
-        np.asarray(_as_dense_array(foci).sum(axis=1)).reshape(-1), spatial_coef.dtype
+        np.asarray(foci.sum(axis=1)).reshape(-1), spatial_coef.dtype
     )
     return log_intensity, moderator, foci_per_voxel, foci_per_experiment
 

--- a/nimare/meta/cbmr/distributions.py
+++ b/nimare/meta/cbmr/distributions.py
@@ -30,8 +30,8 @@ import numpy as np
 
 from nimare.meta.cbmr._torch import torch
 from nimare.meta.cbmr.predictor import (
-    experiment_totals,
     _as_tensor,
+    experiment_totals,
     poisson_log_likelihood,
 )
 

--- a/nimare/meta/cbmr/distributions.py
+++ b/nimare/meta/cbmr/distributions.py
@@ -30,6 +30,7 @@ import numpy as np
 
 from nimare.meta.cbmr._torch import torch
 from nimare.meta.cbmr.predictor import (
+    experiment_totals,
     _as_tensor,
     poisson_log_likelihood,
 )
@@ -100,10 +101,7 @@ def _pattern_quantities(predictor, spatial_coef, global_coef, foci):
     log_intensity = predictor.log_intensity_by_pattern(spatial_coef)
     moderator = predictor.moderator_effect(global_coef).to(spatial_coef.dtype)
     foci_per_voxel = _as_tensor(predictor.patterns.marginal_by_pattern(foci), spatial_coef.dtype)
-    # foci.sum works on both a sparse matrix and an array, so the grid is never materialised.
-    foci_per_experiment = _as_tensor(
-        np.asarray(foci.sum(axis=1)).reshape(-1), spatial_coef.dtype
-    )
+    foci_per_experiment = _as_tensor(experiment_totals(foci), spatial_coef.dtype)
     return log_intensity, moderator, foci_per_voxel, foci_per_experiment
 
 

--- a/nimare/meta/cbmr/information.py
+++ b/nimare/meta/cbmr/information.py
@@ -41,8 +41,27 @@ def _intensity_pieces(model):
     return predictor, loadings, intensity, global_block, weight
 
 
+def _symmetrize(matrix):
+    """Return the exact symmetric part of a matrix that is symmetric in exact arithmetic.
+
+    ``B^T diag(w) B`` is symmetric on paper, but BLAS sums the ``[i, j]`` and ``[j, i]`` dot
+    products in different orders, so they can differ in the last bit. ``eigvalsh`` and the
+    Cholesky read one triangle only, so that difference would quietly decide which value is used.
+    """
+    return 0.5 * (matrix + matrix.T)
+
+
+def _finalize(information, n_spatial, n_global):
+    """Mirror the spatial-by-global block and make the moderator block exactly symmetric."""
+    if n_global:
+        information[n_spatial:, :n_spatial] = information[:n_spatial, n_spatial:].T
+        information[n_spatial:, n_spatial:] = _symmetrize(information[n_spatial:, n_spatial:])
+    return information
+
+
 def _scatter_spatial(information, row, n_bases, block):
     """Add ``L_pc L_pc' * block`` into every spatial cross block the pattern's support touches."""
+    block = _symmetrize(block)
     support = np.flatnonzero(row)
     for c in support:
         rows = slice(c * n_bases, (c + 1) * n_bases)
@@ -97,17 +116,15 @@ def poisson_information_matrix(model):
         marginal_basis = intensity @ bases  # a_pk
         moderator = np.zeros((predictor.patterns.n_patterns, n_global))  # U_pq
         np.add.at(moderator, assignment, weight[:, None] * global_block)
-        cross = np.einsum(
+        information[:n_spatial, n_spatial:] = np.einsum(
             "pc,pk,pq->ckq", loadings, marginal_basis, moderator, optimize=True
         ).reshape(n_spatial, n_global)
-        information[:n_spatial, n_spatial:] = cross
-        information[n_spatial:, :n_spatial] = cross.T
 
         energy = intensity.sum(axis=1)  # E_p
         information[n_spatial:, n_spatial:] = global_block.T @ (
             global_block * (weight * energy[assignment])[:, None]
         )
-    return information
+    return _finalize(information, n_spatial, n_global)
 
 
 def negative_binomial_information_matrix(model, foci):
@@ -198,9 +215,7 @@ def negative_binomial_information_matrix(model, foci):
             + psi_a * a_2
         )
 
-    if n_global:
-        information[n_spatial:, :n_spatial] = information[:n_spatial, n_spatial:].T
-    return information
+    return _finalize(information, n_spatial, n_global)
 
 
 def clustered_negative_binomial_information_matrix(model, foci):
@@ -263,9 +278,7 @@ def clustered_negative_binomial_information_matrix(model, foci):
             member_block * (scale * energy)[:, None]
         )
 
-    if n_global:
-        information[n_spatial:, :n_spatial] = information[:n_spatial, n_spatial:].T
-    return information
+    return _finalize(information, n_spatial, n_global)
 
 
 def _poisson_entry(model, foci):

--- a/nimare/meta/cbmr/information.py
+++ b/nimare/meta/cbmr/information.py
@@ -1,0 +1,300 @@
+"""Closed-form observed information for the CBMR distributions.
+
+Why this exists
+---------------
+:meth:`~nimare.meta.cbmr.model.CBMRModel.information_matrix` differentiates the log-likelihood
+twice with ``torch.func.hessian``, which is ``jacfwd(jacrev(...))``. Forward mode carries one
+tangent per parameter through the likelihood simultaneously, so the intermediate log-intensity
+tensor has shape ``(n_parameters, n_patterns, n_voxels)``. For a 21-group model over 21,789
+voxels that is 28.7 GB -- an out-of-memory kill rather than a slow fit -- and the size is driven
+by the group count, so resampling to a coarser grid does not avoid it.
+
+All three distributions admit a closed form, and it is the same shape in each case. Writing the
+likelihood over patterns as ``predictor.py`` does, ``-log L = sum_p f_p(S_p, gamma)`` with
+``S = (L b) B^T`` the log-intensity, the predictor is *linear* in the coefficients, so the chain
+rule contributes no curvature term and::
+
+    H_bb[(c,k),(c',k')] = sum_p L_pc L_pc' (B^T Sigma_p B)[k,k']
+
+with ``Sigma_p`` the second differential of ``f_p`` in the log-intensity. What differs between
+the distributions is only ``Sigma_p``:
+
+Poisson
+    ``Sigma_p = T_p diag(exp(S_p))``. The data terms are linear in the coefficients, so they
+    differentiate away: the Poisson Hessian does not depend on the foci at all. This is the
+    canonical-link property -- observed and expected information coincide.
+NegativeBinomial
+    ``Sigma_p = diag(w_p)`` with ``w_pv = (R + Y_pv) u_pv A / (u_pv + A)^2``, writing
+    ``A = S1/(theta S2)`` and ``R = S1 A``. Same shape, different weight, and now foci
+    dependent. The Poisson weight is the ``theta -> 0`` limit of this one.
+ClusteredNegativeBinomial
+    The spatial coefficients reach this likelihood only through the scalar
+    ``E_p = sum_v exp(S_pv)``, so ``Sigma_p`` is diagonal *plus rank one* and the spatial block
+    picks up a correction ``g'' a_p a_p^T`` with ``a_p = B^T exp(S_p)``.
+
+Each is ``n_patterns`` symmetric rank-updates of width ``n_bases``, costing
+``O(n_patterns x n_voxels x n_bases^2)`` and allocating one ``(n_voxels, n_bases)`` temporary.
+No ``n_parameters``-sized intermediate is formed anywhere, which is the axis that made the model
+impossible to fit.
+
+The nuisance parameters are held fixed at their fitted values throughout, which is what
+``information_matrix`` has always done and what CBMR reports regression standard errors from.
+That is what makes the overdispersed cases tractable: their special functions then depend on
+constants alone.
+
+Every identity above is proved symbolically, term by term, at
+https://github.com/jdkent/cbmr-proofs -- 59 claims, each a residual simplified by sympy to
+exactly zero -- and checked numerically against ``torch.func.hessian`` in
+``nimare/tests/test_meta_cbmr_information.py``.
+"""
+
+import numpy as np
+from scipy.special import digamma, polygamma
+
+from nimare.meta.cbmr.distributions import (
+    ClusteredNegativeBinomial,
+    NegativeBinomial,
+    Poisson,
+)
+
+
+def _fitted_pieces(model):
+    """Return the quantities all three closed forms are written in terms of."""
+    predictor = model.predictor
+    flat = model.coefficients.detach().cpu().numpy()
+    n_spatial, n_global = model.n_spatial, model.n_global
+
+    spatial = flat[:n_spatial].reshape(predictor.n_spatial_columns, predictor.n_bases)
+    loadings = predictor.patterns.loadings
+    intensity = np.exp((loadings @ spatial) @ predictor.bases.T)  # exp(S), (n_patterns, n_voxels)
+
+    if n_global:
+        global_block = predictor.global_block
+        weight = np.exp(global_block @ flat[n_spatial:])  # exp(m_i)
+    else:
+        global_block = None
+        weight = np.ones(predictor.patterns.assignment.size)
+    return predictor, loadings, intensity, global_block, weight
+
+
+def _scatter_spatial(information, row, n_bases, block):
+    """Add ``L_pc L_pc' * block`` into every spatial cross block the pattern's support touches."""
+    for c in np.flatnonzero(row):
+        rows = slice(c * n_bases, (c + 1) * n_bases)
+        for d in np.flatnonzero(row):
+            information[rows, d * n_bases : (d + 1) * n_bases] += (row[c] * row[d]) * block
+
+
+def _scatter_cross(information, row, n_bases, n_spatial, vector, moderator_row):
+    """Add ``L_pc * vector_k * moderator_q`` into the spatial-by-global cross block."""
+    outer = np.outer(vector, moderator_row)
+    for c in np.flatnonzero(row):
+        information[c * n_bases : (c + 1) * n_bases, n_spatial:] += row[c] * outer
+
+
+def _nuisance(model):
+    """Return the fitted nuisance parameters on the statistical scale."""
+    return model.distribution.transform_nuisance(model.nuisance).detach().cpu().numpy()
+
+
+def poisson_information_matrix(model, foci=None):
+    """Return the observed Fisher information of a fitted Poisson CBMR, in closed form.
+
+    Takes no foci: the Hessian of this likelihood does not depend on them. Identical to
+    ``torch.func.hessian`` of the negative log-likelihood to within floating-point rounding.
+    """
+    predictor, loadings, intensity, global_block, weight = _fitted_pieces(model)
+    n_spatial, n_global, n_bases = model.n_spatial, model.n_global, predictor.n_bases
+    bases = predictor.bases
+    assignment = predictor.patterns.assignment
+
+    total = np.zeros(predictor.patterns.n_patterns)  # T_p
+    np.add.at(total, assignment, weight)
+
+    information = np.zeros((n_spatial + n_global, n_spatial + n_global))
+    for p, row in enumerate(loadings):
+        if not np.any(row) or total[p] == 0.0:
+            continue
+        _scatter_spatial(
+            information, row, n_bases,
+            bases.T @ (bases * (total[p] * intensity[p])[:, None]),
+        )
+
+    if n_global:
+        marginal_basis = intensity @ bases  # a_pk
+        moderator = np.zeros((predictor.patterns.n_patterns, n_global))  # U_pq
+        np.add.at(moderator, assignment, weight[:, None] * global_block)
+        cross = np.einsum(
+            "pc,pk,pq->ckq", loadings, marginal_basis, moderator, optimize=True
+        ).reshape(n_spatial, n_global)
+        information[:n_spatial, n_spatial:] = cross
+        information[n_spatial:, :n_spatial] = cross.T
+
+        energy = intensity.sum(axis=1)  # E_p
+        information[n_spatial:, n_spatial:] = global_block.T @ (
+            global_block * (weight * energy[assignment])[:, None]
+        )
+    return information
+
+
+def negative_binomial_information_matrix(model, foci):
+    """Return the observed Fisher information of a fitted NegativeBinomial CBMR, in closed form.
+
+    Written as ``Psi(R, A, S)`` with ``R = S1^2/(theta S2)`` and ``A = S1/(theta S2)``, which is
+    what makes the derivation tractable: the special functions depend only on ``R``, the voxels
+    only on ``S``, and the moderators only on ``R`` and ``A``.
+
+    Unlike the Poisson case the foci do not drop out -- ``R + Y_v`` is a per-voxel weight -- but
+    they enter only through the pattern marginals.
+    """
+    predictor, loadings, intensity, global_block, weight = _fitted_pieces(model)
+    n_spatial, n_global, n_bases = model.n_spatial, model.n_global, predictor.n_bases
+    n_voxels, bases = predictor.n_voxels, predictor.bases
+    assignment = predictor.patterns.assignment
+    overdispersion = _nuisance(model)
+    marginal = predictor.patterns.marginal_by_pattern(foci)
+
+    information = np.zeros((n_spatial + n_global, n_spatial + n_global))
+    for p, row in enumerate(loadings):
+        if not np.any(row):
+            continue
+        members = np.flatnonzero(assignment == p)
+        member_weight = weight[members]
+        sum_1 = member_weight.sum()
+        sum_2 = np.square(member_weight).sum()
+        a = sum_1 / (overdispersion[p] * sum_2)
+        r = sum_1 * a
+
+        u = intensity[p]
+        counts = marginal[p]
+        denominator = u + a
+
+        _scatter_spatial(
+            information, row, n_bases,
+            bases.T @ (bases * ((r + counts) * u * a / denominator**2)[:, None]),
+        )
+        if not n_global:
+            continue
+
+        # dR/dgamma and dA/dgamma, through their log derivatives.
+        member_block = global_block[members]
+        u_1 = member_weight @ member_block
+        u_2 = np.square(member_weight) @ member_block
+        u_1_2 = member_block.T @ (member_block * member_weight[:, None])
+        u_2_2 = member_block.T @ (member_block * np.square(member_weight)[:, None])
+        d_log_1, d_log_2 = u_1 / sum_1, 2 * u_2 / sum_2
+        dd_log_1 = u_1_2 / sum_1 - np.outer(u_1, u_1) / sum_1**2
+        dd_log_2 = 4 * u_2_2 / sum_2 - 4 * np.outer(u_2, u_2) / sum_2**2
+        d_log_a, d_log_r = d_log_1 - d_log_2, 2 * d_log_1 - d_log_2
+        a_1, r_1 = a * d_log_a, r * d_log_r
+        a_2 = a * (np.outer(d_log_a, d_log_a) + dd_log_1 - dd_log_2)
+        r_2 = r * (np.outer(d_log_r, d_log_r) + 2 * dd_log_1 - dd_log_2)
+
+        # d2Psi/dS dR and d2Psi/dS dA, each carried into gamma by its own chain rule factor.
+        _scatter_cross(information, row, n_bases, n_spatial, bases.T @ (u / denominator), r_1)
+        _scatter_cross(
+            information, row, n_bases, n_spatial,
+            -(bases.T @ ((r + counts) * u / denominator**2)), a_1,
+        )
+
+        psi_r = (
+            -digamma(counts + r).sum() + n_voxels * digamma(r)
+            - n_voxels * np.log(a) + np.log(denominator).sum()
+        )
+        psi_a = -n_voxels * r / a + ((r + counts) / denominator).sum()
+        psi_rr = -polygamma(1, counts + r).sum() + n_voxels * polygamma(1, r)
+        psi_ra = -n_voxels / a + (1.0 / denominator).sum()
+        psi_aa = n_voxels * r / a**2 - ((r + counts) / denominator**2).sum()
+        information[n_spatial:, n_spatial:] += (
+            psi_rr * np.outer(r_1, r_1)
+            + psi_ra * (np.outer(r_1, a_1) + np.outer(a_1, r_1))
+            + psi_aa * np.outer(a_1, a_1)
+            + psi_r * r_2
+            + psi_a * a_2
+        )
+
+    if n_global:
+        information[n_spatial:, :n_spatial] = information[:n_spatial, n_spatial:].T
+    return information
+
+
+def clustered_negative_binomial_information_matrix(model, foci):
+    """Return the observed information of a fitted ClusteredNegativeBinomial, in closed form.
+
+    The spatial coefficients reach this likelihood only through the scalar
+    ``E_p = sum_v exp(S_pv)``, so the spatial block is not the plain ``B^T diag(w) B`` of the
+    other two but that shape plus a rank-one correction, with ``a_p = B^T exp(S_p)``.
+
+    Only the per-experiment foci totals appear; the per-voxel marginals enter the likelihood
+    linearly and so vanish from the Hessian, as in the Poisson case.
+    """
+    predictor, loadings, intensity, global_block, weight = _fitted_pieces(model)
+    n_spatial, n_global, n_bases = model.n_spatial, model.n_global, predictor.n_bases
+    bases = predictor.bases
+    assignment = predictor.patterns.assignment
+    overdispersion = _nuisance(model)
+    per_experiment = _experiment_totals(foci)
+
+    information = np.zeros((n_spatial + n_global, n_spatial + n_global))
+    for p, row in enumerate(loadings):
+        if not np.any(row):
+            continue
+        members = np.flatnonzero(assignment == p)
+        precision = 1.0 / overdispersion[p]
+        u = intensity[p]
+        energy = u.sum()  # E_p
+
+        member_weight = weight[members]
+        excess = per_experiment[members] + precision
+        denominator = energy * member_weight + precision
+
+        gradient = (excess * member_weight / denominator).sum()
+        curvature = -(excess * np.square(member_weight) / denominator**2).sum()
+        marginal_basis = bases.T @ u  # a_k
+
+        _scatter_spatial(
+            information, row, n_bases,
+            gradient * (bases.T @ (bases * u[:, None]))
+            + curvature * np.outer(marginal_basis, marginal_basis),
+        )
+        if not n_global:
+            continue
+
+        member_block = global_block[members]
+        scale = excess * precision * member_weight / denominator**2
+        _scatter_cross(
+            information, row, n_bases, n_spatial, marginal_basis, scale @ member_block
+        )
+        information[n_spatial:, n_spatial:] += member_block.T @ (
+            member_block * (scale * energy)[:, None]
+        )
+
+    if n_global:
+        information[n_spatial:, :n_spatial] = information[:n_spatial, n_spatial:].T
+    return information
+
+
+def _experiment_totals(foci):
+    """Return the foci count per experiment, without densifying a sparse matrix."""
+    return np.asarray(foci.sum(axis=1)).reshape(-1).astype(float)
+
+
+#: The closed form for each distribution, most specific class first so a subclass resolves to
+#: its own entry rather than a base's.
+CLOSED_FORMS = (
+    (ClusteredNegativeBinomial, clustered_negative_binomial_information_matrix),
+    (NegativeBinomial, negative_binomial_information_matrix),
+    (Poisson, poisson_information_matrix),
+)
+
+
+def closed_form_information(distribution):
+    """Return the closed-form information matrix for ``distribution``, or None if there is none.
+
+    None is the signal to fall back to automatic differentiation, so a distribution added
+    without a derivation keeps working rather than silently getting the wrong Hessian.
+    """
+    for klass, function in CLOSED_FORMS:
+        if isinstance(distribution, klass):
+            return function
+    return None

--- a/nimare/meta/cbmr/information.py
+++ b/nimare/meta/cbmr/information.py
@@ -14,6 +14,7 @@ between them. Each is ``n_patterns`` rank-updates of width ``n_bases``, so nothi
 import numpy as np
 from scipy.special import digamma, polygamma
 
+from nimare.meta.cbmr.predictor import experiment_totals
 from nimare.meta.cbmr.distributions import (
     ClusteredNegativeBinomial,
     NegativeBinomial,
@@ -21,8 +22,8 @@ from nimare.meta.cbmr.distributions import (
 )
 
 
-def _fitted_pieces(model):
-    """Return the fitted quantities all closed forms share."""
+def _intensity_pieces(model):
+    """Return the fitted intensity and moderator weights all closed forms share."""
     predictor = model.predictor
     flat = model.coefficients.detach().cpu().numpy()
     n_spatial, n_global = model.n_spatial, model.n_global
@@ -42,9 +43,10 @@ def _fitted_pieces(model):
 
 def _scatter_spatial(information, row, n_bases, block):
     """Add ``L_pc L_pc' * block`` into every spatial cross block the pattern's support touches."""
-    for c in np.flatnonzero(row):
+    support = np.flatnonzero(row)
+    for c in support:
         rows = slice(c * n_bases, (c + 1) * n_bases)
-        for d in np.flatnonzero(row):
+        for d in support:
             information[rows, d * n_bases : (d + 1) * n_bases] += (row[c] * row[d]) * block
 
 
@@ -76,7 +78,7 @@ def poisson_information_matrix(model):
     :obj:`numpy.ndarray`
         Shape ``(n_parameters, n_parameters)``.
     """
-    predictor, loadings, intensity, global_block, weight = _fitted_pieces(model)
+    predictor, loadings, intensity, global_block, weight = _intensity_pieces(model)
     n_spatial, n_global, n_bases = model.n_spatial, model.n_global, predictor.n_bases
     bases = predictor.bases
     assignment = predictor.patterns.assignment
@@ -86,8 +88,6 @@ def poisson_information_matrix(model):
 
     information = np.zeros((n_spatial + n_global, n_spatial + n_global))
     for p, row in enumerate(loadings):
-        if not np.any(row) or total[p] == 0.0:
-            continue
         _scatter_spatial(
             information, row, n_bases,
             bases.T @ (bases * (total[p] * intensity[p])[:, None]),
@@ -134,7 +134,7 @@ def negative_binomial_information_matrix(model, foci):
     Precision is poor when ``theta`` approaches zero. The moderator block then sums large terms
     of opposite sign, and the fit is a Poisson one in all but name.
     """
-    predictor, loadings, intensity, global_block, weight = _fitted_pieces(model)
+    predictor, loadings, intensity, global_block, weight = _intensity_pieces(model)
     n_spatial, n_global, n_bases = model.n_spatial, model.n_global, predictor.n_bases
     n_voxels, bases = predictor.n_voxels, predictor.bases
     assignment = predictor.patterns.assignment
@@ -143,8 +143,6 @@ def negative_binomial_information_matrix(model, foci):
 
     information = np.zeros((n_spatial + n_global, n_spatial + n_global))
     for p, row in enumerate(loadings):
-        if not np.any(row):
-            continue
         members = np.flatnonzero(assignment == p)
         member_weight = weight[members]
         sum_1 = member_weight.sum()
@@ -226,17 +224,15 @@ def clustered_negative_binomial_information_matrix(model, foci):
     ``E_p = sum_v exp(S_pv)``. That makes the spatial block ``B^T diag(w) B`` plus a rank-one
     correction, where the other two distributions need only the first term.
     """
-    predictor, loadings, intensity, global_block, weight = _fitted_pieces(model)
+    predictor, loadings, intensity, global_block, weight = _intensity_pieces(model)
     n_spatial, n_global, n_bases = model.n_spatial, model.n_global, predictor.n_bases
     bases = predictor.bases
     assignment = predictor.patterns.assignment
     overdispersion = _nuisance(model)
-    per_experiment = _experiment_totals(foci)
+    per_experiment = experiment_totals(foci)
 
     information = np.zeros((n_spatial + n_global, n_spatial + n_global))
     for p, row in enumerate(loadings):
-        if not np.any(row):
-            continue
         members = np.flatnonzero(assignment == p)
         precision = 1.0 / overdispersion[p]
         u = intensity[p]
@@ -270,11 +266,6 @@ def clustered_negative_binomial_information_matrix(model, foci):
     if n_global:
         information[n_spatial:, :n_spatial] = information[:n_spatial, n_spatial:].T
     return information
-
-
-def _experiment_totals(foci):
-    """Return the foci count per experiment, without densifying a sparse matrix."""
-    return np.asarray(foci.sum(axis=1)).reshape(-1).astype(float)
 
 
 def _poisson_entry(model, foci):

--- a/nimare/meta/cbmr/information.py
+++ b/nimare/meta/cbmr/information.py
@@ -1,51 +1,19 @@
 """Closed-form observed information for the CBMR distributions.
 
-Why this exists
----------------
-:meth:`~nimare.meta.cbmr.model.CBMRModel.information_matrix` differentiates the log-likelihood
-twice with ``torch.func.hessian``, which is ``jacfwd(jacrev(...))``. Forward mode carries one
-tangent per parameter through the likelihood simultaneously, so the intermediate log-intensity
-tensor has shape ``(n_parameters, n_patterns, n_voxels)``. For a 21-group model over 21,789
-voxels that is 28.7 GB -- an out-of-memory kill rather than a slow fit -- and the size is driven
-by the group count, so resampling to a coarser grid does not avoid it.
-
-All three distributions admit a closed form, and it is the same shape in each case. Writing the
-likelihood over patterns as ``predictor.py`` does, ``-log L = sum_p f_p(S_p, gamma)`` with
-``S = (L b) B^T`` the log-intensity, the predictor is *linear* in the coefficients, so the chain
-rule contributes no curvature term and::
+``torch.func.hessian`` is ``jacfwd(jacrev(...))``. Forward mode carries one tangent per
+parameter, so its intermediate has shape ``(n_parameters, n_patterns, n_voxels)`` -- 28.7 GB for
+a 21-group model over 21,789 voxels. All three distributions have a closed form that avoids it::
 
     H_bb[(c,k),(c',k')] = sum_p L_pc L_pc' (B^T Sigma_p B)[k,k']
 
-with ``Sigma_p`` the second differential of ``f_p`` in the log-intensity. What differs between
-the distributions is only ``Sigma_p``:
+Only ``Sigma_p``, the second derivative of the pattern's term in the log-intensity, differs
+between them. Each is ``n_patterns`` rank-updates of width ``n_bases``, so nothing of size
+``n_parameters`` is built.
 
-Poisson
-    ``Sigma_p = T_p diag(exp(S_p))``. The data terms are linear in the coefficients, so they
-    differentiate away: the Poisson Hessian does not depend on the foci at all. This is the
-    canonical-link property -- observed and expected information coincide.
-NegativeBinomial
-    ``Sigma_p = diag(w_p)`` with ``w_pv = (R + Y_pv) u_pv A / (u_pv + A)^2``, writing
-    ``A = S1/(theta S2)`` and ``R = S1 A``. Same shape, different weight, and now foci
-    dependent. The Poisson weight is the ``theta -> 0`` limit of this one.
-ClusteredNegativeBinomial
-    The spatial coefficients reach this likelihood only through the scalar
-    ``E_p = sum_v exp(S_pv)``, so ``Sigma_p`` is diagonal *plus rank one* and the spatial block
-    picks up a correction ``g'' a_p a_p^T`` with ``a_p = B^T exp(S_p)``.
-
-Each is ``n_patterns`` symmetric rank-updates of width ``n_bases``, costing
-``O(n_patterns x n_voxels x n_bases^2)`` and allocating one ``(n_voxels, n_bases)`` temporary.
-No ``n_parameters``-sized intermediate is formed anywhere, which is the axis that made the model
-impossible to fit.
-
-The nuisance parameters are held fixed at their fitted values throughout, which is what
-``information_matrix`` has always done and what CBMR reports regression standard errors from.
-That is what makes the overdispersed cases tractable: their special functions then depend on
-constants alone.
-
-Every identity above is proved symbolically, term by term, at
-https://github.com/jdkent/cbmr-proofs -- 59 claims, each a residual simplified by sympy to
-exactly zero -- and checked numerically against ``torch.func.hessian`` in
-``nimare/tests/test_meta_cbmr_information.py``.
+Notes
+-----
+Every identity here is derived and proved at https://github.com/jdkent/cbmr-proofs, and checked
+against ``torch.func.hessian`` in ``nimare/tests/test_meta_cbmr_information.py``.
 """
 
 import numpy as np
@@ -59,7 +27,7 @@ from nimare.meta.cbmr.distributions import (
 
 
 def _fitted_pieces(model):
-    """Return the quantities all three closed forms are written in terms of."""
+    """Return the fitted quantities all three closed forms share."""
     predictor = model.predictor
     flat = model.coefficients.detach().cpu().numpy()
     n_spatial, n_global = model.n_spatial, model.n_global
@@ -98,10 +66,20 @@ def _nuisance(model):
 
 
 def poisson_information_matrix(model, foci=None):
-    """Return the observed Fisher information of a fitted Poisson CBMR, in closed form.
+    """Return the observed Fisher information of a fitted Poisson model.
 
-    Takes no foci: the Hessian of this likelihood does not depend on them. Identical to
-    ``torch.func.hessian`` of the negative log-likelihood to within floating-point rounding.
+    Parameters
+    ----------
+    model : :class:`~nimare.meta.cbmr.model.CBMRModel`
+        Fitted model.
+    foci : optional
+        Ignored. Under a log link the Poisson information depends only on the fitted
+        coefficients, so the counts drop out.
+
+    Returns
+    -------
+    :obj:`numpy.ndarray`
+        Shape ``(n_parameters, n_parameters)``.
     """
     predictor, loadings, intensity, global_block, weight = _fitted_pieces(model)
     n_spatial, n_global, n_bases = model.n_spatial, model.n_global, predictor.n_bases
@@ -138,14 +116,28 @@ def poisson_information_matrix(model, foci=None):
 
 
 def negative_binomial_information_matrix(model, foci):
-    """Return the observed Fisher information of a fitted NegativeBinomial CBMR, in closed form.
+    """Return the observed Fisher information of a fitted NegativeBinomial model.
 
-    Written as ``Psi(R, A, S)`` with ``R = S1^2/(theta S2)`` and ``A = S1/(theta S2)``, which is
-    what makes the derivation tractable: the special functions depend only on ``R``, the voxels
-    only on ``S``, and the moderators only on ``R`` and ``A``.
+    Parameters
+    ----------
+    model : :class:`~nimare.meta.cbmr.model.CBMRModel`
+        Fitted model.
+    foci : array_like or :obj:`scipy.sparse.spmatrix`
+        Foci counts. Used, unlike the Poisson case, but only through the pattern marginals.
 
-    Unlike the Poisson case the foci do not drop out -- ``R + Y_v`` is a per-voxel weight -- but
-    they enter only through the pattern marginals.
+    Returns
+    -------
+    :obj:`numpy.ndarray`
+        Shape ``(n_parameters, n_parameters)``.
+
+    Notes
+    -----
+    Uses ``A = S1/(theta S2)`` and ``R = S1 A`` in place of NiMARE's shape and probability. In
+    those terms the gamma functions depend only on ``R``, the voxels only on the log-intensity,
+    and the moderators only on ``R`` and ``A``.
+
+    Precision is poor when ``theta`` approaches zero. The moderator block then sums large terms
+    of opposite sign, and the fit is a Poisson one in all but name.
     """
     predictor, loadings, intensity, global_block, weight = _fitted_pieces(model)
     n_spatial, n_global, n_bases = model.n_spatial, model.n_global, predictor.n_bases
@@ -190,7 +182,7 @@ def negative_binomial_information_matrix(model, foci):
         a_2 = a * (np.outer(d_log_a, d_log_a) + dd_log_1 - dd_log_2)
         r_2 = r * (np.outer(d_log_r, d_log_r) + 2 * dd_log_1 - dd_log_2)
 
-        # d2Psi/dS dR and d2Psi/dS dA, each carried into gamma by its own chain rule factor.
+        # d2Psi/dS dR and d2Psi/dS dA, each carried into gamma by its own chain factor.
         _scatter_cross(information, row, n_bases, n_spatial, bases.T @ (u / denominator), r_1)
         _scatter_cross(
             information, row, n_bases, n_spatial,
@@ -219,14 +211,25 @@ def negative_binomial_information_matrix(model, foci):
 
 
 def clustered_negative_binomial_information_matrix(model, foci):
-    """Return the observed information of a fitted ClusteredNegativeBinomial, in closed form.
+    """Return the observed Fisher information of a fitted ClusteredNegativeBinomial model.
 
+    Parameters
+    ----------
+    model : :class:`~nimare.meta.cbmr.model.CBMRModel`
+        Fitted model.
+    foci : array_like or :obj:`scipy.sparse.spmatrix`
+        Foci counts. Only the per-experiment totals matter here.
+
+    Returns
+    -------
+    :obj:`numpy.ndarray`
+        Shape ``(n_parameters, n_parameters)``.
+
+    Notes
+    -----
     The spatial coefficients reach this likelihood only through the scalar
-    ``E_p = sum_v exp(S_pv)``, so the spatial block is not the plain ``B^T diag(w) B`` of the
-    other two but that shape plus a rank-one correction, with ``a_p = B^T exp(S_p)``.
-
-    Only the per-experiment foci totals appear; the per-voxel marginals enter the likelihood
-    linearly and so vanish from the Hessian, as in the Poisson case.
+    ``E_p = sum_v exp(S_pv)``. That makes the spatial block ``B^T diag(w) B`` plus a rank-one
+    correction, where the other two distributions need only the first term.
     """
     predictor, loadings, intensity, global_block, weight = _fitted_pieces(model)
     n_spatial, n_global, n_bases = model.n_spatial, model.n_global, predictor.n_bases
@@ -279,8 +282,7 @@ def _experiment_totals(foci):
     return np.asarray(foci.sum(axis=1)).reshape(-1).astype(float)
 
 
-#: The closed form for each distribution, most specific class first so a subclass resolves to
-#: its own entry rather than a base's.
+#: Most specific class first, so a subclass resolves to its own entry rather than a base's.
 CLOSED_FORMS = (
     (ClusteredNegativeBinomial, clustered_negative_binomial_information_matrix),
     (NegativeBinomial, negative_binomial_information_matrix),
@@ -289,10 +291,18 @@ CLOSED_FORMS = (
 
 
 def closed_form_information(distribution):
-    """Return the closed-form information matrix for ``distribution``, or None if there is none.
+    """Return the closed-form information function for ``distribution``, or None.
 
-    None is the signal to fall back to automatic differentiation, so a distribution added
-    without a derivation keeps working rather than silently getting the wrong Hessian.
+    Parameters
+    ----------
+    distribution : :class:`~nimare.meta.cbmr.distributions.Distribution`
+        Observation distribution.
+
+    Returns
+    -------
+    callable or None
+        None means no derivation covers this distribution, and the caller should fall back to
+        automatic differentiation rather than use another distribution's formula.
     """
     for klass, function in CLOSED_FORMS:
         if isinstance(distribution, klass):

--- a/nimare/meta/cbmr/information.py
+++ b/nimare/meta/cbmr/information.py
@@ -14,12 +14,12 @@ between them. Each is ``n_patterns`` rank-updates of width ``n_bases``, so nothi
 import numpy as np
 from scipy.special import digamma, polygamma
 
-from nimare.meta.cbmr.predictor import experiment_totals
 from nimare.meta.cbmr.distributions import (
     ClusteredNegativeBinomial,
     NegativeBinomial,
     Poisson,
 )
+from nimare.meta.cbmr.predictor import experiment_totals
 
 
 def _intensity_pieces(model):
@@ -108,8 +108,7 @@ def poisson_information_matrix(model):
     information = np.zeros((n_spatial + n_global, n_spatial + n_global))
     for p, row in enumerate(loadings):
         _scatter_spatial(
-            information, row, n_bases,
-            bases.T @ (bases * (total[p] * intensity[p])[:, None]),
+            information, row, n_bases, bases.T @ (bases * (total[p] * intensity[p])[:, None])
         )
 
     if n_global:
@@ -171,10 +170,8 @@ def negative_binomial_information_matrix(model, foci):
         counts = marginal[p]
         denominator = u + a
 
-        _scatter_spatial(
-            information, row, n_bases,
-            bases.T @ (bases * ((r + counts) * u * a / denominator**2)[:, None]),
-        )
+        weight_v = (r + counts) * u * a / denominator**2
+        _scatter_spatial(information, row, n_bases, bases.T @ (bases * weight_v[:, None]))
         if not n_global:
             continue
 
@@ -194,14 +191,14 @@ def negative_binomial_information_matrix(model, foci):
 
         # d2Psi/dS dR and d2Psi/dS dA, each carried into gamma by its own chain factor.
         _scatter_cross(information, row, n_bases, n_spatial, bases.T @ (u / denominator), r_1)
-        _scatter_cross(
-            information, row, n_bases, n_spatial,
-            -(bases.T @ ((r + counts) * u / denominator**2)), a_1,
-        )
+        cross_a = -(bases.T @ ((r + counts) * u / denominator**2))
+        _scatter_cross(information, row, n_bases, n_spatial, cross_a, a_1)
 
         psi_r = (
-            -digamma(counts + r).sum() + n_voxels * digamma(r)
-            - n_voxels * np.log(a) + np.log(denominator).sum()
+            -digamma(counts + r).sum()
+            + n_voxels * digamma(r)
+            - n_voxels * np.log(a)
+            + np.log(denominator).sum()
         )
         psi_a = -n_voxels * r / a + ((r + counts) / denominator).sum()
         psi_rr = -polygamma(1, counts + r).sum() + n_voxels * polygamma(1, r)
@@ -261,19 +258,16 @@ def clustered_negative_binomial_information_matrix(model, foci):
         curvature = -(excess * np.square(member_weight) / denominator**2).sum()
         marginal_basis = bases.T @ u  # a_k
 
-        _scatter_spatial(
-            information, row, n_bases,
-            gradient * (bases.T @ (bases * u[:, None]))
-            + curvature * np.outer(marginal_basis, marginal_basis),
+        block = gradient * (bases.T @ (bases * u[:, None])) + curvature * np.outer(
+            marginal_basis, marginal_basis
         )
+        _scatter_spatial(information, row, n_bases, block)
         if not n_global:
             continue
 
         member_block = global_block[members]
         scale = excess * precision * member_weight / denominator**2
-        _scatter_cross(
-            information, row, n_bases, n_spatial, marginal_basis, scale @ member_block
-        )
+        _scatter_cross(information, row, n_bases, n_spatial, marginal_basis, scale @ member_block)
         information[n_spatial:, n_spatial:] += member_block.T @ (
             member_block * (scale * energy)[:, None]
         )

--- a/nimare/meta/cbmr/information.py
+++ b/nimare/meta/cbmr/information.py
@@ -9,11 +9,6 @@ a 21-group model over 21,789 voxels. All three distributions have a closed form 
 Only ``Sigma_p``, the second derivative of the pattern's term in the log-intensity, differs
 between them. Each is ``n_patterns`` rank-updates of width ``n_bases``, so nothing of size
 ``n_parameters`` is built.
-
-Notes
------
-Every identity here is derived and proved at https://github.com/jdkent/cbmr-proofs, and checked
-against ``torch.func.hessian`` in ``nimare/tests/test_meta_cbmr_information.py``.
 """
 
 import numpy as np
@@ -27,7 +22,7 @@ from nimare.meta.cbmr.distributions import (
 
 
 def _fitted_pieces(model):
-    """Return the fitted quantities all three closed forms share."""
+    """Return the fitted quantities all closed forms share."""
     predictor = model.predictor
     flat = model.coefficients.detach().cpu().numpy()
     n_spatial, n_global = model.n_spatial, model.n_global
@@ -65,16 +60,16 @@ def _nuisance(model):
     return model.distribution.transform_nuisance(model.nuisance).detach().cpu().numpy()
 
 
-def poisson_information_matrix(model, foci=None):
+def poisson_information_matrix(model):
     """Return the observed Fisher information of a fitted Poisson model.
+
+    Takes no foci. Under a log link the Poisson information depends only on the fitted
+    coefficients, so the counts drop out.
 
     Parameters
     ----------
     model : :class:`~nimare.meta.cbmr.model.CBMRModel`
         Fitted model.
-    foci : optional
-        Ignored. Under a log link the Poisson information depends only on the fitted
-        coefficients, so the counts drop out.
 
     Returns
     -------
@@ -282,11 +277,16 @@ def _experiment_totals(foci):
     return np.asarray(foci.sum(axis=1)).reshape(-1).astype(float)
 
 
+def _poisson_entry(model, foci):
+    """Adapt the Poisson signature to the ``(model, foci)`` the dispatch uses."""
+    return poisson_information_matrix(model)
+
+
 #: Most specific class first, so a subclass resolves to its own entry rather than a base's.
 CLOSED_FORMS = (
     (ClusteredNegativeBinomial, clustered_negative_binomial_information_matrix),
     (NegativeBinomial, negative_binomial_information_matrix),
-    (Poisson, poisson_information_matrix),
+    (Poisson, _poisson_entry),
 )
 
 

--- a/nimare/meta/cbmr/model.py
+++ b/nimare/meta/cbmr/model.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from nimare.meta.cbmr._torch import torch
 from nimare.meta.cbmr.distributions import resolve_distribution
+from nimare.meta.cbmr.information import closed_form_information
 
 LGR = logging.getLogger(__name__)
 
@@ -135,7 +136,19 @@ class CBMRModel(torch.nn.Module):
         One matrix over all coefficients, so the cross blocks between terms are present rather
         than assumed away. Nuisance parameters are held fixed at their fitted values, matching
         how CBMR has always reported regression standard errors.
+
+        Computed in closed form where a derivation exists, which for the distributions NiMARE
+        ships is always; see :mod:`nimare.meta.cbmr.information`. Automatic differentiation
+        remains the fallback for a distribution added without one.
         """
+        closed_form = closed_form_information(self.distribution)
+        if closed_form is not None:
+            return closed_form(self, foci)
+
+        # No derivation for this distribution, so differentiate it. jacfwd(jacrev(.)) carries one
+        # tangent per parameter through the likelihood at once, so the intermediate is
+        # (n_parameters, n_patterns, n_voxels) -- tens of GB on a many-group model. That is why
+        # the three distributions NiMARE ships have closed forms above.
         flat = self.coefficients.detach().clone()
         nuisance = None if self.nuisance is None else self.nuisance.detach().clone()
 
@@ -169,27 +182,9 @@ class CBMRModel(torch.nn.Module):
         if cov_type != "fisher":
             raise ValueError(f"cov_type must be 'fisher' or 'sandwich', got {cov_type!r}.")
 
-        information = self.information_matrix(foci)
-        condition = np.linalg.cond(information)
-        advice = (
-            "The design asks for more spatial detail than these foci can support. Try a coarser "
-            "spline_spacing, a higher incidence_threshold, fewer s() terms, or more experiments; "
-            "CBMRResult.describe_terms() reports the parameter budget per term."
-        )
-        if condition > 1.0 / np.finfo(float).eps:
-            LGR.warning(
-                f"The Fisher information matrix has condition number {condition:.3g}, past what "
-                "double precision can invert meaningfully, so these standard errors should not "
-                f"be trusted. {advice}"
-            )
-        try:
-            return np.linalg.inv(information)
-        except np.linalg.LinAlgError as error:
-            # numpy's bare "Singular matrix" gives a user no idea which knob to turn.
-            raise np.linalg.LinAlgError(
-                f"The Fisher information matrix over {self.n_parameters} coefficients is "
-                f"singular, so no standard errors exist for this fit. {advice}"
-            ) from error
+        from nimare.meta.cbmr.covariance import fisher_covariance
+
+        return fisher_covariance(self, self.information_matrix(foci))
 
     def standard_errors(self, foci, **covariance_kwargs):
         """Return coefficient standard errors, keyed by term.

--- a/nimare/meta/cbmr/model.py
+++ b/nimare/meta/cbmr/model.py
@@ -137,18 +137,16 @@ class CBMRModel(torch.nn.Module):
         than assumed away. Nuisance parameters are held fixed at their fitted values, matching
         how CBMR has always reported regression standard errors.
 
-        Computed in closed form where a derivation exists, which for the distributions NiMARE
-        ships is always; see :mod:`nimare.meta.cbmr.information`. Automatic differentiation
-        remains the fallback for a distribution added without one.
+        Computed in closed form for every distribution NiMARE ships; see
+        :mod:`nimare.meta.cbmr.information`. Automatic differentiation is the fallback for one
+        added without a derivation.
         """
         closed_form = closed_form_information(self.distribution)
         if closed_form is not None:
             return closed_form(self, foci)
 
-        # No derivation for this distribution, so differentiate it. jacfwd(jacrev(.)) carries one
-        # tangent per parameter through the likelihood at once, so the intermediate is
-        # (n_parameters, n_patterns, n_voxels) -- tens of GB on a many-group model. That is why
-        # the three distributions NiMARE ships have closed forms above.
+        # No derivation, so differentiate. jacfwd(jacrev(.)) builds an intermediate of shape
+        # (n_parameters, n_patterns, n_voxels), which is tens of GB on a many-group model.
         flat = self.coefficients.detach().clone()
         nuisance = None if self.nuisance is None else self.nuisance.detach().clone()
 

--- a/nimare/meta/cbmr/model.py
+++ b/nimare/meta/cbmr/model.py
@@ -137,10 +137,10 @@ class CBMRModel(torch.nn.Module):
         """Return the observed Fisher information over the flat coefficient vector.
 
         One matrix over all coefficients, so the cross blocks between terms are present rather
-       than assumed away. Nuisance parameters are held fixed at their fitted values.
+        than assumed away. Nuisance parameters are held fixed at their fitted values.
 
-        Computed in closed form for every distribution with automatic differentiation as the fallback for
-        distributions added without a derivation.
+        Computed in closed form for every distribution with automatic differentiation as the
+        fallback for distributions added without a derivation.
         """
         closed_form = closed_form_information(self.distribution)
         if closed_form is not None:
@@ -180,8 +180,9 @@ class CBMRModel(torch.nn.Module):
         every hypothesis tested against one fit asks for the same matrix, and
         :meth:`~nimare.meta.cbmr.results.CBMRResult.test` would otherwise rebuild it each time.
         The cache holds one matrix, is keyed on the foci and the covariance options, and is
-        cleared by :meth:`fit`. At many groups that matrix is large; could be well over 500mb, but it is shared by every result derived from the fit, since
-        ``CBMRResult.copy`` passes the estimator by reference.
+        cleared by :meth:`fit`. At many groups that matrix is large; could be well over 500mb,
+        but it is shared by every result derived from the fit, since ``CBMRResult.copy`` passes
+        the estimator by reference.
         """
         from nimare.meta.cbmr.covariance import fisher_covariance, sandwich_covariance
 

--- a/nimare/meta/cbmr/model.py
+++ b/nimare/meta/cbmr/model.py
@@ -137,12 +137,10 @@ class CBMRModel(torch.nn.Module):
         """Return the observed Fisher information over the flat coefficient vector.
 
         One matrix over all coefficients, so the cross blocks between terms are present rather
-        than assumed away. Nuisance parameters are held fixed at their fitted values, matching
-        how CBMR has always reported regression standard errors.
+       than assumed away. Nuisance parameters are held fixed at their fitted values.
 
-        Computed in closed form for every distribution NiMARE ships; see
-        :mod:`nimare.meta.cbmr.information`. Automatic differentiation is the fallback for one
-        added without a derivation.
+        Computed in closed form for every distribution with automatic differentiation as the fallback for
+        distributions added without a derivation.
         """
         closed_form = closed_form_information(self.distribution)
         if closed_form is not None:
@@ -182,8 +180,7 @@ class CBMRModel(torch.nn.Module):
         every hypothesis tested against one fit asks for the same matrix, and
         :meth:`~nimare.meta.cbmr.results.CBMRResult.test` would otherwise rebuild it each time.
         The cache holds one matrix, is keyed on the foci and the covariance options, and is
-        cleared by :meth:`fit`. At many groups that matrix is large -- 0.64 GB at 8,947
-        coefficients -- but it is shared by every result derived from the fit, since
+        cleared by :meth:`fit`. At many groups that matrix is large; could be well over 500mb, but it is shared by every result derived from the fit, since
         ``CBMRResult.copy`` passes the estimator by reference.
         """
         from nimare.meta.cbmr.covariance import fisher_covariance, sandwich_covariance

--- a/nimare/meta/cbmr/model.py
+++ b/nimare/meta/cbmr/model.py
@@ -58,6 +58,7 @@ class CBMRModel(torch.nn.Module):
             torch.nn.Parameter(nuisance.detach().to(device)) if nuisance is not None else None
         )
         self._iterations = 0
+        self._covariance_cache = None
 
     @property
     def n_parameters(self):
@@ -102,6 +103,8 @@ class CBMRModel(torch.nn.Module):
         tol : :obj:`float`, optional
             Stopping tolerance on the change in the objective. Default is 1e-8.
         """
+        # Any refit invalidates a cached covariance, which is a function of the converged fit.
+        self._covariance_cache = None
         parameters = [self.coefficients] + ([] if self.nuisance is None else [self.nuisance])
         optimizer = torch.optim.LBFGS(
             params=parameters,
@@ -172,17 +175,35 @@ class CBMRModel(torch.nn.Module):
         meat, correction, ridge
             Passed to :func:`~nimare.meta.cbmr.covariance.sandwich_covariance` when
             ``cov_type="sandwich"``.
-        """
-        if cov_type == "sandwich":
-            from nimare.meta.cbmr.covariance import sandwich_covariance
 
-            return sandwich_covariance(self, foci, meat=meat, correction=correction, ridge=ridge)
-        if cov_type != "fisher":
+        Notes
+        -----
+        The result is cached. It is a function of the converged coefficients and the foci, so
+        every hypothesis tested against one fit asks for the same matrix, and
+        :meth:`~nimare.meta.cbmr.results.CBMRResult.test` would otherwise rebuild it each time.
+        The cache holds one matrix, is keyed on the foci and the covariance options, and is
+        cleared by :meth:`fit`. At many groups that matrix is large -- 0.64 GB at 8,947
+        coefficients -- but it is shared by every result derived from the fit, since
+        ``CBMRResult.copy`` passes the estimator by reference.
+        """
+        from nimare.meta.cbmr.covariance import fisher_covariance, sandwich_covariance
+
+        key = (cov_type, meat, correction, ridge)
+        cached = self._covariance_cache
+        if cached is not None and cached[0] is foci and cached[1] == key:
+            return cached[2]
+
+        if cov_type == "sandwich":
+            value = sandwich_covariance(self, foci, meat=meat, correction=correction, ridge=ridge)
+        elif cov_type == "fisher":
+            value = fisher_covariance(self, self.information_matrix(foci))
+        else:
             raise ValueError(f"cov_type must be 'fisher' or 'sandwich', got {cov_type!r}.")
 
-        from nimare.meta.cbmr.covariance import fisher_covariance
-
-        return fisher_covariance(self, self.information_matrix(foci))
+        # ``foci`` is held in the key, not just its id: ids are recycled, and a freed matrix
+        # could otherwise let a later call match a cache entry that is not its own.
+        self._covariance_cache = (foci, key, value)
+        return value
 
     def standard_errors(self, foci, **covariance_kwargs):
         """Return coefficient standard errors, keyed by term.

--- a/nimare/meta/cbmr/predictor.py
+++ b/nimare/meta/cbmr/predictor.py
@@ -105,11 +105,10 @@ class SpatialPatterns:
     def marginal_by_pattern(self, foci):
         """Sum foci counts over the experiments sharing each pattern.
 
-        A sparse ``foci`` is kept sparse: the scatter-add is written as a product with the
-        ``(n_experiments, n_patterns)`` 0/1 membership matrix, which costs one pass over the
-        stored nonzeros instead of one pass over the full experiment-by-voxel grid. That grid is
-        the array this module exists to avoid --- at 17,000 experiments over a 2 mm mask it is
-        31 GB --- and it would otherwise be materialised here on every likelihood evaluation.
+        A sparse ``foci`` stays sparse. The scatter-add becomes a product with the
+        ``(n_experiments, n_patterns)`` membership matrix, which costs one pass over the stored
+        nonzeros rather than one over the full experiment-by-voxel grid. That grid is the array
+        this module exists to avoid: 31 GB at 17,000 experiments over a 2 mm mask.
 
         Returns
         -------

--- a/nimare/meta/cbmr/predictor.py
+++ b/nimare/meta/cbmr/predictor.py
@@ -105,17 +105,31 @@ class SpatialPatterns:
     def marginal_by_pattern(self, foci):
         """Sum foci counts over the experiments sharing each pattern.
 
+        A sparse ``foci`` is kept sparse: the scatter-add is written as a product with the
+        ``(n_experiments, n_patterns)`` 0/1 membership matrix, which costs one pass over the
+        stored nonzeros instead of one pass over the full experiment-by-voxel grid. That grid is
+        the array this module exists to avoid --- at 17,000 experiments over a 2 mm mask it is
+        31 GB --- and it would otherwise be materialised here on every likelihood evaluation.
+
         Returns
         -------
         :obj:`numpy.ndarray`
             Shape ``(n_patterns, n_voxels)``.
         """
-        foci = _as_dense_array(foci)
         if foci.shape[0] != self.n_experiments:
             raise ValueError(
                 f"foci has {foci.shape[0]} rows but the design covers {self.n_experiments} "
                 "experiments."
             )
+        if scipy.sparse.issparse(foci):
+            rows = np.arange(self.n_experiments)
+            membership = scipy.sparse.csr_matrix(
+                (np.ones(self.n_experiments), (rows, self.assignment)),
+                shape=(self.n_experiments, self.n_patterns),
+            )
+            return np.asarray((membership.T @ foci).todense(), dtype=float)
+
+        foci = _as_dense_array(foci)
         marginal = np.zeros((self.n_patterns, foci.shape[1]), dtype=float)
         np.add.at(marginal, self.assignment, foci)
         return marginal

--- a/nimare/meta/cbmr/predictor.py
+++ b/nimare/meta/cbmr/predictor.py
@@ -105,10 +105,11 @@ class SpatialPatterns:
     def marginal_by_pattern(self, foci):
         """Sum foci counts over the experiments sharing each pattern.
 
-        A sparse ``foci`` stays sparse. The scatter-add becomes a product with the
-        ``(n_experiments, n_patterns)`` membership matrix, which costs one pass over the stored
-        nonzeros rather than one over the full experiment-by-voxel grid. That grid is the array
-        this module exists to avoid: 31 GB at 17,000 experiments over a 2 mm mask.
+        Written as a product with the ``(n_experiments, n_patterns)`` membership matrix. That
+        keeps a sparse ``foci`` sparse, so the cost is one pass over the stored nonzeros rather
+        than one over the full experiment-by-voxel grid -- the array this module exists to avoid,
+        31 GB at 17,000 experiments over a 2 mm mask. The same expression handles a dense
+        ``foci``, and is faster there than the scatter-add it replaces.
 
         Returns
         -------
@@ -120,18 +121,14 @@ class SpatialPatterns:
                 f"foci has {foci.shape[0]} rows but the design covers {self.n_experiments} "
                 "experiments."
             )
-        if scipy.sparse.issparse(foci):
-            rows = np.arange(self.n_experiments)
-            membership = scipy.sparse.csr_matrix(
-                (np.ones(self.n_experiments), (rows, self.assignment)),
-                shape=(self.n_experiments, self.n_patterns),
-            )
-            return np.asarray((membership.T @ foci).todense(), dtype=float)
-
-        foci = _as_dense_array(foci)
-        marginal = np.zeros((self.n_patterns, foci.shape[1]), dtype=float)
-        np.add.at(marginal, self.assignment, foci)
-        return marginal
+        membership = scipy.sparse.csr_matrix(
+            (np.ones(self.n_experiments), (np.arange(self.n_experiments), self.assignment)),
+            shape=(self.n_experiments, self.n_patterns),
+        )
+        marginal = membership.T @ foci
+        if scipy.sparse.issparse(marginal):
+            marginal = marginal.todense()
+        return np.asarray(marginal, dtype=float)
 
 
 class CBMRPredictor:
@@ -263,8 +260,9 @@ def poisson_log_likelihood(predictor, spatial_coef, global_coef, foci):
     marginal_by_pattern = _as_tensor(
         predictor.patterns.marginal_by_pattern(foci), spatial_coef.dtype
     )
+    # foci.sum works on both a sparse matrix and an array, so the grid is never materialised.
     foci_per_experiment = _as_tensor(
-        np.asarray(_as_dense_array(foci).sum(axis=1)).reshape(-1), spatial_coef.dtype
+        np.asarray(foci.sum(axis=1)).reshape(-1), spatial_coef.dtype
     )
 
     log_intensity = predictor.log_intensity_by_pattern(spatial_coef)

--- a/nimare/meta/cbmr/predictor.py
+++ b/nimare/meta/cbmr/predictor.py
@@ -43,6 +43,14 @@ def _as_dense_array(value):
     return np.asarray(value, dtype=float)
 
 
+def experiment_totals(foci):
+    """Return the foci count per experiment, for a sparse matrix or an array alike.
+
+    ``sum`` works on both, so the experiment-by-voxel grid is never materialised.
+    """
+    return np.asarray(foci.sum(axis=1)).reshape(-1)
+
+
 def _as_tensor(array, dtype=torch.float64):
     """Convert an array to a torch tensor, copying anything that is not already contiguous.
 
@@ -260,10 +268,7 @@ def poisson_log_likelihood(predictor, spatial_coef, global_coef, foci):
     marginal_by_pattern = _as_tensor(
         predictor.patterns.marginal_by_pattern(foci), spatial_coef.dtype
     )
-    # foci.sum works on both a sparse matrix and an array, so the grid is never materialised.
-    foci_per_experiment = _as_tensor(
-        np.asarray(foci.sum(axis=1)).reshape(-1), spatial_coef.dtype
-    )
+    foci_per_experiment = _as_tensor(experiment_totals(foci), spatial_coef.dtype)
 
     log_intensity = predictor.log_intensity_by_pattern(spatial_coef)
     moderator = predictor.moderator_effect(global_coef).to(spatial_coef.dtype)

--- a/nimare/tests/test_meta_cbmr_information.py
+++ b/nimare/tests/test_meta_cbmr_information.py
@@ -314,6 +314,40 @@ def test_bordered_route_uses_the_cheap_condition_number(data):
     )
 
 
+def test_covariance_is_cached_across_hypotheses(data):
+    """Every hypothesis against one fit asks for the same matrix; it should be built once."""
+    model, foci = _fit("~ s(diagnosis) + n", "poisson", data)
+    first = model.covariance(foci)
+    assert model.covariance(foci) is first, "a repeated call should hit the cache"
+
+    # The options are part of the key, so a different estimator is not served from it.
+    assert model.covariance(foci, cov_type="sandwich", correction="hc0") is not first
+
+    # A different foci must not match, even though the previous one may have been freed.
+    other = foci * 2
+    assert model.covariance(other) is not first
+    np.testing.assert_allclose(
+        model.covariance(other), np.linalg.inv(model.information_matrix(other)), rtol=1e-6
+    )
+
+
+def test_refitting_clears_the_covariance_cache(data):
+    """The covariance describes the converged fit, so refitting must not serve the old one."""
+    model, foci = _fit("~ s(diagnosis)", "poisson", data)
+    stale = model.covariance(foci)
+    model.fit(foci, n_iter=5, tol=1e-8)
+    fresh = model.covariance(foci)
+    assert fresh is not stale
+
+
+def test_cached_covariance_matches_an_uncached_one(data):
+    """The cache must not change any number a contrast produces."""
+    model, foci = _fit("~ s(diagnosis) + n", "poisson", data)
+    cached = model.covariance(foci)
+    model._covariance_cache = None
+    np.testing.assert_array_equal(model.covariance(foci), cached)
+
+
 def test_cholesky_inverse_declines_a_non_positive_definite_matrix():
     """It returns None rather than raising, so the caller can fall back."""
     assert cholesky_inverse(np.array([[1.0, 2.0], [2.0, 1.0]])) is None

--- a/nimare/tests/test_meta_cbmr_information.py
+++ b/nimare/tests/test_meta_cbmr_information.py
@@ -94,7 +94,7 @@ def _fit(formula, distribution, data, n_iter=60):
 
 
 def _autodiff_information(model, foci):
-    """The path the closed forms replace, called directly."""
+    """Return the information matrix by automatic differentiation, as the stock path does."""
     flat = model.coefficients.detach().clone()
     nuisance = None if model.nuisance is None else model.nuisance.detach().clone()
 

--- a/nimare/tests/test_meta_cbmr_information.py
+++ b/nimare/tests/test_meta_cbmr_information.py
@@ -138,7 +138,9 @@ def test_information_is_symmetric(formula, distribution, data):
     """
     model, foci = _fit(formula, distribution, data)
     information = model.information_matrix(foci)
-    np.testing.assert_allclose(information, information.T, rtol=1e-12, atol=0)
+    # Exact equality, not a tolerance. Each block is built to be bitwise symmetric, so a
+    # tolerance here would hide the case this is guarding against.
+    np.testing.assert_array_equal(information, information.T)
 
 
 def test_poisson_information_ignores_the_foci(data):

--- a/nimare/tests/test_meta_cbmr_information.py
+++ b/nimare/tests/test_meta_cbmr_information.py
@@ -128,6 +128,19 @@ def test_overdispersion_stays_off_the_poisson_boundary(distribution, data):
     assert fitted.min() > 1e-3, f"overdispersion collapsed to {fitted}; counts are not dispersed"
 
 
+@pytest.mark.parametrize("distribution", DISTRIBUTIONS)
+@pytest.mark.parametrize("formula", FORMULAS)
+def test_information_is_symmetric(formula, distribution, data):
+    """A Hessian is symmetric, and each closed form mirrors its cross block by hand.
+
+    That last step is repeated once per distribution, so a fourth one could omit it and produce
+    a matrix that inverts fine but is wrong above the diagonal.
+    """
+    model, foci = _fit(formula, distribution, data)
+    information = model.information_matrix(foci)
+    np.testing.assert_allclose(information, information.T, rtol=1e-12, atol=0)
+
+
 def test_poisson_information_ignores_the_foci(data):
     """Under a log link the counts drop out of the Poisson information."""
     model, foci = _fit("~ s(diagnosis)", "poisson", data)

--- a/nimare/tests/test_meta_cbmr_information.py
+++ b/nimare/tests/test_meta_cbmr_information.py
@@ -281,15 +281,31 @@ def test_covariance_matches_a_dense_inverse(formula, distribution, data):
     assert np.abs(produced - reference).max() / np.abs(reference).max() < tolerance
 
 
-def test_marginal_by_pattern_is_unchanged_by_sparsity(data):
-    """The sparse path must give the same result as the dense one."""
+@pytest.mark.parametrize("distribution", DISTRIBUTIONS)
+def test_sparse_and_dense_foci_agree(distribution, data):
+    """One code path serves both, so the two representations must not diverge.
+
+    The estimator always builds a sparse matrix, but ``fit`` and ``information_matrix`` accept
+    an array too, and NiMARE's other CBMR tests pass one.
+    """
     import scipy.sparse
 
     annotations, bases = data
     predictor = CBMRPredictor(bind(Design.from_formula("~ s(diagnosis)"), annotations), bases)
     rng = np.random.default_rng(5)
     dense = rng.poisson(0.4, (predictor.patterns.n_experiments, N_VOXELS)).astype(float)
+    sparse = scipy.sparse.csr_matrix(dense)
+
     np.testing.assert_array_equal(
         predictor.patterns.marginal_by_pattern(dense),
-        predictor.patterns.marginal_by_pattern(scipy.sparse.csr_matrix(dense)),
+        predictor.patterns.marginal_by_pattern(sparse),
+    )
+
+    model = CBMRModel(predictor, distribution=distribution)
+    model.fit(dense, n_iter=20, tol=1e-8)
+    np.testing.assert_allclose(
+        float(model.log_likelihood(dense)), float(model.log_likelihood(sparse)), rtol=1e-12
+    )
+    np.testing.assert_allclose(
+        model.information_matrix(dense), model.information_matrix(sparse), rtol=1e-12
     )

--- a/nimare/tests/test_meta_cbmr_information.py
+++ b/nimare/tests/test_meta_cbmr_information.py
@@ -20,6 +20,7 @@ else:
         bordered_inverse,
         cholesky_inverse,
         is_block_diagonal,
+        one_norm_condition_number,
         spatial_components,
         symmetric_condition_number,
     )
@@ -274,6 +275,43 @@ def test_a_singular_design_explains_itself_on_the_blockwise_route(data):
 
     with pytest.raises(np.linalg.LinAlgError, match="spline_spacing"):
         model.covariance(foci)
+
+
+def test_one_norm_condition_number_never_underestimates():
+    """kappa_2 <= kappa_1 for symmetric matrices, so warning on the 1-norm cannot miss one.
+
+    That inequality is the whole reason the bordered route may report the cheaper norm.
+    """
+    rng = np.random.default_rng(4)
+    for size in (5, 20, 60):
+        for trial in range(5):
+            root = rng.normal(size=(size, size)) / np.sqrt(size)
+            matrix = root @ root.T + np.eye(size) * 10.0 ** rng.integers(-6, 1)
+            inverse = np.linalg.inv(matrix)
+            assert np.linalg.cond(matrix) <= one_norm_condition_number(matrix, inverse) * (
+                1 + 1e-9
+            ), f"kappa_2 exceeded kappa_1 at size {size}, trial {trial}"
+
+
+def test_bordered_route_uses_the_cheap_condition_number(data):
+    """A moderator design takes the bordered route, whose conditioning comes from the inverse.
+
+    Pinned by identity with ``bordered_inverse`` rather than by a private attribute, so the
+    assertion survives a refactor of how the route is chosen.
+    """
+    model, foci = _fit("~ s(diagnosis) + n", "poisson", data)
+    information = model.information_matrix(foci)
+    components = spatial_components(model.predictor.patterns.loadings, model.predictor.n_bases)
+    assert model.n_global == 1 and len(components) > 1
+    assert is_block_diagonal(information[: model.n_spatial, : model.n_spatial], components)
+
+    covariance = model.covariance(foci)
+    expected = bordered_inverse(information, components, model.n_spatial)
+    np.testing.assert_array_equal(covariance, expected)
+    # The bound that lets this route report the cheaper norm.
+    assert one_norm_condition_number(information, covariance) >= np.linalg.cond(information) * (
+        1 - 1e-9
+    )
 
 
 def test_cholesky_inverse_declines_a_non_positive_definite_matrix():

--- a/nimare/tests/test_meta_cbmr_information.py
+++ b/nimare/tests/test_meta_cbmr_information.py
@@ -1,13 +1,8 @@
 """Tests for the closed-form observed information and the covariance strategies.
 
-Checked against ``torch.func.hessian`` -- the code path these replace -- rather than against a
-reimplementation of the same algebra, so a shared mistake cannot pass. The derivations themselves
-are proved symbolically at https://github.com/jdkent/cbmr-proofs; what is checked here is their
-implementation: the vectorisation, the pattern assembly, the loadings scatter, and the dispatch.
-
-Two structural claims get their own tests because they would otherwise fail silently. The
-Poisson Hessian must not depend on the foci (a canonical-link property), and the other two must,
-so an implementation that ignored the data would pass every equality test but be wrong.
+Checked against ``torch.func.hessian``, the path these replace, so a shared mistake cannot pass.
+The derivations are proved at https://github.com/jdkent/cbmr-proofs; what is checked here is the
+code that implements them.
 """
 
 import numpy as np
@@ -38,9 +33,8 @@ pytestmark = pytest.mark.skipif(not TORCH_INSTALLED, reason="Torch not installed
 N_PER_GROUP = 12
 N_VOXELS = 30
 N_BASES = 4
-# Every design shape the grammar produces that bears on these routines: a cell-means factor
-# (disjoint loadings), the same with one and with two moderators (the cross and global blocks),
-# and a sum-to-zero term (loadings that are neither one-hot nor nonnegative).
+# A cell-means factor, the same with one and two moderators, and a sum-to-zero term whose
+# loadings are neither one-hot nor positive.
 FORMULAS = [
     "~ s(diagnosis)",
     "~ s(diagnosis) + n",
@@ -70,13 +64,9 @@ def data():
 def _fit(formula, distribution, data, n_iter=60):
     """Fit ``distribution`` to counts drawn from a matching generative model.
 
-    The draw matters. Simulating Poisson counts and then fitting a negative binomial drives the
-    overdispersion to the Poisson boundary -- measured, 5e-7 -- and there the (R, A)
-    reparameterisation has A ~ 1e6 and R ~ 1e7, so the gamma-gamma block becomes large
-    opposite-signed terms cancelling to a small one. Both the closed form and automatic
-    differentiation lose precision there, in different ways, and comparing them tests the
-    conditioning of a degenerate fit rather than the derivation. Overdispersed data keeps the
-    fit in the regime the distribution is for.
+    The draw matters. Fitting a negative binomial to Poisson counts pushes its overdispersion to
+    zero, where the closed form loses precision and the comparison measures that instead of the
+    derivation. Overdispersed counts keep the fit in the range the distribution is meant for.
     """
     annotations, bases = data
     predictor = CBMRPredictor(bind(Design.from_formula(formula), annotations), bases)
@@ -91,13 +81,12 @@ def _fit(formula, distribution, data, n_iter=60):
     if distribution == "poisson":
         foci = rng.poisson(mean).astype(float)
     elif distribution == "clusterednegativebinomial":
-        # One latent factor per experiment, shared across the whole brain -- which is exactly
-        # what distinguishes this model from the plain negative binomial. A voxelwise mixture
-        # leaves it with nothing to estimate and its overdispersion collapses.
+        # One factor per experiment, shared across the brain. That is what separates this model
+        # from the plain negative binomial, and a voxelwise mixture leaves it nothing to fit.
         factor = rng.gamma(size, 1.0 / size, size=mean.shape[0])[:, None]
         foci = rng.poisson(mean * factor).astype(float)
     else:
-        # Independent gamma variation at each voxel: the negative binomial's own mixture.
+        # Independent gamma variation at each voxel.
         foci = rng.poisson(rng.gamma(size, mean / size)).astype(float)
     model = CBMRModel(predictor, distribution=distribution)
     model.fit(foci, n_iter=n_iter, tol=1e-8)
@@ -128,11 +117,10 @@ def test_closed_form_matches_autodiff(formula, distribution, data):
 
 @pytest.mark.parametrize("distribution", ["negativebinomial", "clusterednegativebinomial"])
 def test_overdispersion_stays_off_the_poisson_boundary(distribution, data):
-    """Guard the premise of the comparison above.
+    """Guard the premise of the test above.
 
-    If the simulated counts stop being overdispersed, the fits collapse toward Poisson and the
-    equality tests start measuring floating-point cancellation instead of the derivation. This
-    fails first and says so.
+    If the counts stop being overdispersed, the fits collapse toward Poisson and the equality
+    tests start measuring rounding error. This fails first and says so.
     """
     model, _ = _fit("~ s(diagnosis) + n", distribution, data)
     fitted = model.overdispersion()
@@ -141,7 +129,7 @@ def test_overdispersion_stays_off_the_poisson_boundary(distribution, data):
 
 
 def test_poisson_information_ignores_the_foci(data):
-    """A canonical link makes observed and expected information coincide."""
+    """Under a log link the counts drop out of the Poisson information."""
     model, foci = _fit("~ s(diagnosis)", "poisson", data)
     one = closed_form_information(model.distribution)(model, foci)
     two = closed_form_information(model.distribution)(model, foci * 3)
@@ -150,7 +138,7 @@ def test_poisson_information_ignores_the_foci(data):
 
 @pytest.mark.parametrize("distribution", ["negativebinomial", "clusterednegativebinomial"])
 def test_overdispersed_information_uses_the_foci(distribution, data):
-    """The other two must respond, so a foci-blind implementation cannot pass silently."""
+    """The other two must respond, or an implementation ignoring the counts would pass."""
     model, foci = _fit("~ s(diagnosis)", distribution, data)
     one = closed_form_information(model.distribution)(model, foci)
     two = closed_form_information(model.distribution)(model, foci * 3)
@@ -158,7 +146,7 @@ def test_overdispersed_information_uses_the_foci(distribution, data):
 
 
 def test_unknown_distribution_falls_back_to_autodiff(data):
-    """A distribution with no derivation must not silently get someone else's Hessian."""
+    """A distribution with no derivation must not get another one's Hessian."""
     from nimare.meta.cbmr.distributions import Distribution
     from nimare.meta.cbmr.predictor import poisson_log_likelihood
 
@@ -177,7 +165,7 @@ def test_unknown_distribution_falls_back_to_autodiff(data):
 
 
 def test_information_is_block_diagonal_for_a_cell_means_factor(data):
-    """Off-block entries are structurally absent, not merely small."""
+    """Off-block entries are exactly zero, not merely small."""
     model, foci = _fit("~ s(diagnosis)", "poisson", data)
     information = model.information_matrix(foci)
     blocks = spatial_components(model.predictor.patterns.loadings, model.predictor.n_bases)
@@ -190,7 +178,7 @@ def test_information_is_block_diagonal_for_a_cell_means_factor(data):
 
 
 def test_a_moderator_couples_every_column_but_not_the_spatial_block(data):
-    """The bordered structure survives what block diagonality does not."""
+    """Moderators end block diagonality but leave the spatial blocks separable."""
     model, foci = _fit("~ s(diagnosis) + n", "poisson", data)
     information = model.information_matrix(foci)
     spatial = spatial_components(model.predictor.patterns.loadings, model.predictor.n_bases)
@@ -200,7 +188,7 @@ def test_a_moderator_couples_every_column_but_not_the_spatial_block(data):
 
 
 def test_every_inverse_route_agrees():
-    """Blockwise, bordered and Cholesky are one matrix by three roads."""
+    """Blockwise, bordered and Cholesky must give one matrix, not three."""
     n_blocks, width, border = 3, 6, 2
     rng = np.random.default_rng(11)
     blocks, index = [], []
@@ -237,7 +225,7 @@ def test_every_inverse_route_agrees():
     )
     np.testing.assert_allclose(cholesky_inverse(full), np.linalg.inv(full), atol=1e-8)
 
-    # With no border the Schur complement must reproduce the blockwise inverse exactly.
+    # With no border the Schur complement must match the blockwise inverse.
     shrunk = full.copy()
     shrunk[:n_spatial, n_spatial:] = 0.0
     shrunk[n_spatial:, :n_spatial] = 0.0
@@ -249,11 +237,10 @@ def test_every_inverse_route_agrees():
 
 
 def test_a_singular_design_explains_itself_on_the_blockwise_route(data):
-    """The actionable message must not depend on which rung reached the singularity.
+    """The message must not depend on which route hit the singularity.
 
-    The blockwise route inverts each block with ``np.linalg.inv`` directly, so without a shared
-    handler it would surface numpy's bare "Singular matrix" while the dense route explained
-    itself. This is the design that takes that route.
+    The blockwise route inverts each block directly, so without a shared handler it would raise
+    numpy's bare "Singular matrix". This design takes that route.
     """
     annotations, bases = data
     # Duplicated basis columns make each block exactly singular.
@@ -275,7 +262,7 @@ def test_a_singular_design_explains_itself_on_the_blockwise_route(data):
 
 
 def test_cholesky_inverse_declines_a_non_positive_definite_matrix():
-    """It reports rather than raises, so the caller can fall back."""
+    """It returns None rather than raising, so the caller can fall back."""
     assert cholesky_inverse(np.array([[1.0, 2.0], [2.0, 1.0]])) is None
 
 
@@ -295,7 +282,7 @@ def test_covariance_matches_a_dense_inverse(formula, distribution, data):
 
 
 def test_marginal_by_pattern_is_unchanged_by_sparsity(data):
-    """The sparse path added to marginal_by_pattern must be the same scatter-add."""
+    """The sparse path must give the same result as the dense one."""
     import scipy.sparse
 
     annotations, bases = data

--- a/nimare/tests/test_meta_cbmr_information.py
+++ b/nimare/tests/test_meta_cbmr_information.py
@@ -1,0 +1,308 @@
+"""Tests for the closed-form observed information and the covariance strategies.
+
+Checked against ``torch.func.hessian`` -- the code path these replace -- rather than against a
+reimplementation of the same algebra, so a shared mistake cannot pass. The derivations themselves
+are proved symbolically at https://github.com/jdkent/cbmr-proofs; what is checked here is their
+implementation: the vectorisation, the pattern assembly, the loadings scatter, and the dispatch.
+
+Two structural claims get their own tests because they would otherwise fail silently. The
+Poisson Hessian must not depend on the foci (a canonical-link property), and the other two must,
+so an implementation that ignored the data would pass every equality test but be wrong.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+try:
+    import torch  # noqa: F401
+except ImportError:
+    TORCH_INSTALLED = False
+else:
+    TORCH_INSTALLED = True
+    from nimare.meta.cbmr.covariance import (
+        blockwise_inverse,
+        bordered_inverse,
+        cholesky_inverse,
+        is_block_diagonal,
+        spatial_components,
+        symmetric_condition_number,
+    )
+    from nimare.meta.cbmr.information import closed_form_information
+    from nimare.meta.cbmr.model import CBMRModel
+    from nimare.meta.cbmr.predictor import CBMRPredictor
+    from nimare.meta.cbmr.terms import Design, bind
+
+pytestmark = pytest.mark.skipif(not TORCH_INSTALLED, reason="Torch not installed.")
+
+N_PER_GROUP = 12
+N_VOXELS = 30
+N_BASES = 4
+# Every design shape the grammar produces that bears on these routines: a cell-means factor
+# (disjoint loadings), the same with one and with two moderators (the cross and global blocks),
+# and a sum-to-zero term (loadings that are neither one-hot nor nonnegative).
+FORMULAS = [
+    "~ s(diagnosis)",
+    "~ s(diagnosis) + n",
+    "~ s(diagnosis) + n + age",
+    "~ sz(diagnosis) + sz(drug)",
+]
+DISTRIBUTIONS = ["poisson", "negativebinomial", "clusterednegativebinomial"]
+
+
+@pytest.fixture(scope="module")
+def data():
+    """Simulate counts with an interior maximum, as the model tests do."""
+    rng = np.random.default_rng(23)
+    n_experiments = 2 * N_PER_GROUP
+    annotations = pd.DataFrame(
+        {
+            "diagnosis": ["schiz"] * N_PER_GROUP + ["dep"] * N_PER_GROUP,
+            "drug": ["yes", "no"] * N_PER_GROUP,
+            "n": rng.normal(size=n_experiments),
+            "age": rng.normal(size=n_experiments),
+        }
+    )
+    raw = rng.uniform(0.05, 1.0, (N_VOXELS, N_BASES))
+    return annotations, raw / raw.sum(axis=1, keepdims=True)
+
+
+def _fit(formula, distribution, data, n_iter=60):
+    """Fit ``distribution`` to counts drawn from a matching generative model.
+
+    The draw matters. Simulating Poisson counts and then fitting a negative binomial drives the
+    overdispersion to the Poisson boundary -- measured, 5e-7 -- and there the (R, A)
+    reparameterisation has A ~ 1e6 and R ~ 1e7, so the gamma-gamma block becomes large
+    opposite-signed terms cancelling to a small one. Both the closed form and automatic
+    differentiation lose precision there, in different ways, and comparing them tests the
+    conditioning of a degenerate fit rather than the derivation. Overdispersed data keeps the
+    fit in the regime the distribution is for.
+    """
+    annotations, bases = data
+    predictor = CBMRPredictor(bind(Design.from_formula(formula), annotations), bases)
+    rng = np.random.default_rng(29)
+    spatial = torch.tensor(
+        rng.normal(1.3, 0.25, (predictor.n_spatial_columns, predictor.n_bases)),
+        dtype=torch.float64,
+    )
+    intensity = torch.exp(predictor.log_intensity_by_pattern(spatial)).detach().numpy()
+    mean = intensity[predictor.patterns.assignment]
+    size = 6.0
+    if distribution == "poisson":
+        foci = rng.poisson(mean).astype(float)
+    elif distribution == "clusterednegativebinomial":
+        # One latent factor per experiment, shared across the whole brain -- which is exactly
+        # what distinguishes this model from the plain negative binomial. A voxelwise mixture
+        # leaves it with nothing to estimate and its overdispersion collapses.
+        factor = rng.gamma(size, 1.0 / size, size=mean.shape[0])[:, None]
+        foci = rng.poisson(mean * factor).astype(float)
+    else:
+        # Independent gamma variation at each voxel: the negative binomial's own mixture.
+        foci = rng.poisson(rng.gamma(size, mean / size)).astype(float)
+    model = CBMRModel(predictor, distribution=distribution)
+    model.fit(foci, n_iter=n_iter, tol=1e-8)
+    return model, foci
+
+
+def _autodiff_information(model, foci):
+    """The path the closed forms replace, called directly."""
+    flat = model.coefficients.detach().clone()
+    nuisance = None if model.nuisance is None else model.nuisance.detach().clone()
+
+    def negative_log_likelihood(vector):
+        return -model.log_likelihood(foci, flat=vector, nuisance=nuisance)
+
+    hessian = torch.func.hessian(negative_log_likelihood)(flat)
+    return hessian.reshape(model.n_parameters, model.n_parameters).detach().cpu().numpy()
+
+
+@pytest.mark.parametrize("distribution", DISTRIBUTIONS)
+@pytest.mark.parametrize("formula", FORMULAS)
+def test_closed_form_matches_autodiff(formula, distribution, data):
+    """The closed form is the same matrix automatic differentiation produces."""
+    model, foci = _fit(formula, distribution, data)
+    reference = _autodiff_information(model, foci)
+    analytic = closed_form_information(model.distribution)(model, foci)
+    assert np.abs(analytic - reference).max() < 1e-8 * np.abs(reference).max()
+
+
+@pytest.mark.parametrize("distribution", ["negativebinomial", "clusterednegativebinomial"])
+def test_overdispersion_stays_off_the_poisson_boundary(distribution, data):
+    """Guard the premise of the comparison above.
+
+    If the simulated counts stop being overdispersed, the fits collapse toward Poisson and the
+    equality tests start measuring floating-point cancellation instead of the derivation. This
+    fails first and says so.
+    """
+    model, _ = _fit("~ s(diagnosis) + n", distribution, data)
+    fitted = model.overdispersion()
+    assert fitted is not None
+    assert fitted.min() > 1e-3, f"overdispersion collapsed to {fitted}; counts are not dispersed"
+
+
+def test_poisson_information_ignores_the_foci(data):
+    """A canonical link makes observed and expected information coincide."""
+    model, foci = _fit("~ s(diagnosis)", "poisson", data)
+    one = closed_form_information(model.distribution)(model, foci)
+    two = closed_form_information(model.distribution)(model, foci * 3)
+    np.testing.assert_allclose(one, two, rtol=1e-12)
+
+
+@pytest.mark.parametrize("distribution", ["negativebinomial", "clusterednegativebinomial"])
+def test_overdispersed_information_uses_the_foci(distribution, data):
+    """The other two must respond, so a foci-blind implementation cannot pass silently."""
+    model, foci = _fit("~ s(diagnosis)", distribution, data)
+    one = closed_form_information(model.distribution)(model, foci)
+    two = closed_form_information(model.distribution)(model, foci * 3)
+    assert np.abs(one - two).max() > 1e-6 * np.abs(one).max()
+
+
+def test_unknown_distribution_falls_back_to_autodiff(data):
+    """A distribution with no derivation must not silently get someone else's Hessian."""
+    from nimare.meta.cbmr.distributions import Distribution
+    from nimare.meta.cbmr.predictor import poisson_log_likelihood
+
+    class Unlisted(Distribution):
+        name = "Unlisted"
+
+        def log_likelihood(self, predictor, spatial_coef, global_coef, nuisance, foci):
+            return poisson_log_likelihood(predictor, spatial_coef, global_coef, foci)
+
+    assert closed_form_information(Unlisted()) is None
+    model, foci = _fit("~ s(diagnosis)", "poisson", data)
+    model.distribution = Unlisted()
+    np.testing.assert_allclose(
+        model.information_matrix(foci), _autodiff_information(model, foci), rtol=1e-9
+    )
+
+
+def test_information_is_block_diagonal_for_a_cell_means_factor(data):
+    """Off-block entries are structurally absent, not merely small."""
+    model, foci = _fit("~ s(diagnosis)", "poisson", data)
+    information = model.information_matrix(foci)
+    blocks = spatial_components(model.predictor.patterns.loadings, model.predictor.n_bases)
+    assert len(blocks) == 2
+    assert is_block_diagonal(information, blocks)
+    mask = np.ones_like(information, dtype=bool)
+    for index in blocks:
+        mask[np.ix_(index, index)] = False
+    assert np.abs(information[mask]).max() == 0.0
+
+
+def test_a_moderator_couples_every_column_but_not_the_spatial_block(data):
+    """The bordered structure survives what block diagonality does not."""
+    model, foci = _fit("~ s(diagnosis) + n", "poisson", data)
+    information = model.information_matrix(foci)
+    spatial = spatial_components(model.predictor.patterns.loadings, model.predictor.n_bases)
+    assert len(spatial) == 2, "the spatial columns must still separate"
+    assert is_block_diagonal(information[: model.n_spatial, : model.n_spatial], spatial)
+    assert not is_block_diagonal(information, spatial), "gamma must couple the whole matrix"
+
+
+def test_every_inverse_route_agrees():
+    """Blockwise, bordered and Cholesky are one matrix by three roads."""
+    n_blocks, width, border = 3, 6, 2
+    rng = np.random.default_rng(11)
+    blocks, index = [], []
+    for i in range(n_blocks):
+        root = rng.normal(size=(width, width)) / np.sqrt(width)
+        blocks.append(root @ root.T + np.eye(width))
+        index.append(np.arange(i * width, (i + 1) * width))
+    n_spatial = n_blocks * width
+    diagonal = np.zeros((n_spatial, n_spatial))
+    for slot, block in zip(index, blocks):
+        diagonal[np.ix_(slot, slot)] = block
+
+    reference = np.linalg.inv(diagonal)
+    np.testing.assert_allclose(blockwise_inverse(diagonal, index), reference, atol=1e-10)
+    np.testing.assert_allclose(cholesky_inverse(diagonal), reference, atol=1e-10)
+    np.testing.assert_allclose(
+        symmetric_condition_number(diagonal, index), np.linalg.cond(diagonal), rtol=1e-10
+    )
+    np.testing.assert_allclose(
+        symmetric_condition_number(diagonal), np.linalg.cond(diagonal), rtol=1e-10
+    )
+
+    edge = rng.normal(size=(n_spatial, border)) * 0.1
+    root = rng.normal(size=(border, border))
+    full = np.zeros((n_spatial + border, n_spatial + border))
+    full[:n_spatial, :n_spatial] = diagonal
+    full[:n_spatial, n_spatial:] = edge
+    full[n_spatial:, :n_spatial] = edge.T
+    full[n_spatial:, n_spatial:] = (
+        edge.T @ np.linalg.solve(diagonal, edge) + root @ root.T + np.eye(border)
+    )
+    np.testing.assert_allclose(
+        bordered_inverse(full, index, n_spatial), np.linalg.inv(full), atol=1e-8
+    )
+    np.testing.assert_allclose(cholesky_inverse(full), np.linalg.inv(full), atol=1e-8)
+
+    # With no border the Schur complement must reproduce the blockwise inverse exactly.
+    shrunk = full.copy()
+    shrunk[:n_spatial, n_spatial:] = 0.0
+    shrunk[n_spatial:, :n_spatial] = 0.0
+    np.testing.assert_allclose(
+        bordered_inverse(shrunk, index, n_spatial)[:n_spatial, :n_spatial],
+        blockwise_inverse(diagonal, index),
+        atol=1e-10,
+    )
+
+
+def test_a_singular_design_explains_itself_on_the_blockwise_route(data):
+    """The actionable message must not depend on which rung reached the singularity.
+
+    The blockwise route inverts each block with ``np.linalg.inv`` directly, so without a shared
+    handler it would surface numpy's bare "Singular matrix" while the dense route explained
+    itself. This is the design that takes that route.
+    """
+    annotations, bases = data
+    # Duplicated basis columns make each block exactly singular.
+    predictor = CBMRPredictor(
+        bind(Design.from_formula("~ s(diagnosis)"), annotations), np.hstack([bases, bases])
+    )
+    rng = np.random.default_rng(29)
+    spatial = torch.tensor(
+        rng.normal(1.3, 0.25, (predictor.n_spatial_columns, predictor.n_bases)),
+        dtype=torch.float64,
+    )
+    intensity = torch.exp(predictor.log_intensity_by_pattern(spatial)).detach().numpy()
+    foci = rng.poisson(intensity[predictor.patterns.assignment]).astype(float)
+    model = CBMRModel(predictor, distribution="poisson")
+    model.fit(foci, n_iter=60, tol=1e-8)
+
+    with pytest.raises(np.linalg.LinAlgError, match="spline_spacing"):
+        model.covariance(foci)
+
+
+def test_cholesky_inverse_declines_a_non_positive_definite_matrix():
+    """It reports rather than raises, so the caller can fall back."""
+    assert cholesky_inverse(np.array([[1.0, 2.0], [2.0, 1.0]])) is None
+
+
+@pytest.mark.parametrize("distribution", DISTRIBUTIONS)
+@pytest.mark.parametrize("formula", FORMULAS)
+def test_covariance_matches_a_dense_inverse(formula, distribution, data):
+    """Whichever rung the design reaches, the answer is the dense inverse."""
+    model, foci = _fit(formula, distribution, data)
+    information = model.information_matrix(foci)
+    condition = np.linalg.cond(information)
+    if condition > 1.0 / np.finfo(float).eps:
+        pytest.skip("information matrix is numerically singular; no inverse to compare against")
+    reference = np.linalg.inv(information)
+    produced = model.covariance(foci)
+    tolerance = max(1e-10, 100 * condition * np.finfo(float).eps)
+    assert np.abs(produced - reference).max() / np.abs(reference).max() < tolerance
+
+
+def test_marginal_by_pattern_is_unchanged_by_sparsity(data):
+    """The sparse path added to marginal_by_pattern must be the same scatter-add."""
+    import scipy.sparse
+
+    annotations, bases = data
+    predictor = CBMRPredictor(bind(Design.from_formula("~ s(diagnosis)"), annotations), bases)
+    rng = np.random.default_rng(5)
+    dense = rng.poisson(0.4, (predictor.patterns.n_experiments, N_VOXELS)).astype(float)
+    np.testing.assert_array_equal(
+        predictor.patterns.marginal_by_pattern(dense),
+        predictor.patterns.marginal_by_pattern(scipy.sparse.csr_matrix(dense)),
+    )


### PR DESCRIPTION
information_matrix differentiates the log-likelihood twice with torch.func.hessian, which is jacfwd(jacrev(.)). Forward mode carries one tangent per parameter through the likelihood at once, so the intermediate log-intensity tensor has shape (n_parameters, n_patterns, n_voxels). On a 21-group diagnosis model over 21,789 voxels that is 28.7 GB: the model cannot be fitted at all, and the size is driven by the group count, so a coarser grid does not avoid it.

All three distributions admit a closed form, and it is the same shape in each case. The predictor is linear in the coefficients, so the chain rule contributes no curvature term and the spatial block is sum_p L_pc L_pc' (B^T Sigma_p B), with Sigma_p the second differential in the log-intensity. Only Sigma_p differs: diagonal for Poisson and NegativeBinomial, diagonal plus rank one for ClusteredNegativeBinomial, whose spatial coefficients enter only through the scalar sum_v exp(S_pv). Each is n_patterns rank-updates of width n_bases, so nothing of size n_parameters is formed. Automatic differentiation stays as the fallback for a distribution added without a derivation.

That exposes the next bottleneck: covariance() spent 163 s on an SVD for a diagnostic condition number against 14 s for the inverse it was diagnosing. The same L_pc L_pc' factor says which coefficients can covary, independently of the distribution, so the information matrix is exactly block diagonal for a cell-means factor and bordered block diagonal once moderators are added. covariance() now dispatches over that structure, and takes the condition number from a symmetric eigensolver rather than an SVD -- exact, since a symmetric matrix's singular values are its absolute eigenvalues. Every rung returns the same matrix and reports the same condition number; only the work differs.

marginal_by_pattern keeps a sparse foci sparse, since densifying it inside the routine meant to avoid large allocations would defeat the purpose.

Measured on the real 21-group pool, complete run including 20 one-versus-rest contrasts: 769 s and 5.49 GB peak before, 44 s and 2.67 GB after.

Every identity is proved symbolically at https://github.com/jdkent/cbmr-proofs (59 claims, each a residual simplified to exactly zero) and checked numerically against torch.func.hessian in the new tests.

<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes # .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

-
-

## Summary by Sourcery

Replace CBMR Hessian-based information and dense covariance workflows with closed-form, structure-aware computations that substantially reduce runtime and peak memory usage.

New Features:
- Compute observed Fisher information in closed form for Poisson, Negative Binomial, and Clustered Negative Binomial CBMR models, while retaining automatic differentiation as a fallback for unsupported distributions.
- Exploit block and bordered-block structure to accelerate Fisher covariance inversion and condition-number evaluation.
- Cache covariance matrices across repeated hypothesis tests for a fitted model.
- Preserve sparse foci inputs during pattern marginalization and experiment-total calculations.

Bug Fixes:
- Avoid memory-intensive Hessian intermediates and dense sparse-foci allocations that could prevent large CBMR models from fitting.

Enhancements:
- Add symbolic and numerical validation of information derivations, covariance routes, sparse/dense input equivalence, singular designs, and cache behavior.

CI:
- Relax benchmark regression detection to flag runs that are at least 20% slower than the baseline.

Tests:
- Add comprehensive tests comparing closed-form information with automatic differentiation across distributions and model designs.

Chores:
- Update CBMR benchmarks to reuse cached setup data and remove the obsolete diagnostics benchmark.