### PR TITLE
Store foci on CBMRModel

### DIFF
--- a/nimare/meta/cbmr/contrasts.py
+++ b/nimare/meta/cbmr/contrasts.py
@@ -276,7 +276,7 @@ def _statistics(model, block, contrast, constants, covariance_block, bases):
 
 
 def evaluate_hypotheses(
-    model, hypotheses=None, foci=None, name=None, term=None, method=None, **covariance_kwargs
+    model, hypotheses=None, name=None, term=None, method=None, **covariance_kwargs
 ):
     """Test hypotheses about the fitted coefficients.
 
@@ -287,8 +287,6 @@ def evaluate_hypotheses(
     hypotheses : :obj:`str` or :obj:`list` of :obj:`str`, optional
         Hypotheses over level names. A list is tested jointly, as a generalized linear
         hypothesis, rather than one at a time.
-    foci : array_like
-        The foci the model was fitted to.
     name : :obj:`str`, optional
         Overrides the label derived from the hypothesis. Rarely needed.
     term, method : :obj:`str`, optional
@@ -320,7 +318,7 @@ def evaluate_hypotheses(
 
     bases = model.predictor.bases
     slices = bound_design.parameter_slices(model.predictor.n_bases)
-    covariance = model.covariance(foci, **covariance_kwargs)
+    covariance = model.covariance(**covariance_kwargs)
 
     maps, tables = {}, {}
     for label, statement in requested:

--- a/nimare/meta/cbmr/covariance.py
+++ b/nimare/meta/cbmr/covariance.py
@@ -65,7 +65,7 @@ def _validate(meat, correction):
     return meat, correction
 
 
-def _fitted_pieces(model, foci):
+def _fitted_pieces(model):
     """Return residuals, fitted means, and the design's structural blocks.
 
     The mean carries the exposure; the score contributions below do not gain a term for it,
@@ -74,21 +74,21 @@ def _fitted_pieces(model, foci):
     applied by each caller.
     """
     predictor = model.predictor
-    counts = _as_dense_array(foci)
+    counts = _as_dense_array(model.foci)
 
     spatial_coef, global_coef = model.unpack(model.coefficients.detach())
     mean = predictor.fitted_mean(spatial_coef, global_coef).detach().cpu().numpy()
     return counts - mean, mean, predictor.spatial_block, predictor.global_block, predictor.bases
 
 
-def _leverage(model, foci, spatial_block, global_block, bases, mean):
+def _leverage(model, spatial_block, global_block, bases, mean):
     """Return the leverage of every experiment-voxel cell.
 
     ``h_iv = x_iv' A^-1 x_iv`` scaled by the cell's mean, as for any GLM hat value. Assembled
     from the design's structure rather than from the rows themselves, which would be an
     (experiment x voxel) x parameters array.
     """
-    bread_inverse = np.linalg.inv(model.information_matrix(foci))
+    bread_inverse = np.linalg.inv(model.information_matrix())
     n_spatial = model.n_spatial
     n_columns, n_bases = spatial_block.shape[1], bases.shape[1]
 
@@ -159,15 +159,13 @@ def _scores_by_cluster(residuals, spatial_block, global_block, bases, n_spatial)
     return np.hstack([spatial_scores, global_scores])
 
 
-def sandwich_covariance(model, foci, meat="cluster", correction="hc1", ridge=0.0):
+def sandwich_covariance(model, meat="cluster", correction="hc1", ridge=0.0):
     """Return the sandwich covariance of the regression coefficients.
 
     Parameters
     ----------
     model : :class:`~nimare.meta.cbmr.model.CBMRModel`
         Fitted model.
-    foci : array_like
-        Foci counts the model was fitted to.
     meat : {"cluster", "iid"}, optional
         How score contributions are grouped. Default is ``"cluster"``, which allows arbitrary
         correlation within an experiment.
@@ -183,12 +181,12 @@ def sandwich_covariance(model, foci, meat="cluster", correction="hc1", ridge=0.0
         Covariance matrix over the flat coefficient vector, in the design's parameter layout.
     """
     meat_kind, correction = _validate(meat, correction)
-    residuals, mean, spatial_block, global_block, bases = _fitted_pieces(model, foci)
+    residuals, mean, spatial_block, global_block, bases = _fitted_pieces(model)
     n_spatial = model.n_spatial
     n_parameters = model.n_parameters
 
     if correction == "hc3":
-        leverage = _leverage(model, foci, spatial_block, global_block, bases, mean)
+        leverage = _leverage(model, spatial_block, global_block, bases, mean)
         # Clip below one: a leverage at or above one would divide by zero, which happens when a
         # cell is fitted exactly and carries no information about anything else.
         residuals = residuals / np.clip(1.0 - leverage, 1e-6, None)
@@ -213,7 +211,7 @@ def sandwich_covariance(model, foci, meat="cluster", correction="hc1", ridge=0.0
 
     _warn_if_meat_is_rank_deficient(model, meat_matrix, meat_kind)
 
-    bread = model.information_matrix(foci)
+    bread = model.information_matrix()
     if ridge:
         bread = bread + ridge * np.eye(n_parameters)
     bread_inverse = np.linalg.inv(bread)

--- a/nimare/meta/cbmr/estimator.py
+++ b/nimare/meta/cbmr/estimator.py
@@ -430,10 +430,10 @@ class CBMR(_CBMRInputs):
         self.cbmr_model = CBMRModel(self.predictor, self.distribution, device=self.device)
         self.cbmr_model.fit(foci, n_iter=self.n_iter, lr=self.lr, tol=self.tol)
 
-        maps, tables = self._summarize(foci)
+        maps, tables = self._summarize()
         return maps, tables, self._description_text()
 
-    def _summarize(self, foci):
+    def _summarize(self):
         """Turn the fitted model into result maps and tables.
 
         Reported per *term*, not per spatial pattern. A design with a continuously varying
@@ -446,7 +446,7 @@ class CBMR(_CBMRInputs):
         maps, tables = {}, {}
         bases = self.predictor.bases
         coefficients = self.cbmr_model.fitted_coefficients()
-        errors = self.cbmr_model.standard_errors(foci)
+        errors = self.cbmr_model.standard_errors()
 
         for block in self.bound_design.blocks:
             if block.term.exposure:

--- a/nimare/meta/cbmr/information.py
+++ b/nimare/meta/cbmr/information.py
@@ -130,15 +130,13 @@ def poisson_information_matrix(model):
     return _finalize(information, n_spatial, n_global)
 
 
-def negative_binomial_information_matrix(model, foci):
+def negative_binomial_information_matrix(model):
     """Return the observed Fisher information of a fitted NegativeBinomial model.
 
     Parameters
     ----------
     model : :class:`~nimare.meta.cbmr.model.CBMRModel`
         Fitted model.
-    foci : array_like or :obj:`scipy.sparse.spmatrix`
-        Foci counts. Used, unlike the Poisson case, but only through the pattern marginals.
 
     Returns
     -------
@@ -159,7 +157,7 @@ def negative_binomial_information_matrix(model, foci):
     n_voxels, bases = predictor.n_voxels, predictor.bases
     assignment = predictor.patterns.assignment
     overdispersion = _nuisance(model)
-    marginal = predictor.patterns.marginal_by_pattern(foci)
+    marginal = predictor.patterns.marginal_by_pattern(model.foci)
 
     information = np.zeros((n_spatial + n_global, n_spatial + n_global))
     for p, row in enumerate(loadings):
@@ -219,15 +217,13 @@ def negative_binomial_information_matrix(model, foci):
     return _finalize(information, n_spatial, n_global)
 
 
-def clustered_negative_binomial_information_matrix(model, foci):
+def clustered_negative_binomial_information_matrix(model):
     """Return the observed Fisher information of a fitted ClusteredNegativeBinomial model.
 
     Parameters
     ----------
     model : :class:`~nimare.meta.cbmr.model.CBMRModel`
         Fitted model.
-    foci : array_like or :obj:`scipy.sparse.spmatrix`
-        Foci counts. Only the per-experiment totals matter here.
 
     Returns
     -------
@@ -245,7 +241,7 @@ def clustered_negative_binomial_information_matrix(model, foci):
     bases = predictor.bases
     assignment = predictor.patterns.assignment
     overdispersion = _nuisance(model)
-    per_experiment = experiment_totals(foci)
+    per_experiment = experiment_totals(model.foci)
 
     information = np.zeros((n_spatial + n_global, n_spatial + n_global))
     for p, row in enumerate(loadings):
@@ -279,8 +275,8 @@ def clustered_negative_binomial_information_matrix(model, foci):
     return _finalize(information, n_spatial, n_global)
 
 
-def _poisson_entry(model, foci):
-    """Adapt the Poisson signature to the ``(model, foci)`` the dispatch uses."""
+def _poisson_entry(model):
+    """Adapt the Poisson signature to the dispatch used by closed-form information."""
     return poisson_information_matrix(model)
 
 

--- a/nimare/meta/cbmr/model.py
+++ b/nimare/meta/cbmr/model.py
@@ -58,12 +58,31 @@ class CBMRModel(torch.nn.Module):
             torch.nn.Parameter(nuisance.detach().to(device)) if nuisance is not None else None
         )
         self._iterations = 0
