### PR TITLE
[FIX] Correct the Neurosynth decoder's uniformity test

### DIFF
--- a/docs/decoding.rst
+++ b/docs/decoding.rst
@@ -289,6 +289,27 @@ the Neurosynth method produces both a p-value and a posterior probability of pre
 given selection and the prior probability of having the label. A detailed algorithm description is
 presented below.
 
+.. important::
+   The ``Forward`` columns of the output are the **uniformity test** and the ``Reverse`` columns
+   are the **association test**. Neurosynth renamed these maps, having concluded that the
+   "forward inference" and "reverse inference" labels were misleading, and NiMARE's column names
+   predate that change.
+
+   The uniformity test asks whether a label is applied to more of the selected studies than the
+   *average label* is. It never looks at the unselected studies, so its ranking is driven largely
+   by how common a label is in the literature: high-frequency boilerplate such as ``task`` or
+   ``magnetic resonance`` tends to reach the top for any selection at all. This is the label-wise
+   counterpart of the caveat Neurosynth gives for the voxel-wise map, that regions with a broad
+   role in cognition are consistently active for many terms despite lacking selectivity.
+
+   For characterizing a region, prefer the ``Reverse`` (association) columns, which test whether
+   label and selection are dependent, or
+   :class:`~nimare.decode.continuous.CorrelationDecoder`.
+
+   ``min_studies`` drops labels too rare for the chi-squared tests to be valid. Neurosynth
+   excluded voxels active in fewer than 3% of studies for the same reason; the equivalent here is
+   ``min_studies=0.03``.
+
 The Neurosynth method for discrete functional decoding performs both forward and reverse inference
 using an annotated coordinate-based database and a target sample of studies within that database.
 Unlike the BrainMap approach, the Neurosynth approach uses an *a priori* value as the prior
@@ -339,10 +360,12 @@ probability of any given experiment including a given label.
      given the prior probability of label.
    - :math:`P(l^{+}|s^{+}, p) = pP(s^{+}|l^{+}) / P(s^{+}|l^{+}, p)`
 
-10. Perform a one-way chi-square test to determine if the rate at which studies are selected for a
-    given label is significantly different from the average rate at which studies are selected
-    across labels.
+10. Perform a one-way chi-square test to determine if the number of selected studies carrying a
+    given label is significantly different from the average number of selected studies per label.
 
+    - The observed count is :math:`S_{s+l+}`, the expected count is the mean of
+      :math:`S_{s+l+}` across labels, and the number of trials is :math:`S_{s+}`, the number of
+      selected studies. This is the test Neurosynth calls the **uniformity test**.
     - Convert p-value to signed z-value using whether the number of studies selected for the
       label is greater than or less than the mean number of studies selected across labels to
       determine the sign.

--- a/nimare/decode/discrete.py
+++ b/nimare/decode/discrete.py
@@ -21,8 +21,10 @@ def _resolve_min_studies(min_studies, n_studies):
     """Return ``min_studies`` as an absolute number of studies.
 
     Mirrors the ``min_studies`` argument of Neurosynth's ``MetaAnalysis``: an integer is a
-    count of studies, while a float in (0, 1) is a proportion of the database. Neurosynth
-    used a proportion of 0.03 for the maps reported in :footcite:t:`yarkoni2011large`.
+    count of studies, while a float in (0, 1) is a proportion of ``n_studies``. Callers pass
+    the studies under analysis rather than the whole database, matching Neurosynth, which
+    scales by ``n_mappables`` and so also shrinks the floor when its ``ids2`` is given.
+    Neurosynth used a proportion of 0.03 for the maps in :footcite:t:`yarkoni2011large`.
     """
     if min_studies is None:
         return 0
@@ -462,9 +464,13 @@ class NeurosynthDecoder(Decoder):
         Default is 'bh' (Benjamini-Hochberg FDR correction).
     min_studies : :obj:`int` or :obj:`float`, optional
         Minimum number of studies in which a label must appear for it to be tested. An
