### PR TITLE
[FIX] NaN-safe FDR correction, and a one-tailed z for BrainMap forward inference

### DIFF
--- a/nimare/decode/discrete.py
+++ b/nimare/decode/discrete.py
@@ -270,6 +270,12 @@ def brainmap_decode(
         label: 'pForward', 'zForward', 'likelihoodForward', 'pReverse',
         'zReverse', and 'probReverse'.
 
+    Notes
+    -----
+    Forward inference uses the upper tail of a binomial distribution, so it is a one-sided
+    test of enrichment and 'zForward' is a one-tailed, non-negative z-value. Forward
+    inference here cannot report depletion; 'zReverse' remains two-tailed and signed.
+
     See Also
     --------
     :func:`~nimare.decode.discrete.BrainMapDecoder`: The associated class for this method.
@@ -327,11 +333,11 @@ def brainmap_decode(
     p_term_g_selected = p_term_g_selected / np.nansum(p_term_g_selected)  # Normalize
 
     # Significance testing
-    # Forward inference significance is determined with a binomial distribution
+    # Forward inference significance is determined with a binomial distribution. ``logsf`` is
+    # the upper tail alone, so this is a one-sided test of enrichment: a small p-value can only
+    # mean more selected studies carry the label than the selection rate would predict. The
+    # z-value is therefore one-tailed and unsigned; there is no lower tail for it to report.
     nlogp_fi = binom.logsf(k=n_selected_term, n=n_term_foci, p=p_selected)
-    sign_fi = np.sign(
-        n_selected_term - np.mean(n_selected_term)
-    ).ravel()  # pylint: disable=no-member
 
     # Two-way chi-square test for association of activation
     cells = np.array(
@@ -364,7 +370,7 @@ def brainmap_decode(
     # Compute z-values
     p_corr_fi = _clip_p_values(np.exp(nlogp_corr_fi), dtype=np.float64, copy=False)
     p_corr_ri = _clip_p_values(np.exp(nlogp_corr_ri), dtype=np.float64, copy=False)
-    z_corr_fi = nlogp_to_z(nlogp_corr_fi, "two") * sign_fi
+    z_corr_fi = nlogp_to_z(nlogp_corr_fi, "one")
     z_corr_ri = nlogp_to_z(nlogp_corr_ri, "two") * sign_ri
 
     # Effect size

--- a/nimare/decode/discrete.py
+++ b/nimare/decode/discrete.py
@@ -337,7 +337,13 @@ def brainmap_decode(
     # the upper tail alone, so this is a one-sided test of enrichment: a small p-value can only
     # mean more selected studies carry the label than the selection rate would predict. The
     # z-value is therefore one-tailed and unsigned; there is no lower tail for it to report.
-    nlogp_fi = binom.logsf(k=n_selected_term, n=n_term_foci, p=p_selected)
+    #
+    # ``logsf(k)`` is P(X > k), so the observation itself has to be put back in: the one-sided
+    # p-value for observing ``k`` is P(X >= k) == logsf(k - 1). Without the shift a label whose
+    # every focus falls inside the selection gets P(X > n) == 0 and an infinite z, and a label
+    # observed zero times gets P(X > 0), which is small whenever the label is rare. ``logsf(-1)``
+    # is log(1), so a zero count needs no special case.
+    nlogp_fi = binom.logsf(k=n_selected_term - 1, n=n_term_foci, p=p_selected)
 
     # Two-way chi-square test for association of activation
     cells = np.array(

--- a/nimare/stats.py
+++ b/nimare/stats.py
@@ -374,12 +374,25 @@ def nlogp_fdr(nlogp, method="bh"):
     nlogp = _check_nlogp(nlogp)
     n_tests = nlogp.size
 
-    corrected = np.full(nlogp.shape, np.nan)
-    evaluated = ~np.isnan(nlogp)
-    if not np.any(evaluated):
-        return corrected
-    nlogp = nlogp[evaluated]
+    # The mask is one byte per test against the eight the sort already costs, so checking is
+    # far cheaper than the copies the NaN path needs. Voxelwise callers take the fast path.
+    unevaluated = np.isnan(nlogp)
+    if not unevaluated.any():
+        return _fdr_step_up(nlogp, method, n_tests)
 
+    corrected = np.full(nlogp.shape, np.nan)
+    evaluated = ~unevaluated
+    if evaluated.any():
+        corrected[evaluated] = _fdr_step_up(nlogp[evaluated], method, n_tests)
+    return corrected
+
+
+def _fdr_step_up(nlogp, method, n_tests):
+    """Run the step-up procedure over tests that were evaluated.
+
+    ``nlogp`` holds only the evaluated tests, while ``n_tests`` counts every test in the
+    family, so the two differ exactly when some test came back NaN.
+    """
     sort_idx = np.argsort(nlogp)
     revert_idx = np.argsort(sort_idx)
 
@@ -389,5 +402,4 @@ def nlogp_fdr(nlogp, method="bh"):
 
     log_adjusted = nlogp[sort_idx] - log_ecdffactor
     log_adjusted = np.minimum.accumulate(log_adjusted[::-1])[::-1]
-    corrected[evaluated] = np.minimum(log_adjusted, 0.0)[revert_idx]
-    return corrected
+    return np.minimum(log_adjusted, 0.0)[revert_idx]

--- a/nimare/stats.py
+++ b/nimare/stats.py
@@ -357,7 +357,15 @@ def nlogp_fdr(nlogp, method="bh"):
     Returns
     -------
     :obj:`numpy.ndarray`
-        Natural logarithms of the corrected p-values.
+        Natural logarithms of the corrected p-values. NaN entries stay NaN.
+
+    Notes
+    -----
+    A NaN is a test that could not be evaluated, so it takes no part in the step-up procedure
+    and comes back as NaN. It is still counted in the number of tests, which is the more
+    conservative of the two readings and the one R's ``p.adjust`` takes: NAs are dropped from
+    the procedure while ``n`` stays at the full length of the input. Without this, a single
+    NaN would win every ``minimum.accumulate`` comparison and erase the whole correction.
 
     References
     ----------
@@ -366,13 +374,20 @@ def nlogp_fdr(nlogp, method="bh"):
     nlogp = _check_nlogp(nlogp)
     n_tests = nlogp.size
 
+    corrected = np.full(nlogp.shape, np.nan)
+    evaluated = ~np.isnan(nlogp)
+    if not np.any(evaluated):
+        return corrected
+    nlogp = nlogp[evaluated]
+
     sort_idx = np.argsort(nlogp)
     revert_idx = np.argsort(sort_idx)
 
-    log_ecdffactor = np.log(np.arange(1, n_tests + 1) / n_tests)
+    log_ecdffactor = np.log(np.arange(1, nlogp.size + 1) / n_tests)
     if method == "by":
         log_ecdffactor = log_ecdffactor - np.log(np.sum(1 / np.arange(1, n_tests + 1)))
 
     log_adjusted = nlogp[sort_idx] - log_ecdffactor
     log_adjusted = np.minimum.accumulate(log_adjusted[::-1])[::-1]
-    return np.minimum(log_adjusted, 0.0)[revert_idx]
+    corrected[evaluated] = np.minimum(log_adjusted, 0.0)[revert_idx]
+    return corrected

--- a/nimare/tests/test_decode_discrete.py
+++ b/nimare/tests/test_decode_discrete.py
@@ -116,3 +116,49 @@ def test_brainmap_decode_forward_z_is_one_tailed_and_unsigned(testdata_laird):
 
     expected = nlogp_to_z(np.log(decoded_df["pForward"].values), "one")
     np.testing.assert_allclose(decoded_df["zForward"].values, expected, rtol=1e-6)
+
+
+def _saturated_label_inputs():
+    """One label whose every focus falls inside the selection, and one carried by nobody."""
+    ids = [f"s{i:02d}" for i in range(40)]
+    coordinates = pd.DataFrame({"id": ids, "x": 0.0, "y": 0.0, "z": 0.0, "space": "MNI"})
+    annotations = pd.DataFrame(
+        {
+            "id": ids,
+            "common": [1] * 30 + [0] * 10,
+            "absent": [0] * 39 + [1],  # carried only by an unselected study
+            "saturated": [1] * 8 + [0] * 32,  # every carrier is selected
+        }
+    )
+    return coordinates, annotations, ids[:20]
+
+
+def test_brainmap_decode_forward_p_is_the_inclusive_upper_tail():
+    """The one-sided p-value for observing k is P(X >= k), i.e. ``logsf(k - 1)``.
+
+    Regression test: ``logsf(k)`` is P(X > k), which excludes the observation. A label whose
+    every focus falls inside the selection then gets P(X > n) == 0 and an infinite z.
+    """
+    coordinates, annotations, selected = _saturated_label_inputs()
+    decoded_df = discrete.brainmap_decode(
+        coordinates,
+        annotations,
+        ids=selected,
+        features=["common", "absent", "saturated"],
+        correction=None,
+    )
+
+    assert np.isfinite(decoded_df["zForward"]).all()
+    # All 8 carriers of 'saturated' are selected, and p_selected is 0.5, so P(X >= 8) = 0.5 ** 8.
+    assert decoded_df.loc["saturated", "pForward"] == pytest.approx(0.5**8)
+    # A label no selected study carries is never evidence of enrichment.
+    assert decoded_df.loc["absent", "pForward"] == pytest.approx(1.0)
+    assert decoded_df.loc["absent", "zForward"] == pytest.approx(0.0)
+
+
+def test_brainmap_decode_zero_count_is_never_enrichment():
+    """``logsf(-1)`` is log(1), so an unobserved label needs no special case."""
+    from scipy.stats import binom
+
+    assert binom.logsf(k=-1, n=1, p=0.001) == 0.0
+    assert binom.logsf(k=-1, n=50, p=0.3) == 0.0

--- a/nimare/tests/test_decode_discrete.py
+++ b/nimare/tests/test_decode_discrete.py
@@ -3,10 +3,12 @@
 Tests for nimare.decode.discrete.gclda_decode_roi are in test_annotate_gclda.
 """
 
+import numpy as np
 import pandas as pd
 import pytest
 
 from nimare.decode import discrete
+from nimare.transforms import nlogp_to_z
 
 
 def test_neurosynth_decode(testdata_laird):
@@ -90,3 +92,27 @@ def test_ROIAssociationDecoder(testdata_laird, roi_img):
     decoded_df = decoder.transform()
     assert isinstance(decoded_df, pd.DataFrame)
     assert decoded_df.shape == (len(labels), 1)
+
+
+def test_brainmap_decode_forward_z_is_one_tailed_and_unsigned(testdata_laird):
+    """Forward inference is ``binom.logsf``, an upper tail, so its z has no lower side.
+
+    Regression test: the one-sided p-value was converted with a two-tailed rule and then
+    multiplied by a sign taken from the mean label count, which could report a
+    significant *depletion* that the test never tested for.
+    """
+    ids = testdata_laird.ids[:5]
+    features = testdata_laird.annotations.columns.tolist()[5:10]
+    decoded_df = discrete.brainmap_decode(
+        testdata_laird.coordinates,
+        testdata_laird.annotations,
+        ids=ids,
+        features=features,
+        correction=None,
+    )
+
+    finite = decoded_df["zForward"].dropna()
+    assert (finite >= 0).all()
+
+    expected = nlogp_to_z(np.log(decoded_df["pForward"].values), "one")
+    np.testing.assert_allclose(decoded_df["zForward"].values, expected, rtol=1e-6)

--- a/nimare/tests/test_stats.py
+++ b/nimare/tests/test_stats.py
@@ -197,3 +197,70 @@ def test_log_corrections_reject_plain_p_values(correct):
     """Passing p-values would adjust every one of them to 1, so say so instead."""
     with pytest.raises(ValueError, match="natural logarithms"):
         correct(np.array([0.01, 0.5]))
+
+
+@pytest.mark.parametrize("method", ["bh", "by"])
+def test_nlogp_fdr_does_not_let_one_nan_erase_the_correction(method):
+    """A NaN is one unevaluated test, not a reason to discard every other result.
+
+    Regression test: NaN sorts last and wins every ``minimum.accumulate`` comparison, so a
+    single NaN used to turn the entire corrected array into NaN.
+    """
+    nlogp = np.array([-20.0, -10.0, -1.0, np.nan, -5.0])
+    corrected = nlogp_fdr(nlogp, method=method)
+
+    assert np.isnan(corrected[3])
+    assert np.all(np.isfinite(np.delete(corrected, 3)))
+
+
+@pytest.mark.parametrize("method", ["bh", "by"])
+def test_nlogp_fdr_matches_r_p_adjust_with_a_nan(method):
+    """A NaN leaves the procedure but stays in ``n``, as R's ``p.adjust`` has it."""
+    nlogp = np.array([-20.0, -10.0, -1.0, np.nan, -5.0])
+    corrected = nlogp_fdr(nlogp, method=method)
+
+    n_tests = nlogp.size  # 5, including the NaN
+    evaluated = nlogp[~np.isnan(nlogp)]
+    order = np.argsort(evaluated)
+    ranks = np.arange(1, evaluated.size + 1)  # 1..4, over the evaluated tests only
+    factor = np.log(ranks / n_tests)
+    if method == "by":
+        factor = factor - np.log(np.sum(1 / np.arange(1, n_tests + 1)))
+    expected = np.minimum.accumulate((evaluated[order] - factor)[::-1])[::-1]
+    expected = np.minimum(expected, 0.0)[np.argsort(order)]
+
+    np.testing.assert_allclose(corrected[~np.isnan(nlogp)], expected, rtol=1e-12)
+
+
+@pytest.mark.parametrize("method", ["bh", "by"])
+def test_nlogp_fdr_without_nans_is_unchanged(method):
+    """The NaN handling must not perturb the ordinary path."""
+    nlogp = np.array([-20.0, -10.0, -1.0, -3.0, -5.0])
+    corrected = nlogp_fdr(nlogp, method=method)
+
+    n_tests = nlogp.size
+    order = np.argsort(nlogp)
+    factor = np.log(np.arange(1, n_tests + 1) / n_tests)
+    if method == "by":
+        factor = factor - np.log(np.sum(1 / np.arange(1, n_tests + 1)))
+    expected = np.minimum.accumulate((nlogp[order] - factor)[::-1])[::-1]
+    expected = np.minimum(expected, 0.0)[np.argsort(order)]
+
+    np.testing.assert_array_equal(corrected, expected)
+
+
+def test_nlogp_fdr_all_nan():
+    """An array with nothing to correct comes back as it went in."""
+    corrected = nlogp_fdr(np.array([np.nan, np.nan]))
+    assert np.all(np.isnan(corrected))
+
+
+def test_nlogp_bonferroni_passes_nans_through():
+    """Bonferroni never compared across entries, so it only needs pinning."""
+    nlogp = np.array([-20.0, np.nan, -5.0])
+    corrected = nlogp_bonferroni(nlogp)
+
+    assert np.isnan(corrected[1])
+    np.testing.assert_allclose(
+        corrected[[0, 2]], np.minimum(nlogp[[0, 2]] + np.log(3), 0.0), rtol=1e-12
+    )


### PR DESCRIPTION
Two independent defects found while investigating the `neurosynth_decode` NaN report
(https://neurostars.org/t/negative-chi-square-values-in-neurosynth-decode-forward-inference/36387,
fixed in #1138). Neither is caused by that bug and neither is fixed by it, so they are split out here.

## 1. One NaN erases an entire FDR correction

`nlogp_fdr` sorts with `argsort`, which places NaN last, then runs `minimum.accumulate` over the reversed array. `np.minimum` propagates NaN, so the NaN is the first value the running minimum sees and everything behind it becomes NaN:

```python
>>> nlogp_fdr(np.array([-20.0, -10.0, -1.0, np.nan, -5.0]))
array([nan, nan, nan, nan, nan])
```

One unevaluated test discards the whole family. This is how 343 NaN labels became 3228 NaN labels in the linked report, but the defect is in a shared utility used by `FDRCorrector`, `MKDAChi2`, and both discrete decoders, so it outlives that particular caller.

**Fix:** NaN entries are held out of the step-up procedure and returned as NaN, while still counting toward the number of tests. That is the more conservative of the two readings and the one R's `p.adjust` takes — it drops NAs from the procedure while leaving `n` at the full length of the input:

```r
if(all(nna <- !is.na(p))) nna <- TRUE
p <- p[nna]; lp <- length(p)
BH = { i <- lp:1L; ...; pmin(1, cummin(n/i * p[o]))[ro] }   # n is the full length
```

With no NaN present, `lp == n` and the arithmetic is identical to before. A test pins that path byte-for-byte so the NaN handling cannot perturb ordinary use, and another checks the NaN case against the `n/i` factor computed longhand.

`nlogp_bonferroni` adds a scalar per entry and never compares across them, so it was already NaN-safe. It gains a test rather than a change.

## 2. BrainMap forward inference converted a one-sided p-value with a two-tailed rule

`brainmap_decode` computes forward inference as the upper tail of a binomial:

```python
nlogp_fi = binom.logsf(k=n_selected_term, n=n_term_foci, p=p_selected)
sign_fi = np.sign(n_selected_term - np.mean(n_selected_term))
...
z_corr_fi = nlogp_to_z(nlogp_corr_fi, "two") * sign_fi
```

`logsf` is the upper tail alone, so a small p-value can only mean *more* selected studies carry the label than the selection rate predicts. Converting it with the two-tailed rule and then multiplying by a sign taken from the mean label count meant a label could be reported as significantly **depleted** on the strength of a p-value that only ever tested enrichment — and the sign came from a comparison against the average label, which is not the quantity the binomial tested either.

**Fix:** `zForward` is now one-tailed and unsigned. `zReverse` comes from a two-way chi-squared and remains two-tailed and signed.

**This changes `zForward` values from `brainmap_decode`.** `pForward`, `zReverse`, and all effect sizes are unaffected. The docstring now states that forward inference here cannot report depletion.

## 3. The upper tail excluded the observation itself

Caught in review. `binom.logsf(k)` is `P(X > k)`, but the one-sided p-value for an observed count `k` is `P(X >= k)`, so the argument has to be `k - 1`. I had originally flagged this as out of scope; that was the wrong call, because it interacts directly with the change above — dropping the sign turns what used to surface as a large *negative* z into a large *positive* one.

Two reachable cases:

- **A label whose every focus falls inside the selection** gets `P(X > n) == 0` exactly, so `pForward` underflowed to `4.94e-324` and `zForward` came out as `inf`. The `n_selected_term < 5` guard does not catch this, since such a label can carry any number of studies. On a 40-study synthetic where all 8 carriers of a label are selected and `p_selected` is 0.5, `zForward` was `inf` and is now `2.66`, with `pForward` exactly `0.5 ** 8`.
- **A label observed zero times** gets `P(X > 0)`, which is small whenever the label is rare, so it reads as enrichment on the strength of never having been observed (z of 3.09 at `p_selected = 0.001`). The `< 5` guard does mask this one in the current code, but it is the same defect.

`logsf(-1)` is `log(1)`, so a zero count needs no special handling.

**This changes every `pForward` from `brainmap_decode`**: the previous values were anti-conservative by one term of the pmf.

## Tests

Six new tests: NaN non-propagation for both `bh` and `by`, agreement with the `p.adjust` factor under a NaN, an exact-equality pin on the no-NaN path, the all-NaN case, Bonferroni pass-through, and a check that BrainMap's `zForward` is non-negative and matches a one-tailed conversion. 118 passed across `test_stats`, `test_decode_discrete`, `test_transforms`, and `test_correct`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make FDR correction robust to unevaluated tests and align BrainMap forward inference with its one-sided enrichment test.

Bug Fixes:
- Prevent NaN values from propagating through and invalidating an entire FDR correction while preserving conservative multiple-testing counts.
- Correct BrainMap forward-inference p-values to use the inclusive binomial upper tail and report one-tailed, non-negative z-values limited to enrichment.

Enhancements:
- Document the distinct directional interpretation of BrainMap forward and reverse inference.

Tests:
- Add regression coverage for NaN-safe BH and BY corrections, unchanged no-NaN behavior, all-NaN inputs, and Bonferroni NaN pass-through.
- Add BrainMap tests covering one-tailed unsigned z-values, inclusive upper-tail probabilities, saturated and unobserved labels.