+        self._foci = None
+        self._candidate_foci = None
         self._covariance_cache = None
 
     @property
     def n_parameters(self):
         """Number of regression coefficients, excluding nuisance parameters."""
         return self.n_spatial + self.n_global
+
+    @property
+    def foci(self):
+        """Foci counts the model was fit to."""
+        return self._require_foci()
+
+    @staticmethod
+    def _copy_foci(foci):
+        """Return a copy of foci that external mutation cannot change in place."""
+        copied = foci.copy() if hasattr(foci, "copy") else np.array(foci, copy=True)
+        if hasattr(copied, "setflags"):
+            copied.setflags(write=False)
+        for array_name in ("data", "indices", "indptr", "row", "col"):
+            array = getattr(copied, array_name, None)
+            if hasattr(array, "setflags"):
+                array.setflags(write=False)
+        return copied
 
     def unpack(self, flat):
         """Split a flat coefficient vector into spatial and non-spatial parts."""
@@ -73,8 +92,21 @@ class CBMRModel(torch.nn.Module):
         global_coef = flat[self.n_spatial :] if self.n_global else None
         return spatial, global_coef
 
-    def log_likelihood(self, foci, flat=None, nuisance=None):
+    def _require_foci(self):
+        """Return the fitted foci matrix, or fail if the model has not been fit."""
+        if self._foci is None:
+            raise ValueError(
+                "CBMRModel must be fit before foci-dependent quantities are available."
+            )
+        return self._foci
+
+    def _active_foci(self):
+        """Return the candidate foci during fitting, otherwise the fitted foci."""
+        return self._candidate_foci if self._candidate_foci is not None else self._require_foci()
+
+    def log_likelihood(self, flat=None, nuisance=None):
         """Return the log-likelihood at ``flat``, defaulting to the current coefficients."""
+        foci = self._active_foci()
         flat = self.coefficients if flat is None else flat
         raw_nuisance = self.nuisance if nuisance is None else nuisance
         spatial, global_coef = self.unpack(flat)
@@ -85,9 +117,9 @@ class CBMRModel(torch.nn.Module):
             self.predictor, spatial, global_coef, transformed, foci
         )
 
-    def forward(self, foci):
+    def forward(self):
         """Return the negative log-likelihood, the quantity being minimized."""
-        return -self.log_likelihood(foci)
+        return -self.log_likelihood()
 
     def fit(self, foci, n_iter=1000, lr=1.0, tol=1e-8):
         """Fit by L-BFGS.
@@ -103,9 +135,11 @@ class CBMRModel(torch.nn.Module):
         tol : :obj:`float`, optional
             Stopping tolerance on the change in the objective. Default is 1e-8.
         """
-        # Any refit invalidates a cached covariance, which is a function of the converged fit.
-        self._covariance_cache = None
         parameters = [self.coefficients] + ([] if self.nuisance is None else [self.nuisance])
+        previous_values = [parameter.detach().clone() for parameter in parameters]
+        previous_iterations = self._iterations
+        candidate_foci = self._copy_foci(foci)
+        self._candidate_foci = candidate_foci
         optimizer = torch.optim.LBFGS(
             params=parameters,
             lr=lr,
@@ -114,26 +148,40 @@ class CBMRModel(torch.nn.Module):
             line_search_fn="strong_wolfe",
         )
 
-        def closure():
-            optimizer.zero_grad()
-            loss = self(foci)
-            loss.backward()
-            return loss
+        try:
 
-        optimizer.step(closure)
-        state = optimizer.state.get(parameters[0], {})
-        self._iterations = int(state.get("n_iter", 0))
+            def closure():
+                optimizer.zero_grad()
+                loss = self()
+                loss.backward()
+                return loss
 
-        loss = self(foci)
-        if not torch.isfinite(loss):
-            raise ValueError(
-                f"The {self.distribution.name} log-likelihood became "
-                f"{float(loss.detach())} during optimization. Try a smaller lr, a coarser "
-                "spline_spacing, or the Poisson distribution."
-            )
+            optimizer.step(closure)
+            state = optimizer.state.get(parameters[0], {})
+            iterations = int(state.get("n_iter", 0))
+
+            loss = self()
+            if not torch.isfinite(loss):
+                raise ValueError(
+                    f"The {self.distribution.name} log-likelihood became "
+                    f"{float(loss.detach())} during optimization. Try a smaller lr, a coarser "
+                    "spline_spacing, or the Poisson distribution."
+                )
+        except Exception:
+            with torch.no_grad():
+                for parameter, previous_value in zip(parameters, previous_values):
+                    parameter.copy_(previous_value)
+            self._iterations = previous_iterations
+            raise
+        finally:
+            self._candidate_foci = None
+
+        self._foci = candidate_foci
+        self._covariance_cache = None
+        self._iterations = iterations
         return self
 