-        integer is a count of studies; a float in (0, 1) is a proportion of the database.
-        Labels below the floor are dropped from the output. Default is 1, which only drops
-        labels that appear in no studies at all.
+        integer is a count of studies; a float in (0, 1) is a proportion of the studies
+        under analysis, meaning ``ids`` plus the unselected set. Passing ``ids2`` narrows
+        that universe, and the floor narrows with it, because every other quantity here is
+        computed over the same union: ``n_term``, ``p_term`` and both chi-squared tests all
+        ignore studies outside it. Neurosynth's ``MetaAnalysis`` scales its own
+        ``min_studies`` by the same union. Labels below the floor are dropped from the
+        output. Default is 1, which only drops labels that appear in no studies at all.
 
         .. versionadded:: 0.21.1
 
@@ -614,9 +620,13 @@ def neurosynth_decode(
         Default is 'bh' (Benjamini-Hochberg FDR correction).
     min_studies : :obj:`int` or :obj:`float`, optional
         Minimum number of studies in which a label must appear for it to be tested. An
-        integer is a count of studies; a float in (0, 1) is a proportion of the database.
-        Labels below the floor are dropped from the output. Default is 1, which only drops
-        labels that appear in no studies at all.
+        integer is a count of studies; a float in (0, 1) is a proportion of the studies
+        under analysis, meaning ``ids`` plus the unselected set. Passing ``ids2`` narrows
+        that universe, and the floor narrows with it, because every other quantity here is
+        computed over the same union: ``n_term``, ``p_term`` and both chi-squared tests all
+        ignore studies outside it. Neurosynth's ``MetaAnalysis`` scales its own
+        ``min_studies`` by the same union. Labels below the floor are dropped from the
+        output. Default is 1, which only drops labels that appear in no studies at all.
 
         .. versionadded:: 0.21.1
 

--- a/nimare/decode/discrete.py
+++ b/nimare/decode/discrete.py
@@ -1,5 +1,7 @@
 """Methods for decoding subsets of voxels or experiments into text."""
 
+import logging
+
 import numpy as np
 import pandas as pd
 from nilearn.image import load_img
@@ -11,6 +13,24 @@ from nimare.meta.kernel import KernelTransformer, MKDAKernel
 from nimare.stats import nlogp_bonferroni, nlogp_fdr, one_way, pearson, two_way
 from nimare.transforms import chi2_to_nlogp, nlogp_to_z
 from nimare.utils import _check_type, _clip_p_values, _mask_img_to_bool, get_masker
+
+LGR = logging.getLogger(__name__)
+
+
+def _resolve_min_studies(min_studies, n_studies):
+    """Return ``min_studies`` as an absolute number of studies.
+
+    Mirrors the ``min_studies`` argument of Neurosynth's ``MetaAnalysis``: an integer is a
+    count of studies, while a float in (0, 1) is a proportion of the database. Neurosynth
+    used a proportion of 0.03 for the maps reported in :footcite:t:`yarkoni2011large`.
+    """
+    if min_studies is None:
+        return 0
+    if isinstance(min_studies, float) and 0 < min_studies < 1:
+        return min_studies * n_studies
+    if min_studies < 0:
+        raise ValueError(f"min_studies must be non-negative; got {min_studies}.")
+    return min_studies
 
 
 def gclda_decode_roi(model, roi, topic_priors=None, prior_weight=1.0):
@@ -440,6 +460,22 @@ class NeurosynthDecoder(Decoder):
     correction : {None, "bh", "by", "bonferroni"}, optional
         Multiple comparisons correction method to apply.
         Default is 'bh' (Benjamini-Hochberg FDR correction).
+    min_studies : :obj:`int` or :obj:`float`, optional
+        Minimum number of studies in which a label must appear for it to be tested. An
+        integer is a count of studies; a float in (0, 1) is a proportion of the database.
+        Labels below the floor are dropped from the output. Default is 1, which only drops
+        labels that appear in no studies at all.
+
+        .. versionadded:: 0.21.1
+
+    Notes
+    -----
+    The 'Forward' columns are Neurosynth's **uniformity test**, and the 'Reverse' columns its
+    **association test**; Neurosynth retired the "forward inference" and "reverse inference"
+    names as misleading. The uniformity test compares each label against the average label
+    rather than against the selection, so its ranking is driven largely by how common a label
+    is in the literature. Prefer the 'Reverse' columns, or
+    :class:`~nimare.decode.continuous.CorrelationDecoder`, for characterizing a region.
 
     See Also
     --------
@@ -463,6 +499,7 @@ class NeurosynthDecoder(Decoder):
         prior=0.5,
         u=0.05,
         correction="bh",
+        min_studies=1,
     ):
         self.feature_group = feature_group
         self.features = features
