### PR TITLE
Fix discrete decoder correction defaults

### DIFF
--- a/docs/decoding.rst
+++ b/docs/decoding.rst
@@ -256,7 +256,7 @@ of foci associated with each study in the database.
    decoder = BrainMapDecoder(
        frequency_threshold=0.001,
        u=0.05,
-       correction='fdr_bh',
+       correction='bh',
    )
    decoder.fit(ns_dset)
    decoding_results = decoder.transform(amygdala_ids)
@@ -360,7 +360,7 @@ probability of any given experiment including a given label.
    decoder = NeurosynthDecoder(
        frequency_threshold=0.001,
        u=0.05,
-       correction='fdr_bh',
+       correction='bh',
    )
    decoder.fit(ns_dset)
    decoding_results = decoder.transform(amygdala_ids)
@@ -387,8 +387,6 @@ This approach uses the following steps to calculate label-wise correlation value
 
    decoder = ROIAssociationDecoder(
       "data/amygdala.nii.gz",
-      u=0.05,
-      correction="fdr_bh",
    )
    decoder.fit(ns_dset)
    decoding_results = decoder.transform()

--- a/nimare/decode/discrete.py
+++ b/nimare/decode/discrete.py
@@ -165,7 +165,7 @@ class BrainMapDecoder(Decoder):
         features=None,
         frequency_threshold=0.001,
         u=0.05,
-        correction="fdr_bh",
+        correction="bh",
     ):
         self.feature_group = feature_group
         self.features = features
@@ -224,7 +224,7 @@ def brainmap_decode(
     features=None,
     frequency_threshold=0.001,
     u=0.05,
-    correction="fdr_bh",
+    correction="bh",
 ):
     """Perform image-to-text decoding for discrete inputs according to the BrainMap method.
 
@@ -349,15 +349,17 @@ def brainmap_decode(
     nlogp_ri[n_selected_term < 5] = 0.0
 
     # Multiple comparisons correction across features. Separately done for FI and RI.
-    if correction in ("bh", "by"):
+    if correction is None:
+        nlogp_corr_fi = nlogp_fi
+        nlogp_corr_ri = nlogp_ri
+    elif correction in ("bh", "by"):
         nlogp_corr_fi = nlogp_fdr(nlogp_fi, method=correction)
         nlogp_corr_ri = nlogp_fdr(nlogp_ri, method=correction)
     elif correction == "bonferroni":
         nlogp_corr_fi = nlogp_bonferroni(nlogp_fi)
         nlogp_corr_ri = nlogp_bonferroni(nlogp_ri)
     else:
-        nlogp_corr_fi = nlogp_fi
-        nlogp_corr_ri = nlogp_ri
+        raise ValueError("Argument 'correction' must be one of None, 'bh', 'by', or 'bonferroni'.")
 
     # Compute z-values
     p_corr_fi = _clip_p_values(np.exp(nlogp_corr_fi), dtype=np.float64, copy=False)
@@ -460,7 +462,7 @@ class NeurosynthDecoder(Decoder):
         frequency_threshold=0.001,
         prior=0.5,
         u=0.05,
-        correction="fdr_bh",
+        correction="bh",
     ):
         self.feature_group = feature_group
         self.features = features
@@ -522,7 +524,7 @@ def neurosynth_decode(
     frequency_threshold=0.001,
     prior=0.5,
     u=0.05,
-    correction="fdr_bh",
+    correction="bh",
 ):
     """Perform discrete functional decoding according to Neurosynth's meta-analytic method.
 
@@ -643,15 +645,17 @@ def neurosynth_decode(
     sign_ri = np.sign(p_selected_g_term - p_selected_g_noterm).ravel()  # pylint: disable=no-member
 
     # Multiple comparisons correction across terms. Separately done for FI and RI.
-    if correction in ("bh", "by"):
+    if correction is None:
+        nlogp_corr_fi = nlogp_fi
+        nlogp_corr_ri = nlogp_ri
+    elif correction in ("bh", "by"):
         nlogp_corr_fi = nlogp_fdr(nlogp_fi, method=correction)
         nlogp_corr_ri = nlogp_fdr(nlogp_ri, method=correction)
     elif correction == "bonferroni":
         nlogp_corr_fi = nlogp_bonferroni(nlogp_fi)
         nlogp_corr_ri = nlogp_bonferroni(nlogp_ri)
     else:
-        nlogp_corr_fi = nlogp_fi
-        nlogp_corr_ri = nlogp_ri
+        raise ValueError("Argument 'correction' must be one of None, 'bh', 'by', or 'bonferroni'.")
 
     # Compute z-values
     p_corr_fi = _clip_p_values(np.exp(nlogp_corr_fi), dtype=np.float64, copy=False)


### PR DESCRIPTION
Closes #1119.

Changes proposed in this pull request:

- Change the default correction method for the BrainMap and Neurosynth discrete decoders from `fdr_bh` to the supported `bh` value.
- Handle `correction=None` explicitly and raise a `ValueError` for unsupported correction methods.
- Update the decoding documentation to match the supported correction options.

Testing:

- `pytest nimare/tests/test_decode_discrete.py -q`
- `make lint`

## Summary by Sourcery

Correct discrete decoder correction defaults and validation to align behavior with the supported correction methods.

Bug Fixes:
- Use the supported Benjamini–Hochberg correction by default for BrainMap and Neurosynth discrete decoders.
- Handle uncorrected decoding explicitly when correction is None and reject unsupported correction methods with a clear error.

Documentation:
- Update decoding documentation to reflect the supported multiple-comparison correction options.