-    def information_matrix(self, foci):
+    def information_matrix(self):
         """Return the observed Fisher information over the flat coefficient vector.
 
         One matrix over all coefficients, so the cross blocks between terms are present rather
@@ -142,9 +190,10 @@ class CBMRModel(torch.nn.Module):
         Computed in closed form for every distribution with automatic differentiation as the
         fallback for distributions added without a derivation.
         """
+        self._require_foci()
         closed_form = closed_form_information(self.distribution)
         if closed_form is not None:
-            return closed_form(self, foci)
+            return closed_form(self)
 
         # No derivation, so differentiate. jacfwd(jacrev(.)) builds an intermediate of shape
         # (n_parameters, n_patterns, n_voxels), which is tens of GB on a many-group model.
@@ -152,18 +201,16 @@ class CBMRModel(torch.nn.Module):
         nuisance = None if self.nuisance is None else self.nuisance.detach().clone()
 
         def negative_log_likelihood(vector):
-            return -self.log_likelihood(foci, flat=vector, nuisance=nuisance)
+            return -self.log_likelihood(flat=vector, nuisance=nuisance)
 
         hessian = torch.func.hessian(negative_log_likelihood)(flat)
         return hessian.reshape(self.n_parameters, self.n_parameters).detach().cpu().numpy()
 
-    def covariance(self, foci, cov_type="fisher", meat="cluster", correction="hc1", ridge=0.0):
+    def covariance(self, cov_type="fisher", meat="cluster", correction="hc1", ridge=0.0):
         """Return the coefficient covariance.
 
         Parameters
         ----------
-        foci : array_like
-            Foci counts the model was fitted to.
         cov_type : {"fisher", "sandwich"}, optional
             ``"fisher"`` inverts the observed information, which is correct only if the Poisson
             mean-variance relationship holds. ``"sandwich"`` replaces the model-based variance
@@ -176,40 +223,37 @@ class CBMRModel(torch.nn.Module):
 
         Notes
         -----
-        The result is cached. It is a function of the converged coefficients and the foci, so
-        every hypothesis tested against one fit asks for the same matrix, and
+        The result is cached. It is a function of the converged coefficients and the fitted foci,
+        so every hypothesis tested against one fit asks for the same matrix, and
         :meth:`~nimare.meta.cbmr.results.CBMRResult.test` would otherwise rebuild it each time.
-        The cache holds one matrix, is keyed on the foci and the covariance options, and is
-        cleared by :meth:`fit`. At many groups that matrix is large; could be well over 500mb,
-        but it is shared by every result derived from the fit, since ``CBMRResult.copy`` passes
-        the estimator by reference.
+        The cache holds one matrix, is keyed on the covariance options, and is cleared by
+        :meth:`fit`. At many groups that matrix is large; could be well over 500mb, but it is
+        shared by every result derived from the fit, since ``CBMRResult.copy`` passes the
+        estimator by reference.
         """
         from nimare.meta.cbmr.covariance import fisher_covariance, sandwich_covariance
 
+        self._require_foci()
         key = (cov_type, meat, correction, ridge)
         cached = self._covariance_cache
-        if cached is not None and cached[0] is foci and cached[1] == key:
-            return cached[2]
+        if cached is not None and cached[0] == key:
+            return cached[1]
 
         if cov_type == "sandwich":
-            value = sandwich_covariance(self, foci, meat=meat, correction=correction, ridge=ridge)
+            value = sandwich_covariance(self, meat=meat, correction=correction, ridge=ridge)
         elif cov_type == "fisher":
-            value = fisher_covariance(self, self.information_matrix(foci))
+            value = fisher_covariance(self, self.information_matrix())
         else:
             raise ValueError(f"cov_type must be 'fisher' or 'sandwich', got {cov_type!r}.")
 
-        # ``foci`` is held in the key, not just its id: ids are recycled, and a freed matrix
-        # could otherwise let a later call match a cache entry that is not its own.
-        self._covariance_cache = (foci, key, value)
+        self._covariance_cache = (key, value)
         return value
 
-    def standard_errors(self, foci, **covariance_kwargs):
+    def standard_errors(self, **covariance_kwargs):
         """Return coefficient standard errors, keyed by term.
 
         Parameters
         ----------
-        foci : array_like
-            Foci counts the model was fitted to.
         **covariance_kwargs
             Passed to :meth:`covariance`, so ``cov_type="sandwich"`` gives robust errors.
 
@@ -219,7 +263,7 @@ class CBMRModel(torch.nn.Module):
             Maps the rendered term to an array of standard errors, shaped
             ``(n_columns, n_bases)`` for a spatial term and ``(n_columns,)`` otherwise.
         """
-        covariance = self.covariance(foci, **covariance_kwargs)
+        covariance = self.covariance(**covariance_kwargs)
         errors = np.sqrt(np.diag(covariance))
         result = {}
         for name, term_slice in self.predictor.design.parameter_slices(

--- a/nimare/meta/cbmr/results.py
+++ b/nimare/meta/cbmr/results.py
@@ -103,11 +103,9 @@ class CBMRResult(MetaResult):
                 "This result has no fitted model to test; it was not produced by CBMR.fit."
             )
 