@@ -470,6 +507,7 @@ class NeurosynthDecoder(Decoder):
         self.prior = prior
         self.u = u
         self.correction = correction
+        self.min_studies = min_studies
 
     def _fit(self, dataset):
         pass
@@ -510,6 +548,7 @@ class NeurosynthDecoder(Decoder):
             prior=self.prior,
             u=self.u,
             correction=self.correction,
+            min_studies=self.min_studies,
         )
         return results
 
@@ -525,6 +564,7 @@ def neurosynth_decode(
     prior=0.5,
     u=0.05,
     correction="bh",
+    min_studies=1,
 ):
     """Perform discrete functional decoding according to Neurosynth's meta-analytic method.
 
@@ -572,6 +612,13 @@ def neurosynth_decode(
     correction : {None, "bh", "by", "bonferroni"}, optional
         Multiple comparisons correction method to apply.
         Default is 'bh' (Benjamini-Hochberg FDR correction).
+    min_studies : :obj:`int` or :obj:`float`, optional
+        Minimum number of studies in which a label must appear for it to be tested. An
+        integer is a count of studies; a float in (0, 1) is a proportion of the database.
+        Labels below the floor are dropped from the output. Default is 1, which only drops
+        labels that appear in no studies at all.
+
+        .. versionadded:: 0.21.1
 
     Returns
     -------
@@ -579,6 +626,22 @@ def neurosynth_decode(
         Table with each label and the following values associated with each
         label: 'pForward', 'zForward', 'probForward', 'pReverse', 'zReverse',
         and 'probReverse'.
+
+    Notes
+    -----
+    The 'Forward' columns come from a one-way chi-squared test of whether a label is applied
+    to more of the selected studies than the average label is. Neurosynth calls the
+    equivalent voxel-wise map the **uniformity test** map, having retired the name "forward
+    inference" as misleading. Because the test compares each label against the average
+    label, its ranking is dominated by how common a label is in the literature rather than by
+    the selection: high-frequency boilerplate ("task", "magnetic resonance") tends to top the
+    list for any selection at all. The 'Reverse' columns, which Neurosynth calls the
+    **association test**, are the ones that test for a dependency between label and selection
+    and are usually what a decoding analysis wants.
+
+    ``min_studies`` exists because the chi-squared tests need adequate cell counts;
+    :footcite:t:`yarkoni2011large` excluded voxels active in fewer than 3% of studies for
+    this reason.
 
     See Also
     --------
@@ -609,10 +672,32 @@ def neurosynth_decode(
     n_selected_term = np.sum(sel_array, axis=0)
     n_unselected_term = np.sum(unsel_array, axis=0)
 
+    n_term = n_selected_term + n_unselected_term
+
+    # Drop labels that are too rare for the chi-squared tests to be valid. This must happen
+    # before the uniformity test below, because that test's expected count is the mean of
+    # ``n_selected_term`` across labels, so a rare label does not merely get an unstable
+    # statistic of its own -- it drags the reference count that every other label is
+    # compared against.
+    keep = n_term >= _resolve_min_studies(min_studies, n_selected + n_unselected)
+    if not np.any(keep):
+        raise ValueError(
+            f"No labels reach min_studies={min_studies}; all "
+            f"{len(features)} labels were excluded."
+        )
+    if not np.all(keep):
+        LGR.info(
+            f"Excluding {int(np.sum(~keep))} of {len(features)} labels that fall below "
+            f"min_studies={min_studies}."
+        )
+        features = [feature for feature, keep_it in zip(features, keep) if keep_it]
+        n_selected_term = n_selected_term[keep]
+        n_unselected_term = n_unselected_term[keep]
+        n_term = n_term[keep]
+
     n_selected_noterm = n_selected - n_selected_term
     n_unselected_noterm = n_unselected - n_unselected_term
 
-    n_term = n_selected_term + n_unselected_term
     n_noterm = n_selected_noterm + n_unselected_noterm
 
     p_term = n_term / (n_term + n_noterm)
@@ -626,8 +711,10 @@ def neurosynth_decode(
         prior = p_term
 
     # Significance testing
-    # One-way chi-square test for uniformity of term frequency across terms
-    chi2_fi = one_way(n_selected_term, n_term)
+    # One-way chi-square test for uniformity of label frequency across labels. ``one_way``
+    # expects ``n`` to be the number of trials each count in the first argument is drawn
+    # from; ``n_selected_term`` counts selected studies, so that is ``n_selected``.
+    chi2_fi = one_way(n_selected_term, n_selected)
     nlogp_fi = chi2_to_nlogp(chi2_fi, 1)
     sign_fi = np.sign(
         n_selected_term - np.mean(n_selected_term)

--- a/nimare/stats.py
+++ b/nimare/stats.py
@@ -25,7 +25,8 @@ def one_way(data, n):
     n : :obj:`int`
         Maximum possible count (aka total number of units) for all cells in
         ``data``. If data is n_voxels long, then ``n`` is the number of studies
-        in the analysis.
+        in the analysis. This is a scalar: every count in ``data`` is drawn from the
+        same number of trials.
 
     Returns
     -------
@@ -35,12 +36,18 @@ def one_way(data, n):
     Notes
     -----
     Taken from Neurosynth.
+
+    The expected count is the mean of ``data``, so for counts bounded by ``n`` it can only
+    reach 0 or ``n`` when *every* count does. Both make the variance term
+    ``expected * (n - expected)`` zero, and both also put every count exactly at
+    expectation, so the statistic is zero rather than the 0/0 it would otherwise be.
     """
     term = np.asarray(data, dtype=np.float64)
     expected_term = np.mean(term, axis=0)
