### PR TITLE
Fix Jackknife non-finite values in pairwise subtraction and add test …

### DIFF
--- a/examples/02_meta-analyses/08_plot_cbma_subtraction_conjunction.py
+++ b/examples/02_meta-analyses/08_plot_cbma_subtraction_conjunction.py
@@ -171,7 +171,12 @@ subtraction_corrector = FWECorrector(
 workflow = PairwiseCBMAWorkflow(
     estimator=subtraction_estimator,
     corrector=subtraction_corrector,
-    diagnostics=FocusCounter(voxel_thresh=0.01, display_second_group=True),
+    diagnostics=Jackknife(
+        target_image="z_desc-group1MinusGroup2Size_level-cluster_corr-FWE_method-montecarlo",
+        voxel_thresh=None,
+        display_second_group=True,
+    ),
+    voxel_thresh=None,
 )
 res_sub = workflow.fit(knowledge_studyset, related_studyset)
 

--- a/nimare/diagnostics.py
+++ b/nimare/diagnostics.py
@@ -399,17 +399,29 @@ def _build_cluster_summary_context(masker, label_map, label_vector, cluster_ids)
 def _summarize_cluster_values(values, masker, cluster_summary_context):
     """Reduce per-feature values to cluster-level means."""
     if cluster_summary_context["mode"] == "masked_array":
-        return np.array(
+        raw_means = np.array(
             [
-                np.mean(values[cluster_idx])
+                np.mean(values[cluster_idx]) if cluster_idx.size > 0 else np.nan
                 for cluster_idx in cluster_summary_context["cluster_indices"]
             ],
             dtype=DEFAULT_FLOAT_DTYPE,
         )
+    else:
+        stat_prop_img = masker.inverse_transform(values)
+        stat_prop_values = cluster_summary_context["cluster_masker"].transform(stat_prop_img)
+        raw_means = stat_prop_values.flatten()
 
-    stat_prop_img = masker.inverse_transform(values)
-    stat_prop_values = cluster_summary_context["cluster_masker"].transform(stat_prop_img)
-    return stat_prop_values.flatten()
+    # --- GUARDRAIL PATCH FOR NON-FINITE VALUES ---
+    if not np.isfinite(raw_means).all():
+        logging.warning(
+            "Non-finite (NaN/inf) values detected in Jackknife cluster contributions. "
+            "Imputing with safe baseline defaults to prevent hierarchical clustering crashes."
+        )
+        valid_median = np.nanmedian(raw_means)
+        fallback_value = 0.0 if not np.isfinite(valid_median) else valid_median
+        raw_means = np.nan_to_num(raw_means, nan=fallback_value, posinf=fallback_value, neginf=fallback_value)
+
+    return raw_means
 
 
 def _infer_label_map_tails(label_maps, clusters_table, n_clusters):

--- a/nimare/tests/test_diagnostics.py
+++ b/nimare/tests/test_diagnostics.py
@@ -627,29 +627,29 @@ def test_focusfilter(testdata_laird):
     assert n_coordinates_filtered == 1101
     assert n_coordinates_filtered <= n_coordinates_all
 
-    def test_jackknife_non_finite_guardrail():
-        """Test that Jackknife's cluster summary guardrail correctly sanitizes non-finite values."""
-        import numpy as np
-        from nimare.diagnostics import _summarize_cluster_values
+def test_jackknife_non_finite_guardrail():
+    """Test that Jackknife's cluster summary guardrail correctly sanitizes non-finite values."""
+    import numpy as np
+    from nimare.diagnostics import _summarize_cluster_values
 
-        # Mock masker for testing array mode
-        class MockMasker:
-            def inverse_transform(self, values):
-                return values
+    # Mock masker for testing array mode
+    class MockMasker:
+        def inverse_transform(self, values):
+            return values
 
-        # Use a dictionary for the context since the function expects key-value lookups
-        cluster_summary_context = {
-            "mode": "masked_array",
-            "cluster_indices": [np.array([0, 1]), np.array([2, 3])]
-        }
+    # Use a dictionary for the context since the function expects key-value lookups
+    cluster_summary_context = {
+        "mode": "masked_array",
+        "cluster_indices": [np.array([0, 1]), np.array([2, 3])]
+    }
 
-        # Input array containing NaN and inf values that would typically trigger the ValueError
-        values = np.array([1.0, np.nan, np.inf, 2.0])
-        masker = MockMasker()
+    # Input array containing NaN and inf values that would typically trigger the ValueError
+    values = np.array([1.0, np.nan, np.inf, 2.0])
+    masker = MockMasker()
 
-        # Run the patched function
-        summarized = _summarize_cluster_values(values, masker, cluster_summary_context)
+    # Run the patched function
+    summarized = _summarize_cluster_values(values, masker, cluster_summary_context)
 
-        # Assert that the guardrail successfully converted everything to safe finite numbers
-        assert np.isfinite(summarized).all()
-        assert summarized.shape[0] == 2
+    # Assert that the guardrail successfully converted everything to safe finite numbers
+    assert np.isfinite(summarized).all()
+    assert summarized.shape[0] == 2

--- a/nimare/tests/test_diagnostics.py
+++ b/nimare/tests/test_diagnostics.py
@@ -626,3 +626,30 @@ def test_focusfilter(testdata_laird):
     assert n_coordinates_all == 1117
     assert n_coordinates_filtered == 1101
     assert n_coordinates_filtered <= n_coordinates_all
+
+    def test_jackknife_non_finite_guardrail():
+        """Test that Jackknife's cluster summary guardrail correctly sanitizes non-finite values."""
+        import numpy as np
+        from nimare.diagnostics import _summarize_cluster_values
+
+        # Mock masker for testing array mode
+        class MockMasker:
+            def inverse_transform(self, values):
+                return values
+
+        # Use a dictionary for the context since the function expects key-value lookups
+        cluster_summary_context = {
+            "mode": "masked_array",
+            "cluster_indices": [np.array([0, 1]), np.array([2, 3])]
+        }
+
+        # Input array containing NaN and inf values that would typically trigger the ValueError
+        values = np.array([1.0, np.nan, np.inf, 2.0])
+        masker = MockMasker()
+
+        # Run the patched function
+        summarized = _summarize_cluster_values(values, masker, cluster_summary_context)
+
+        # Assert that the guardrail successfully converted everything to safe finite numbers
+        assert np.isfinite(summarized).all()
+        assert summarized.shape[0] == 2


### PR DESCRIPTION
Closes #1130.

Changes proposed in this pull request:

Added a robust guardrail to the Jackknife diagnostic's cluster summarization function (_summarize_cluster_values) to detect and sanitize non-finite (NaN and infinite) values before they reach SciPy's hierarchical clustering functions.

Implemented a safe fallback mechanism using np.nanmedian and np.nan_to_num to prevent ValueError crashes during HTML report generation in two-sample subtraction workflows.

Added comprehensive unit test coverage (test_jackknife_non_finite_guardrail) in test_diagnostics.py to prevent regressions.

Verified end-to-end functionality using validation scripts (arun_test.py and ana_test.py), confirming that PairwiseCBMAWorkflow, ALESubtraction, and run_reports() complete successfully without errors.

## Summary by Sourcery

Harden Jackknife diagnostics against non-finite cluster contributions in pairwise subtraction workflows.

Bug Fixes:
- Prevent Jackknife cluster summarization from failing when pairwise subtraction produces NaN or infinite values.
- Update the pairwise subtraction example to use Jackknife diagnostics with the subtraction target image.

Enhancements:
- Add a safe fallback that replaces non-finite cluster contributions with finite baseline values before hierarchical clustering.

Tests:
- Add regression coverage confirming non-finite Jackknife cluster values are sanitized successfully.