-        foci = estimator.inputs_["foci"]
         computed = evaluate_hypotheses(
             model,
             hypotheses,
-            foci,
             name=name,
             term=term,
             method=method,

--- a/nimare/tests/test_meta_cbmr_contrasts.py
+++ b/nimare/tests/test_meta_cbmr_contrasts.py
@@ -130,25 +130,25 @@ def test_patsy_grammar_reaches_users(fitted, statement, expected_label):
     Arithmetic and bare difference expressions come free with
     :meth:`patsy.DesignInfo.linear_constraint`; a hand-rolled parser had neither.
     """
-    model, foci = fitted
-    result = evaluate_hypotheses(model, statement, foci)
+    model, _ = fitted
+    result = evaluate_hypotheses(model, statement)
     emitted = list(result["maps"]) + list(result["tables"])
     assert any(name.endswith(expected_label) for name in emitted), emitted
 
 
 def test_a_non_zero_right_hand_side_shifts_the_estimate(fitted):
     """``a = 1`` must test against one, not against zero."""
-    model, foci = fitted
-    against_zero = evaluate_hypotheses(model, "a = 0", foci)["maps"]["est_a"]
-    against_one = evaluate_hypotheses(model, "a = 1", foci)["maps"]["est_a_vs_1"]
+    model, _ = fitted
+    against_zero = evaluate_hypotheses(model, "a = 0")["maps"]["est_a"]
+    against_one = evaluate_hypotheses(model, "a = 1")["maps"]["est_a_vs_1"]
 
     np.testing.assert_allclose(against_one, against_zero - 1.0, rtol=1e-10)
 
 
 def test_a_list_is_tested_jointly(fitted):
     """Several statements are one generalized linear hypothesis, not several tests."""
-    model, foci = fitted
-    result = evaluate_hypotheses(model, ["a = b", "b = c"], foci, name="joint")
+    model, _ = fitted
+    result = evaluate_hypotheses(model, ["a = b", "b = c"], name="joint")
 
     assert "chiSquare_joint" in result["maps"]
     assert np.all(result["maps"]["chiSquare_joint"] >= 0)
@@ -158,16 +158,16 @@ def test_a_list_is_tested_jointly(fitted):
 
 def test_unknown_coefficients_list_the_options(fitted):
     """A typo should name what the design actually has."""
-    model, foci = fitted
+    model, _ = fitted
     with pytest.raises(ContrastError, match="coefficient names"):
-        evaluate_hypotheses(model, "a = z", foci)
+        evaluate_hypotheses(model, "a = z")
 
 
 def test_cross_term_contrasts_are_refused(fitted):
     """A map and a number have no common scale, so this is refused rather than guessed."""
-    model, foci = fitted
+    model, _ = fitted
     with pytest.raises(ContrastError, match="must stay within one term"):
-        evaluate_hypotheses(model, "a = n", foci)
+        evaluate_hypotheses(model, "a = n")
 
 
 def test_a_degenerate_contrast_is_refused(fitted):
@@ -176,9 +176,9 @@ def test_a_degenerate_contrast_is_refused(fitted):
     Caught by patsy rather than here -- it reports "no variables appear in constraint" -- which is
     why there is no separate check for it in ``build_contrast``.
     """
-    model, foci = fitted
+    model, _ = fitted
     with pytest.raises(ContrastError, match="no variables appear"):
-        evaluate_hypotheses(model, "a - a = 0", foci)
+        evaluate_hypotheses(model, "a - a = 0")
 
 
 # ---------------------------------------------------------------- translation
@@ -191,8 +191,8 @@ def test_level_contrasts_work_on_a_reparameterized_term():
     ``dx[sz2]``, so a user could only state hypotheses in a space with no interpretation. This is
     exactly the hypothesis-matrix versus contrast-matrix distinction ``hypr`` formalizes.
     """
-    model, foci = _fit("~ sz(dx) + n")
-    result = evaluate_hypotheses(model, "a = b", foci)
+    model, _ = _fit("~ sz(dx) + n")
+    result = evaluate_hypotheses(model, "a = b")
 
     assert set(result["maps"]) == {
         "est_a_vs_b",
@@ -219,8 +219,8 @@ def test_the_same_contrast_agrees_across_parameterizations():
     constrained = _fit_to("~ sz(dx) + n", foci, annotations, bases)
 
     for statement in ("a = b", "b = c", "2 * a = b + c"):
-        first = evaluate_hypotheses(cell_means, statement, foci)["maps"]
-        second = evaluate_hypotheses(constrained, statement, foci)["maps"]
+        first = evaluate_hypotheses(cell_means, statement)["maps"]
+        second = evaluate_hypotheses(constrained, statement)["maps"]
         key = next(k for k in first if k.startswith("z_"))
         np.testing.assert_allclose(
             second[key], first[key], rtol=1e-4, atol=1e-6, err_msg=statement
@@ -237,8 +237,8 @@ def test_estimate_and_standard_error_maps_are_emitted(fitted):
     Contrast exposes ``effect_size``/``effect_variance``; emitting only ``z`` would put CBMR at
     odds with both, and with its own scalar path.
     """
-    model, foci = fitted
-    maps = evaluate_hypotheses(model, "a = b", foci)["maps"]
+    model, _ = fitted
+    maps = evaluate_hypotheses(model, "a = b")["maps"]
 
     assert {"est_a_vs_b", "se_a_vs_b"} <= set(maps)
     assert np.all(maps["se_a_vs_b"] > 0)
@@ -257,7 +257,7 @@ def test_spatial_contrast_matches_statsmodels(fitted):
     ).fit()
     covariance = np.asarray(expected_fit.cov_params())
 
-    maps = evaluate_hypotheses(model, "a = b", foci)["maps"]
+    maps = evaluate_hypotheses(model, "a = b")["maps"]
 
     names = list(predictor.design.blocks[0].column_names)
     index_a, index_b = names.index("dx[a]"), names.index("dx[b]")
@@ -284,7 +284,7 @@ def test_scalar_contrast_matches_statsmodels(fitted):
         family=statsmodels_api.families.Poisson(),
     ).fit()
 
-    table = evaluate_hypotheses(model, "n = 0", foci)["tables"]["contrast_n"]
+    table = evaluate_hypotheses(model, "n = 0")["tables"]["contrast_n"]
 
     assert {"est", "se", "z", "p", "logp"} <= set(table.columns)
     np.testing.assert_allclose(table["est"].iloc[0], expected_fit.params[-1], rtol=1e-4)
@@ -293,9 +293,9 @@ def test_scalar_contrast_matches_statsmodels(fitted):
 
 def test_reversing_a_contrast_flips_its_sign(fitted):
     """A sanity check that the direction means what it reads as."""
-    model, foci = fitted
-    forward = evaluate_hypotheses(model, "a = b", foci)["maps"]
-    reverse = evaluate_hypotheses(model, "b = a", foci)["maps"]
+    model, _ = fitted
+    forward = evaluate_hypotheses(model, "a = b")["maps"]
+    reverse = evaluate_hypotheses(model, "b = a")["maps"]
 
     np.testing.assert_allclose(forward["est_a_vs_b"], -reverse["est_b_vs_a"], rtol=1e-10)
     np.testing.assert_allclose(forward["se_a_vs_b"], reverse["se_b_vs_a"], rtol=1e-10)
@@ -315,15 +315,15 @@ def test_reversing_a_contrast_flips_its_sign(fitted):
 )
 def test_named_families_enumerate_the_comparisons(fitted, method, expected):
     """Enumerate every comparison, instead of asking the user for one call per pair."""
-    model, foci = fitted
+    model, _ = fitted
     labels = [label for label, _ in generate_hypotheses(model.predictor.design, "dx", method)]
     assert labels == expected
 
 
 def test_pairwise_emits_one_set_of_maps_per_pair(fitted):
     """Each generated contrast gets its own label, as gratia's difference_smooths does."""