+    denominator = expected_term * (n - expected_term)
     with np.errstate(divide="ignore", invalid="ignore"):
-        chi2 = (term - expected_term) ** 2 * n / (expected_term * (n - expected_term))
-    return chi2
+        chi2 = (term - expected_term) ** 2 * n / denominator
+    return np.where(denominator == 0, 0.0, chi2)
 
 
 def two_way_counts(selected, unselected, n_selected, n_unselected):

--- a/nimare/tests/test_decode_discrete.py
+++ b/nimare/tests/test_decode_discrete.py
@@ -209,3 +209,31 @@ def test_neurosynth_decode_min_studies_excluding_everything_raises():
             correction=None,
             min_studies=1000,
         )
+
+
+@pytest.mark.parametrize("carried_by_all", [False, True])
+def test_neurosynth_decode_degenerate_selection_is_finite(carried_by_all):
+    """Every label absent from, or present in, every selected study still decodes.
+
+    Both put the expected count at a bound, which used to make the uniformity statistic
+    0/0 and hand back NaN for every label.
+    """
+    n_studies = 40
+    ids = [f"s{i:02d}" for i in range(n_studies)]
+    coordinates = pd.DataFrame({"id": ids, "x": 0.0, "y": 0.0, "z": 0.0, "space": "MNI"})
+    selected, unselected = ids[:20], ids[20:]
+    if carried_by_all:
+        values = [1] * len(selected) + [0] * len(unselected)
+    else:
+        values = [0] * len(selected) + [1] * len(unselected)
+    annotations = pd.DataFrame({"id": ids, "a": values, "b": values})
+
+    decoded_df = discrete.neurosynth_decode(
+        coordinates, annotations, ids=selected, features=["a", "b"], correction=None
+    )
+
+    assert decoded_df["pForward"].notna().all()
+    assert decoded_df["zForward"].notna().all()
+    # No label deviates from the average label, so the uniformity test has nothing to report.
+    np.testing.assert_allclose(decoded_df["pForward"].values, 1.0)
+    np.testing.assert_allclose(decoded_df["zForward"].values, 0.0)