-    model, foci = fitted
-    maps = evaluate_hypotheses(model, term="dx", method="pairwise", foci=foci)["maps"]
+    model, _ = fitted
+    maps = evaluate_hypotheses(model, term="dx", method="pairwise")["maps"]
 
     assert sorted(k for k in maps if k.startswith("z_")) == ["z_a_vs_b", "z_a_vs_c", "z_b_vs_c"]
     assert sorted(k for k in maps if k.startswith("est_")) == [
@@ -335,9 +335,9 @@ def test_pairwise_emits_one_set_of_maps_per_pair(fitted):
 
 def test_a_generated_family_agrees_with_the_hand_written_contrast(fitted):
     """Generating a contrast must not compute anything different from naming it."""
-    model, foci = fitted
-    generated = evaluate_hypotheses(model, term="dx", method="pairwise", foci=foci)["maps"]
-    named = evaluate_hypotheses(model, "a = b", foci)["maps"]
+    model, _ = fitted
+    generated = evaluate_hypotheses(model, term="dx", method="pairwise")["maps"]
+    named = evaluate_hypotheses(model, "a = b")["maps"]
 
     np.testing.assert_allclose(generated["z_a_vs_b"], named["z_a_vs_b"], rtol=1e-12)
 
@@ -366,13 +366,13 @@ def test_unknown_method_and_term_are_reported(fitted):
 
 def test_the_two_forms_are_mutually_exclusive(fitted):
     """Naming a hypothesis and generating a family are alternatives, not combinable."""
-    model, foci = fitted
+    model, _ = fitted
     with pytest.raises(ContrastError, match="not both"):
-        evaluate_hypotheses(model, "a = b", foci, term="dx", method="pairwise")
+        evaluate_hypotheses(model, "a = b", term="dx", method="pairwise")
     with pytest.raises(ContrastError, match="together"):
-        evaluate_hypotheses(model, foci=foci, term="dx")
+        evaluate_hypotheses(model, term="dx")
     with pytest.raises(ContrastError, match="Give either"):
-        evaluate_hypotheses(model, foci=foci)
+        evaluate_hypotheses(model)
 
 
 def test_build_contrast_pushes_through_the_level_map():

--- a/nimare/tests/test_meta_cbmr_covariance.py
+++ b/nimare/tests/test_meta_cbmr_covariance.py
@@ -116,7 +116,7 @@ def test_iid_hc0_matches_statsmodels(fitted):
     checked against :func:`_reference_sandwich` instead.
     """
     model, foci, _ = fitted
-    actual = sandwich_covariance(model, foci, meat="iid", correction="hc0")
+    actual = sandwich_covariance(model, meat="iid", correction="hc0")
     expected = _statsmodels(model, foci, cov_type="HC0").cov_params()
 
     np.testing.assert_allclose(actual, np.asarray(expected), rtol=1e-5, atol=1e-9)
@@ -145,7 +145,7 @@ def test_iid_sandwich_matches_the_direct_computation(fitted, correction):
     are built from the design's Kronecker structure rather than from its rows.
     """
     model, foci, _ = fitted
-    actual = sandwich_covariance(model, foci, meat="iid", correction=correction)
+    actual = sandwich_covariance(model, meat="iid", correction=correction)
     expected = _reference_sandwich(model, foci, correction)
 
     np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-10)
@@ -161,7 +161,7 @@ def test_cluster_sandwich_matches_statsmodels(fitted):
     n_experiments = model.predictor.patterns.n_experiments
     groups = np.repeat(np.arange(n_experiments), N_VOXELS)
 
-    actual = sandwich_covariance(model, foci, meat="cluster", correction="hc0")
+    actual = sandwich_covariance(model, meat="cluster", correction="hc0")
     expected = _statsmodels(
         model, foci, cov_type="cluster", cov_kwds={"groups": groups, "use_correction": False}
     ).cov_params()
@@ -176,8 +176,8 @@ def test_cluster_standard_errors_exceed_model_based_ones(fitted):
     uncertainty. If this ever reversed, the estimator would be giving false comfort.
     """
     model, foci, _ = fitted
-    model_based = np.sqrt(np.diag(model.covariance(foci)))
-    clustered = np.sqrt(np.diag(sandwich_covariance(model, foci, meat="cluster")))
+    model_based = np.sqrt(np.diag(model.covariance()))
+    clustered = np.sqrt(np.diag(sandwich_covariance(model, meat="cluster")))
 
     assert np.median(clustered / model_based) > 1.0
 
@@ -186,7 +186,7 @@ def test_sandwich_is_symmetric_and_positive_semidefinite(fitted):
     """A covariance matrix has to look like one."""
     model, foci, _ = fitted
     for meat, correction in (("cluster", "hc1"), ("iid", "hc3")):
-        covariance = sandwich_covariance(model, foci, meat=meat, correction=correction)
+        covariance = sandwich_covariance(model, meat=meat, correction=correction)
         np.testing.assert_allclose(covariance, covariance.T, rtol=1e-10)
         eigenvalues = np.linalg.eigvalsh(covariance)
         assert eigenvalues.min() > -1e-8 * max(1.0, eigenvalues.max())
@@ -195,8 +195,8 @@ def test_sandwich_is_symmetric_and_positive_semidefinite(fitted):
 def test_ridge_regularizes_the_bread(fitted):
     """A ridge should shrink the covariance, for designs whose information is near-singular."""
     model, foci, _ = fitted
-    plain = sandwich_covariance(model, foci, meat="cluster", correction="hc0")
-    ridged = sandwich_covariance(model, foci, meat="cluster", correction="hc0", ridge=1.0)
+    plain = sandwich_covariance(model, meat="cluster", correction="hc0")
+    ridged = sandwich_covariance(model, meat="cluster", correction="hc0", ridge=1.0)
 
     assert np.trace(ridged) < np.trace(plain)
 
@@ -205,16 +205,16 @@ def test_cluster_with_hc3_is_refused(fitted):
     """Per-observation leverage has no meaning once observations are summed into clusters."""
     model, foci, _ = fitted
     with pytest.raises(CovarianceError, match="no counterpart"):
-        sandwich_covariance(model, foci, meat="cluster", correction="hc3")
+        sandwich_covariance(model, meat="cluster", correction="hc3")
 
 
 def test_invalid_options_are_reported(fitted):
     """Typos in the options should name the alternatives."""
     model, foci, _ = fitted
     with pytest.raises(CovarianceError, match="meat must be one of"):
-        sandwich_covariance(model, foci, meat="sandwich")
+        sandwich_covariance(model, meat="sandwich")
     with pytest.raises(CovarianceError, match="correction must be one of"):
-        sandwich_covariance(model, foci, correction="hc9")
+        sandwich_covariance(model, correction="hc9")
 
 
 def test_hc1_refuses_an_overparameterized_design(fitted):
@@ -226,8 +226,8 @@ def test_hc1_refuses_an_overparameterized_design(fitted):
         bind(Design.from_formula("~ s(dx) + n"), annotations),
         wide / wide.sum(axis=1, keepdims=True),
     )
-    wide_model = CBMRModel(predictor, Poisson())
     wide_foci = np.asarray(foci)
+    wide_model = CBMRModel(predictor, Poisson()).fit(wide_foci, n_iter=1)
 
     with pytest.raises(CovarianceError, match="hc1 scales by"):
-        sandwich_covariance(wide_model, wide_foci, meat="cluster", correction="hc1")
+        sandwich_covariance(wide_model, meat="cluster", correction="hc1")

--- a/nimare/tests/test_meta_cbmr_exposure.py
+++ b/nimare/tests/test_meta_cbmr_exposure.py
@@ -277,10 +277,9 @@ def test_the_closed_form_information_sees_the_exposure(data, formula):
     form while the autodiff fallback stayed correct.
     """
     model = _model(formula, data)