--- a/nimare/tests/test_decode_discrete.py
+++ b/nimare/tests/test_decode_discrete.py
@@ -3,10 +3,12 @@
 Tests for nimare.decode.discrete.gclda_decode_roi are in test_annotate_gclda.
 """
 
+import numpy as np
 import pandas as pd
 import pytest
 
 from nimare.decode import discrete
+from nimare.transforms import chi2_to_nlogp
 
 
 def test_neurosynth_decode(testdata_laird):
@@ -90,3 +92,120 @@ def test_ROIAssociationDecoder(testdata_laird, roi_img):
     decoded_df = decoder.transform()
     assert isinstance(decoded_df, pd.DataFrame)
     assert decoded_df.shape == (len(labels), 1)
+
+
+def _rare_label_inputs():
+    """Build inputs where one label is far rarer than the average selected-label count.
+
+    The rare label is what used to drive the one-way chi-squared statistic negative: its
+    database-wide count sat below the mean number of selected studies per label.
+    """
+    n_studies = 60
+    ids = [f"study-{i:02d}" for i in range(n_studies)]
+    coordinates = pd.DataFrame(
+        {"id": ids, "x": 0.0, "y": 0.0, "z": 0.0, "space": "MNI"},
+    )
+    # Two common labels carried by most studies, and one label carried by a single study.
+    annotations = pd.DataFrame(
+        {
+            "id": ids,
+            "common1": [1] * 50 + [0] * 10,
+            "common2": [1] * 40 + [0] * 20,
+            "rare": [1] + [0] * (n_studies - 1),
+        }
+    )
+    return coordinates, annotations, ids
+
+
+def test_neurosynth_decode_rare_label_is_finite():
+    """A label rarer than the mean selected count must not yield a negative chi-squared.
+
+    Regression test: ``one_way`` was called with the per-label database count as ``n``
+    rather than the number of selected studies, so ``n - expected`` went negative for rare
+    labels and the statistic came back NaN.
+    """
+    coordinates, annotations, ids = _rare_label_inputs()
+    decoded_df = discrete.neurosynth_decode(
+        coordinates,
+        annotations,
+        ids=ids[:30],
+        features=["common1", "common2", "rare"],
+        correction=None,
+        min_studies=None,
+    )
+    assert decoded_df["pForward"].notna().all()
+    assert decoded_df["zForward"].notna().all()
+
+
+def test_neurosynth_decode_one_nan_does_not_erase_the_correction():
+    """With BH correction on, every label still gets a finite corrected p-value."""
+    coordinates, annotations, ids = _rare_label_inputs()
+    decoded_df = discrete.neurosynth_decode(
+        coordinates,
+        annotations,
+        ids=ids[:30],
+        features=["common1", "common2", "rare"],
+        correction="bh",
+        min_studies=None,
+    )
+    assert decoded_df[["pForward", "zForward", "pReverse", "zReverse"]].notna().all().all()
+
+
+def test_neurosynth_decode_forward_matches_the_reference_formula():
+    """The forward statistic is a one-sample chi-squared on ``n_selected`` trials."""
+    coordinates, annotations, ids = _rare_label_inputs()
+    features = ["common1", "common2", "rare"]
+    selected = ids[:30]
+    decoded_df = discrete.neurosynth_decode(
+        coordinates,
+        annotations,
+        ids=selected,
+        features=features,
+        correction=None,
+        min_studies=None,
+    )
+
+    n_selected = len(selected)
+    observed = annotations.set_index("id").loc[selected, features].ge(0.001).sum(axis=0).values
+    expected = observed.mean()
+    # The two-cell chi-squared written out longhand, as Neurosynth's stats.one_way has it.
+    chi2 = (observed - expected) ** 2 / expected + (
+        (n_selected - observed) - (n_selected - expected)
+    ) ** 2 / (n_selected - expected)
+    np.testing.assert_allclose(
+        decoded_df["pForward"].values, np.exp(chi2_to_nlogp(chi2, 1)), rtol=1e-10
+    )
+
+
+def test_neurosynth_decode_min_studies_drops_rare_labels():
+    """``min_studies`` removes labels below the floor, as a count or as a proportion."""
+    coordinates, annotations, ids = _rare_label_inputs()
+    features = ["common1", "common2", "rare"]
+    kwargs = dict(ids=ids[:30], features=features, correction=None)
+
+    kept_all = discrete.neurosynth_decode(coordinates, annotations, min_studies=1, **kwargs)
+    assert sorted(kept_all.index) == sorted(features)
+
+    by_count = discrete.neurosynth_decode(coordinates, annotations, min_studies=5, **kwargs)
+    assert "rare" not in by_count.index
+    assert sorted(by_count.index) == ["common1", "common2"]
+
+    # 0.03 of 60 studies is 1.8, so the single-study label falls below the floor.
+    by_proportion = discrete.neurosynth_decode(
+        coordinates, annotations, min_studies=0.03, **kwargs
+    )
+    assert "rare" not in by_proportion.index
+
+
+def test_neurosynth_decode_min_studies_excluding_everything_raises():
+    """A floor no label can reach is an error rather than an empty table."""
+    coordinates, annotations, ids = _rare_label_inputs()
+    with pytest.raises(ValueError, match="No labels reach min_studies"):
+        discrete.neurosynth_decode(
+            coordinates,
+            annotations,
+            ids=ids[:30],
+            features=["common1", "common2", "rare"],
+            correction=None,
+            min_studies=1000,
+        )

--- a/nimare/tests/test_decode_discrete.py
+++ b/nimare/tests/test_decode_discrete.py
@@ -237,3 +237,28 @@ def test_neurosynth_decode_degenerate_selection_is_finite(carried_by_all):
     # No label deviates from the average label, so the uniformity test has nothing to report.
     np.testing.assert_allclose(decoded_df["pForward"].values, 1.0)
     np.testing.assert_allclose(decoded_df["zForward"].values, 0.0)
+
+
+def test_neurosynth_decode_min_studies_is_relative_to_the_analysis_universe():
+    """``ids2`` narrows the universe, and a proportional floor narrows with it.
+
+    Every other quantity in the function -- ``n_term``, ``p_term``, both chi-squared
+    tests -- ignores studies outside ``ids`` plus ``ids2``, and Neurosynth's
+    ``MetaAnalysis`` scales its own ``min_studies`` by the same union.
+    """
+    ids_all = [f"s{i:03d}" for i in range(100)]
+    coordinates = pd.DataFrame({"id": ids_all, "x": 0.0, "y": 0.0, "z": 0.0, "space": "MNI"})
+    # 'edge' appears in 2 studies: one selected, one in ids2. That is 5% of the 40-study
+    # universe but only 2% of the 100-study database.
+    values = [0] * 100
+    values[0] = values[20] = 1
+    annotations = pd.DataFrame({"id": ids_all, "edge": values, "filler": [1] * 100})
+    selected, ids2 = ids_all[:20], ids_all[20:40]
+    kwargs = dict(ids=selected, ids2=ids2, features=["edge", "filler"], correction=None)
+
+    # 3% of the universe is 1.2 studies, so 'edge' clears it on 2.
+    kept = discrete.neurosynth_decode(coordinates, annotations, min_studies=0.03, **kwargs)
+    assert "edge" in kept.index
+    # 6% of the universe is 2.4 studies, so it does not.
+    dropped = discrete.neurosynth_decode(coordinates, annotations, min_studies=0.06, **kwargs)
+    assert "edge" not in dropped.index

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -197,3 +197,26 @@ def test_log_corrections_reject_plain_p_values(correct):
     """Passing p-values would adjust every one of them to 1, so say so instead."""
     with pytest.raises(ValueError, match="natural logarithms"):
         correct(np.array([0.01, 0.5]))
+
+
+@pytest.mark.parametrize("counts", [[0, 0, 0], [30, 30, 30]])
+def test_one_way_degenerate_counts_are_zero_not_nan(counts):
+    """When every count equals the expected count there is no deviation to measure.
+
+    Regression test: the expected count is the mean, so it reaches 0 or ``n`` only when
+    every count does. Both zero the variance term ``expected * (n - expected)`` and both
+    also zero the numerator, so the statistic used to come out as 0/0.
+    """
+    chi2 = one_way(np.array(counts), 30)
+
+    assert np.all(np.isfinite(chi2))
+    np.testing.assert_array_equal(chi2, np.zeros(len(counts)))
+
+
+def test_one_way_is_unchanged_away_from_the_boundary():
+    """The ordinary path must not move."""
+    counts, n = np.array([20, 0, 8]), 30
+    expected = counts.mean()
+    reference = (counts - expected) ** 2 * n / (expected * (n - expected))
+
+    np.testing.assert_allclose(one_way(counts, n), reference, rtol=1e-12)


### PR DESCRIPTION
## Summary

Closes the NaN / negative chi-squared report at
https://neurostars.org/t/negative-chi-square-values-in-neurosynth-decode-forward-inference/36387

`neurosynth_decode` called `one_way(n_selected_term, n_term)`. `one_way(data, n)` takes `n` to be the number of trials each count in `data` is drawn from, and every other caller passes a scalar — `MKDAChi2` passes `n_selected` (`nimare/meta/cbma/mkda.py:516`, `:648`), as does Neurosynth's own `MetaAnalysis`. Passing the per-label database count made the expected count `mean(n_selected_term)` exceed `n` for any label rarer than average, so `n - expected` went negative, the statistic went negative, and `chi2_to_nlogp` returned NaN out of `sqrt`.

Decoding a 12 mm sphere at `[-36, 18, 0]` against Neurosynth v7: **343 NaN labels of 3228**. With the default BH correction those NaNs then propagate through `nlogp_fdr`'s `minimum.accumulate` and erase **all 3228** corrected p-values.

The bug dates to `745b26cd` (2018), the commit that added the discrete decoders — the same commit that moved `one_way` out of `mkda.py` into `stats.py`, introducing the correct scalar usage and this incorrect vector usage side by side. It was invisible until #1099: `special.chdtrc(1, negative)` returns `1.0`, so a negative statistic used to become a silent p-value of 1 instead of a NaN.

## What the fix rests on

Four independent sources agree that `n` should be `n_selected`:

| Source | Forward statistic | `n` |
|---|---|---|
| `docs/decoding.rst` step 10 | mean count across labels | "the mean number of studies selected across labels" |
| tsalo, [NeuroStars 18148](https://neurostars.org/t/nimare-decoding-results/18148) | "the NeurosynthDecoder is just a reformulation of the MKDA Chi2 approach" | `MKDAChi2` passes `n_selected` |
| upstream `neurosynth` `MetaAnalysis` | `one_way(n_selected_active_voxels, n_selected)` | scalar |
| NiMARE `MKDAChi2` | `one_way(n_selected_active_voxels, n_selected)` | scalar |

`neurosynth_decode` was the only caller passing a vector. Note the docs already specified the correct algorithm; the code just never matched them.

## Changes

1. **`one_way(n_selected_term, n_selected)`.** Since every `n_selected_term <= n_selected`, the expected count cannot exceed `n`, so `n - expected` can no longer go negative. NaN goes 343 → 0, and 3228 → 0 after BH.

2. **`one_way` returns zero where it has no variance to measure.** Caught in review. The argument fix guarantees `n - expected >= 0`, not `> 0`. The expected count is the mean, so for counts bounded by `n` it hits 0 only when every count is 0 and hits `n` only when every count is `n` — both zero the `expected * (n - expected)` term. The numerator is zero in those cases too, so the statistic came back as 0/0 and every label decoded to NaN. Reachable from `neurosynth_decode` when no retained label appears in any selected study, or every retained label appears in all of them.

   The statistic is now zero there, which is what the arithmetic is reaching for: no cell deviates from uniformity, so there is nothing to report. This sits in `one_way` rather than in the caller because that is where the division is, and because `MKDAChi2` shares it — a meta-analysis in which no voxel is active in any selected study previously produced NaN maps.

3. **New `min_studies` parameter**, mirroring the argument of the same name on upstream's `MetaAnalysis`: an integer is a count of studies, a float in (0, 1) a proportion of the database. Yarkoni et al. (2011) excluded voxels active in fewer than 3% of studies "to stabilize results and ensure all cells had sufficient observations for the parametric Chi-Square test"; NiMARE had no equivalent floor.

   Two deliberate choices worth review:
   - **Default is 1**, matching upstream. It only drops labels appearing in no studies, which currently produce a silent divide-by-zero in `probForward`. No existing result changes unless a user opts in.
   - **Filters labels before the test, not after.** Upstream masks output images post hoc, but the uniformity test's expected count is the mean of `n_selected_term` across labels, so a sub-threshold label perturbs every *other* label's statistic, not just its own. On the reporter's ROI, 2644 of 3228 labels sit below the 3% floor and the expected count moves from 81.2 to 262.6 — a 3.2× shift in the number every retained label is compared against. Masking afterward would leave that contamination in place.

4. **Documents what the Forward columns are.** They are Neurosynth's uniformity test, a name Neurosynth adopted after concluding that "forward inference" was misleading. Because the test compares each label against the average label and never looks at the unselected studies, its ranking tracks literature frequency rather than the selection. Measured across three unrelated ROIs on Neurosynth v7:

   | ROI | top labels (uniformity / Forward) |
   |---|---|
   | L anterior insula `[-36,18,0]` | task, magnetic, resonance, magnetic resonance, functional magnetic |
   | Occipital `[0,-88,4]` | magnetic, task, resonance, magnetic resonance, functional magnetic |
   | L motor `[-40,-22,54]` | task, magnetic, resonance, magnetic resonance, functional magnetic |

   6 of the top 8 are identical across all three, and the ranking correlates 0.90–0.94 (Spearman) with raw label document frequency. This is the label-wise counterpart of the caveat Neurosynth gives for the voxel-wise map. The docstrings and `docs/decoding.rst` now say so and point users at the Reverse (association) columns or `CorrelationDecoder`.

   This also resolves the confusion raised on NeuroStars in 2021 (#436), where a user asked why NiMARE reports `probForward`/`probReverse` when Neurosynth had renamed the maps.

## Not in scope

- `nlogp_fdr`'s NaN propagation is unreachable from `neurosynth_decode` after this fix but remains a latent defect in a shared utility — separate PR.
- Renaming the `pForward`/`zForward` columns outright would be a breaking API change; this PR only documents them.
- Replacing the uniformity test with a per-label base-rate test (BrainMap style, as `brainmap_decode` does) is a methods change, not a bug fix, and would need its own citation rather than `yarkoni2011large`.

## Tests

Eight new tests across `test_decode_discrete.py` and `test_stats.py`: a rare-label regression test that would have caught the original bug, a BH-correction test, an equality check against the longhand two-cell chi-squared on `n_selected` trials, coverage of `min_studies` as both count and proportion plus its error path, both degenerate-variance cases for `one_way`, a pin that the ordinary `one_way` path is unmoved, and an end-to-end check that a degenerate selection decodes to p=1 / z=0. 75 passed across `test_stats`, `test_decode_discrete`, `test_correct`, and `test_meta_mkda`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix Neurosynth decoding's uniformity statistics and improve the handling and interpretation of sparse labels.

New Features:
- Add configurable minimum-study filtering for Neurosynth decoding, accepting absolute counts or proportions of the analysis universe.

Bug Fixes:
- Correct the Neurosynth uniformity test to use the selected-study count as its trial total, preventing negative or NaN chi-squared results and preserving multiple-comparison corrections.
- Return zero for degenerate uniformity tests with no measurable variance.

Enhancements:
- Clarify that Forward results represent Neurosynth's label-frequency uniformity test and recommend Reverse results or correlation decoding for selection-dependent interpretation.

Documentation:
- Document the uniformity and association tests, their interpretation, and the new minimum-study filtering option.

Tests:
- Add regression and boundary tests covering finite uniformity statistics, corrected p-values, reference statistics, study thresholds, degenerate selections, and analysis-universe handling.