-    foci = data[2]
 
     def negative_log_likelihood(vector):
-        return -model.log_likelihood(foci, flat=vector, nuisance=None)
+        return -model.log_likelihood(flat=vector, nuisance=None)
 
     reference = (
         torch.func.hessian(negative_log_likelihood)(model.coefficients.detach().clone())
@@ -289,7 +288,7 @@ def test_the_closed_form_information_sees_the_exposure(data, formula):
         .cpu()
         .numpy()
     )
-    analytic = closed_form_information(model.distribution)(model, foci)
+    analytic = closed_form_information(model.distribution)(model)
     assert np.abs(analytic - reference).max() < 1e-8 * np.abs(reference).max()
 
 

--- a/nimare/tests/test_meta_cbmr_formula.py
+++ b/nimare/tests/test_meta_cbmr_formula.py
@@ -465,9 +465,7 @@ def test_the_public_fit_optimizes_the_statsmodels_likelihood(studyset, formula):
     expected = statsmodels_api.GLM(
         foci.reshape(-1), design, family=statsmodels_api.families.Poisson()
     ).loglike(coefficients)
-    actual = float(estimator.cbmr_model.log_likelihood(foci).detach()) - float(
-        gammaln(foci + 1).sum()
-    )
+    actual = float(estimator.cbmr_model.log_likelihood().detach()) - float(gammaln(foci + 1).sum())
 
     np.testing.assert_allclose(actual, expected, rtol=1e-9)
 
@@ -486,7 +484,6 @@ def test_the_public_fit_reports_the_design_derived_standard_errors(studyset):
     estimator = CBMR("~ 1 + diagnosis", **FIT_KWARGS)
     estimator.fit(dataset=studyset)
 
-    foci = np.asarray(estimator.inputs_["foci"].todense(), dtype=float)
     design = _materialize_public_design(estimator)
     coefficients = estimator.cbmr_model.coefficients.detach().numpy()
 
@@ -494,7 +491,7 @@ def test_the_public_fit_reports_the_design_derived_standard_errors(studyset):
     information = design.T @ (design * mean[:, None])
     expected = np.sqrt(np.diag(np.linalg.inv(information)))
 
-    actual = np.sqrt(np.diag(estimator.cbmr_model.covariance(foci)))
+    actual = np.sqrt(np.diag(estimator.cbmr_model.covariance()))
     np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-10)
 
 

--- a/nimare/tests/test_meta_cbmr_information.py
+++ b/nimare/tests/test_meta_cbmr_information.py
@@ -94,13 +94,13 @@ def _fit(formula, distribution, data, n_iter=60):
     return model, foci
 
 
-def _autodiff_information(model, foci):
+def _autodiff_information(model):
     """Return the information matrix by automatic differentiation, as the stock path does."""
     flat = model.coefficients.detach().clone()
     nuisance = None if model.nuisance is None else model.nuisance.detach().clone()
 
     def negative_log_likelihood(vector):
-        return -model.log_likelihood(foci, flat=vector, nuisance=nuisance)
+        return -model.log_likelihood(flat=vector, nuisance=nuisance)
 
     hessian = torch.func.hessian(negative_log_likelihood)(flat)
     return hessian.reshape(model.n_parameters, model.n_parameters).detach().cpu().numpy()
@@ -110,9 +110,9 @@ def _autodiff_information(model, foci):
 @pytest.mark.parametrize("formula", FORMULAS)
 def test_closed_form_matches_autodiff(formula, distribution, data):
     """The closed form is the same matrix automatic differentiation produces."""
-    model, foci = _fit(formula, distribution, data)
-    reference = _autodiff_information(model, foci)
-    analytic = closed_form_information(model.distribution)(model, foci)
+    model, _ = _fit(formula, distribution, data)
+    reference = _autodiff_information(model)
+    analytic = closed_form_information(model.distribution)(model)
     assert np.abs(analytic - reference).max() < 1e-8 * np.abs(reference).max()
 
 
@@ -137,8 +137,8 @@ def test_information_is_symmetric(formula, distribution, data):
     That last step is repeated once per distribution, so a fourth one could omit it and produce
     a matrix that inverts fine but is wrong above the diagonal.
     """
-    model, foci = _fit(formula, distribution, data)
-    information = model.information_matrix(foci)
+    model, _ = _fit(formula, distribution, data)
+    information = model.information_matrix()
     # Exact equality, not a tolerance. Each block is built to be bitwise symmetric, so a
     # tolerance here would hide the case this is guarding against.
     np.testing.assert_array_equal(information, information.T)
@@ -147,8 +147,9 @@ def test_information_is_symmetric(formula, distribution, data):
 def test_poisson_information_ignores_the_foci(data):
     """Under a log link the counts drop out of the Poisson information."""
     model, foci = _fit("~ s(diagnosis)", "poisson", data)
-    one = closed_form_information(model.distribution)(model, foci)
-    two = closed_form_information(model.distribution)(model, foci * 3)
+    one = closed_form_information(model.distribution)(model)
+    model._foci = foci * 3
+    two = closed_form_information(model.distribution)(model)
     np.testing.assert_allclose(one, two, rtol=1e-12)
 
 
@@ -156,8 +157,9 @@ def test_poisson_information_ignores_the_foci(data):
 def test_overdispersed_information_uses_the_foci(distribution, data):
     """The other two must respond, or an implementation ignoring the counts would pass."""
     model, foci = _fit("~ s(diagnosis)", distribution, data)
-    one = closed_form_information(model.distribution)(model, foci)
-    two = closed_form_information(model.distribution)(model, foci * 3)
+    one = closed_form_information(model.distribution)(model)
+    model._foci = foci * 3
+    two = closed_form_information(model.distribution)(model)
     assert np.abs(one - two).max() > 1e-6 * np.abs(one).max()
 
 
@@ -175,15 +177,13 @@ def test_unknown_distribution_falls_back_to_autodiff(data):
     assert closed_form_information(Unlisted()) is None
     model, foci = _fit("~ s(diagnosis)", "poisson", data)
     model.distribution = Unlisted()
-    np.testing.assert_allclose(
-        model.information_matrix(foci), _autodiff_information(model, foci), rtol=1e-9
-    )
+    np.testing.assert_allclose(model.information_matrix(), _autodiff_information(model), rtol=1e-9)
 
 
 def test_information_is_block_diagonal_for_a_cell_means_factor(data):
     """Off-block entries are exactly zero, not merely small."""
-    model, foci = _fit("~ s(diagnosis)", "poisson", data)
-    information = model.information_matrix(foci)
+    model, _ = _fit("~ s(diagnosis)", "poisson", data)
+    information = model.information_matrix()
     blocks = spatial_components(model.predictor.patterns.loadings, model.predictor.n_bases)
     assert len(blocks) == 2
     assert is_block_diagonal(information, blocks)
@@ -195,8 +195,8 @@ def test_information_is_block_diagonal_for_a_cell_means_factor(data):
 
 def test_a_moderator_couples_every_column_but_not_the_spatial_block(data):
     """Moderators end block diagonality but leave the spatial blocks separable."""
-    model, foci = _fit("~ s(diagnosis) + n", "poisson", data)
-    information = model.information_matrix(foci)
+    model, _ = _fit("~ s(diagnosis) + n", "poisson", data)
+    information = model.information_matrix()
     spatial = spatial_components(model.predictor.patterns.loadings, model.predictor.n_bases)
     assert len(spatial) == 2, "the spatial columns must still separate"
     assert is_block_diagonal(information[: model.n_spatial, : model.n_spatial], spatial)
@@ -274,7 +274,7 @@ def test_a_singular_design_explains_itself_on_the_blockwise_route(data):
     model.fit(foci, n_iter=60, tol=1e-8)
 
     with pytest.raises(np.linalg.LinAlgError, match="spline_spacing"):
-        model.covariance(foci)
+        model.covariance()
 
 
 def test_one_norm_condition_number_never_underestimates():
@@ -299,13 +299,13 @@ def test_bordered_route_uses_the_cheap_condition_number(data):
     Pinned by identity with ``bordered_inverse`` rather than by a private attribute, so the
     assertion survives a refactor of how the route is chosen.
     """
-    model, foci = _fit("~ s(diagnosis) + n", "poisson", data)
-    information = model.information_matrix(foci)
+    model, _ = _fit("~ s(diagnosis) + n", "poisson", data)
+    information = model.information_matrix()
     components = spatial_components(model.predictor.patterns.loadings, model.predictor.n_bases)
     assert model.n_global == 1 and len(components) > 1
     assert is_block_diagonal(information[: model.n_spatial, : model.n_spatial], components)
 
-    covariance = model.covariance(foci)
+    covariance = model.covariance()
     expected = bordered_inverse(information, components, model.n_spatial)
     np.testing.assert_array_equal(covariance, expected)
     # The bound that lets this route report the cheaper norm.
@@ -316,36 +316,29 @@ def test_bordered_route_uses_the_cheap_condition_number(data):
 
 def test_covariance_is_cached_across_hypotheses(data):
     """Every hypothesis against one fit asks for the same matrix; it should be built once."""
-    model, foci = _fit("~ s(diagnosis) + n", "poisson", data)
-    first = model.covariance(foci)
-    assert model.covariance(foci) is first, "a repeated call should hit the cache"
+    model, _ = _fit("~ s(diagnosis) + n", "poisson", data)
+    first = model.covariance()
+    assert model.covariance() is first, "a repeated call should hit the cache"
 
     # The options are part of the key, so a different estimator is not served from it.
-    assert model.covariance(foci, cov_type="sandwich", correction="hc0") is not first
-
-    # A different foci must not match, even though the previous one may have been freed.
-    other = foci * 2
-    assert model.covariance(other) is not first
-    np.testing.assert_allclose(
-        model.covariance(other), np.linalg.inv(model.information_matrix(other)), rtol=1e-6
-    )
+    assert model.covariance(cov_type="sandwich", correction="hc0") is not first
 
 
 def test_refitting_clears_the_covariance_cache(data):
     """The covariance describes the converged fit, so refitting must not serve the old one."""
     model, foci = _fit("~ s(diagnosis)", "poisson", data)
-    stale = model.covariance(foci)
+    stale = model.covariance()
     model.fit(foci, n_iter=5, tol=1e-8)
-    fresh = model.covariance(foci)
+    fresh = model.covariance()
     assert fresh is not stale
 
 
 def test_cached_covariance_matches_an_uncached_one(data):
     """The cache must not change any number a contrast produces."""
-    model, foci = _fit("~ s(diagnosis) + n", "poisson", data)
-    cached = model.covariance(foci)
+    model, _ = _fit("~ s(diagnosis) + n", "poisson", data)
+    cached = model.covariance()
     model._covariance_cache = None
-    np.testing.assert_array_equal(model.covariance(foci), cached)
+    np.testing.assert_array_equal(model.covariance(), cached)
 
 
 def test_cholesky_inverse_declines_a_non_positive_definite_matrix():
@@ -357,13 +350,13 @@ def test_cholesky_inverse_declines_a_non_positive_definite_matrix():
 @pytest.mark.parametrize("formula", FORMULAS)
 def test_covariance_matches_a_dense_inverse(formula, distribution, data):
     """Whichever rung the design reaches, the answer is the dense inverse."""
-    model, foci = _fit(formula, distribution, data)
-    information = model.information_matrix(foci)
+    model, _ = _fit(formula, distribution, data)
+    information = model.information_matrix()
     condition = np.linalg.cond(information)
     if condition > 1.0 / np.finfo(float).eps:
         pytest.skip("information matrix is numerically singular; no inverse to compare against")
     reference = np.linalg.inv(information)
-    produced = model.covariance(foci)
+    produced = model.covariance()
     tolerance = max(1e-10, 100 * condition * np.finfo(float).eps)
     assert np.abs(produced - reference).max() / np.abs(reference).max() < tolerance
 
@@ -390,9 +383,8 @@ def test_sparse_and_dense_foci_agree(distribution, data):
 
     model = CBMRModel(predictor, distribution=distribution)
     model.fit(dense, n_iter=20, tol=1e-8)
-    np.testing.assert_allclose(
-        float(model.log_likelihood(dense)), float(model.log_likelihood(sparse)), rtol=1e-12
-    )
-    np.testing.assert_allclose(
-        model.information_matrix(dense), model.information_matrix(sparse), rtol=1e-12
-    )
+    dense_likelihood = float(model.log_likelihood())
+    dense_information = model.information_matrix()
+    model._foci = sparse
+    np.testing.assert_allclose(dense_likelihood, float(model.log_likelihood()), rtol=1e-12)
+    np.testing.assert_allclose(dense_information, model.information_matrix(), rtol=1e-12)

--- a/nimare/tests/test_meta_cbmr_model.py
+++ b/nimare/tests/test_meta_cbmr_model.py
@@ -135,9 +135,61 @@ def test_fitted_coefficients_match_statsmodels(data, formula):
     model = CBMRModel(predictor, Poisson()).fit(foci, n_iter=2000, tol=1e-12)
     expected = _statsmodels_fit(predictor, foci)
 
+    assert model.foci is not foci
+    assert not model.foci.flags.writeable
+    np.testing.assert_array_equal(model.foci, foci)
     np.testing.assert_allclose(
         model.coefficients.detach().numpy(), expected.params, rtol=1e-4, atol=1e-5
     )
+
+
+def test_fitted_foci_are_isolated_from_later_input_mutation(data):
+    """Changing the caller's array after fit must not change fitted quantities."""
+    annotations, bases, _ = data
+    predictor = _build("~ s(diagnosis) + n", annotations, bases)
+    foci = _simulate(predictor, np.random.default_rng(33))
+    expected_foci = foci.copy()
+
+    model = CBMRModel(predictor, Poisson()).fit(foci, n_iter=500)
+    likelihood = float(model.log_likelihood())
+    covariance = model.covariance()
+
+    foci += 100.0
+
+    np.testing.assert_array_equal(model.foci, expected_foci)
+    np.testing.assert_allclose(float(model.log_likelihood()), likelihood, rtol=1e-12)
+    assert model.covariance() is covariance
+
+
+def test_failed_refit_preserves_the_previous_fitted_state(data, monkeypatch):
+    """A failed refit must not pair new foci with the previous coefficients."""
+    annotations, bases, _ = data
+    predictor = _build("~ s(diagnosis) + n", annotations, bases)
+    first_foci = _simulate(predictor, np.random.default_rng(35))
+    second_foci = _simulate(predictor, np.random.default_rng(36))
+
+    model = CBMRModel(predictor, Poisson()).fit(first_foci, n_iter=500)
+    previous_foci = model.foci
+    previous_coefficients = model.coefficients.detach().clone()
+    previous_iterations = model._iterations
+    previous_covariance = model.covariance()
+
+    def fail_after_mutation(optimizer, closure):
+        with torch.no_grad():
+            for group in optimizer.param_groups:
+                for parameter in group["params"]:
+                    parameter.add_(1.0)
+        raise RuntimeError("optimizer failed")
+
+    monkeypatch.setattr(torch.optim.LBFGS, "step", fail_after_mutation)
+    with pytest.raises(RuntimeError, match="optimizer failed"):
+        model.fit(second_foci, n_iter=1)
+
+    assert model.foci is previous_foci
+    assert model._iterations == previous_iterations
+    assert model.covariance() is previous_covariance
+    np.testing.assert_array_equal(model.foci, previous_foci)
+    np.testing.assert_allclose(model.coefficients.detach(), previous_coefficients)
 
 
 @pytest.mark.parametrize(
@@ -157,7 +209,7 @@ def test_standard_errors_match_statsmodels(data, formula):
     model = CBMRModel(predictor, Poisson()).fit(foci, n_iter=2000, tol=1e-12)
     expected = _statsmodels_fit(predictor, foci)
 
-    errors = np.sqrt(np.diag(model.covariance(foci)))
+    errors = np.sqrt(np.diag(model.covariance()))
     np.testing.assert_allclose(errors, expected.bse, rtol=1e-5, atol=1e-8)
 
 
@@ -172,7 +224,7 @@ def test_information_matrix_has_nonzero_cross_blocks(data):
     foci = _simulate(predictor, np.random.default_rng(41))
     model = CBMRModel(predictor, Poisson()).fit(foci, n_iter=500)
 
-    information = model.information_matrix(foci)
+    information = model.information_matrix()
     slices = predictor.design.parameter_slices(predictor.n_bases)
     cross = information[slices["s(diagnosis)"], slices["n"]]
 
@@ -187,7 +239,7 @@ def test_standard_errors_are_reported_per_term(data):
     foci = _simulate(predictor, np.random.default_rng(43))
     model = CBMRModel(predictor, Poisson()).fit(foci, n_iter=500)
 
-    errors = model.standard_errors(foci)
+    errors = model.standard_errors()
     assert set(errors) == {"s(diagnosis)", "n"}
     assert errors["s(diagnosis)"].shape == (2, N_BASES)
     assert errors["n"].shape == (1,)
@@ -217,7 +269,7 @@ def test_negative_binomial_fits_a_grouped_design(data):
     assert model.nuisance is not None
     assert model.nuisance.shape == (predictor.patterns.n_patterns,)
     assert torch.all(torch.isfinite(model.nuisance))
-    assert torch.isfinite(model.log_likelihood(foci))
+    assert torch.isfinite(model.log_likelihood())
 
     # Reported on the statistical scale and strictly positive, whatever the optimizer did to
     # the unconstrained parameter it actually moves.
@@ -266,7 +318,7 @@ def test_ill_conditioned_information_warns(data, caplog):
 
     with caplog.at_level("WARNING", logger="nimare.meta.cbmr.model"):
         try:
-            model.covariance(foci)
+            model.covariance()
         except np.linalg.LinAlgError:
             pass  # exactly singular is also an acceptable outcome
     assert any("condition number" in message for message in caplog.messages)
@@ -293,7 +345,7 @@ def test_additive_sum_to_zero_factors_are_fittable(data):
         model.coefficients.detach().numpy(), expected.params, rtol=1e-4, atol=1e-5
     )
     np.testing.assert_allclose(
-        np.sqrt(np.diag(model.covariance(foci))), expected.bse, rtol=1e-5, atol=1e-8
+        np.sqrt(np.diag(model.covariance())), expected.bse, rtol=1e-5, atol=1e-8
     )
 
 
@@ -330,4 +382,4 @@ def test_singular_information_says_which_knob_to_turn(data):
     model = CBMRModel(predictor, Poisson()).fit(foci, n_iter=100)
 
     with pytest.raises(np.linalg.LinAlgError, match="spline_spacing"):
-        model.covariance(foci)
+        model.covariance()


### PR DESCRIPTION
## Summary
- store the fitted foci matrix on CBMRModel when fit is called
- remove repeated foci arguments from model likelihood, information, covariance, standard-error, and contrast paths
- update CBMR tests for the stored-foci API and covariance cache behavior

## Tests
- python -m pytest nimare/tests/test_meta_cbmr_model.py -q
- python -m pytest nimare/tests/test_meta_cbmr_covariance.py -q
- python -m pytest nimare/tests/test_meta_cbmr_information.py -q
- python -m pytest nimare/tests/test_meta_cbmr_contrasts.py -q
- python -m pytest nimare/tests/test_meta_cbmr_exposure.py nimare/tests/test_meta_cbmr_formula.py -q
- git diff --check

Closes neurostuff/NiMARE#1118

## Summary by Sourcery

Make CBMRModel retain the foci used for fitting and use that state throughout fitted-model inference.

New Features:
- Store an immutable copy of the fitted foci on CBMRModel for reuse by downstream fitted-model operations.

Bug Fixes:
- Preserve the previous fitted state, coefficients, foci, and covariance cache when a refit fails.

Enhancements:
- Simplify likelihood, information, covariance, standard-error, and contrast APIs by deriving foci from the fitted model.
- Tie covariance caching to covariance options and invalidate it only after a successful refit.

Tests:
- Update CBMR model, information, covariance, contrast, exposure, and formula tests for the stored-foci API and refit/cache behavior.