### PR TITLE
[FIX] ensure traversing slices of a studyset maintains the view

### DIFF
--- a/nimare/studyset/__init__.py
+++ b/nimare/studyset/__init__.py
@@ -22,7 +22,9 @@ The layering, which the module boundaries enforce:
 
 ``nested``
     read-only ``Study``/``Analysis``/``Point``/``Image`` accessors over the
-    columns, for callers that want to walk the studyset as objects.
+    columns. A walk is
+    confined to the view it started from, so it reports what that view's frames
+    and blocks report.
 
 Data flows store -> view -> block and never back.
 

--- a/nimare/studyset/nested.py
+++ b/nimare/studyset/nested.py
@@ -1,10 +1,13 @@
 """Read-only nested accessors over the columns.
 
 Convenient for inspection and for code that reads a studyset the way the document
-is shaped. These are *views*, not storage: they hold a store and a row, and every
-attribute is a column lookup. The previous implementation kept an equivalent
-object graph as a second copy of the data, which is what the revision counters
-and mutation tracking existed to keep in step.
+is shaped. An accessor is a view and a row, and
+every attribute is a column lookup.
+
+The view travels with the accessor rather than being applied once at the top: an
+analysis reached from a sliced studyset shows only its selected foci, the study
+reached back from that analysis hides the same analyses the slice did, and both
+read coordinates in the view's space.
 """
 
 from __future__ import annotations
@@ -14,15 +17,30 @@ import numpy as np
 __all__ = ["Analysis", "Image", "Point", "Study", "studies_of"]
 
 
-class _Row:
-    __slots__ = ("_store", "_row", "_context")
+def _kept(flags, lo, hi):
+    """Return the rows in ``[lo, hi)`` that ``flags`` keeps, all of them for ``None``.
 
-    def __init__(self, store, row, context=None):
-        self._store = store
+    The view's flag bytes are memoised and ``None`` when it narrows nothing, so a
+    walk over an unnarrowed studyset costs no lookups and a narrowed one costs
+    one per child.
+    """
+    if flags is None:
+        return range(lo, hi)
+    return [r for r in range(lo, hi) if flags[r]]
+
+
+class _Row:
+    __slots__ = ("_view", "_row", "_store", "_context")
+
+    def __init__(self, view, row):
+        # The view fixes which rows are visible and
+        # which space coordinates are read in. Every accessor this one produces
+        # gets the same view, so a walk cannot drift from the view's frames.
+        self._view = view
         self._row = int(row)
-        # Coordinates are stored raw and projected on demand, so an accessor
-        # needs to know which space it is being read in.
-        self._context = context
+        # Read off the view once: caches of it, not a second source of truth.
+        self._store = view.store
+        self._context = view.context
 
     #: The ColumnStore on the store that this accessor's attributes live in.
     _attrs = None
@@ -98,10 +116,11 @@ class Study(_Row):
 
     @property
     def analyses(self):
-        """Return this study's analyses."""
-        store = self._store
-        lo, hi = store.analysis_offsets[self._row], store.analysis_offsets[self._row + 1]
-        return [Analysis(store, r, self._context) for r in range(int(lo), int(hi))]
+        """Return this study's analyses that the selection keeps."""
+        offsets = self._store.analysis_offsets
+        lo, hi = offsets[self._row], offsets[self._row + 1]
+        rows = _kept(self._view.analysis_flags(), int(lo), int(hi))
+        return [Analysis(self._view, r) for r in rows]
 
     def __repr__(self):
         """Return a debugging representation naming the study."""
@@ -140,7 +159,7 @@ class Analysis(_Row):
     @property
     def study(self):
         """Return the study this analysis belongs to."""
-        return Study(self._store, int(self._store.study_idx[self._row]), self._context)
+        return Study(self._view, int(self._store.study_idx[self._row]))
 
     @property
     def metadata(self):
@@ -185,10 +204,11 @@ class Analysis(_Row):
 
     @property
     def points(self):
-        """Return this analysis' foci."""
-        store = self._store
-        lo, hi = store.point_offsets[self._row], store.point_offsets[self._row + 1]
-        return [Point(store, r, self._context) for r in range(int(lo), int(hi))]
+        """Return this analysis' foci that the selection keeps."""
+        offsets = self._store.point_offsets
+        lo, hi = offsets[self._row], offsets[self._row + 1]
+        rows = _kept(self._view.point_flags(), int(lo), int(hi))
+        return [Point(self._view, r) for r in rows]
 
     @property
     def images(self):
@@ -198,7 +218,7 @@ class Analysis(_Row):
         if ia is None or not ia.n_rows:
             return []
         rows = np.flatnonzero(ia.dense["analysis_idx"] == self._row)
-        return [Image(store, r, self._context) for r in rows]
+        return [Image(self._view, r) for r in rows]
 
     @property
     def conditions(self):
@@ -237,7 +257,7 @@ class Point(_Row):
     def _projected(self):
         from nimare.studyset.layout import harmonized_coordinates
 
-        target = getattr(self._context, "space", None)
+        target = self._context.space
         return harmonized_coordinates(self._store, target)
 
     @property
@@ -297,15 +317,26 @@ class Image(_Row):
         """Return what this image holds, such as ``z`` or ``varcope``."""
         return self._attr("value_type")
 
+    def _ref(self, name):
+        """Return one stored reference, resolved against the view's base path.
+
+        A reference is stored the way the document writes it, which is usually
+        relative, so a reader that is not sitting in the base path cannot open
+        it. The view resolves relative paths on export/edit.
+        """
+        from nimare.studyset.io.nimads import _resolve
+
+        return _resolve(self._attr(name), self._context.basepath)
+
     @property
     def url(self):
         """Return the URL this image was fetched from."""
-        return self._attr("url")
+        return self._ref("url")
 
     @property
     def filename(self):
         """Return the path this image is stored at."""
-        return self._attr("filename")
+        return self._ref("filename")
 
     @property
     def space(self):
@@ -320,7 +351,7 @@ class Image(_Row):
     @property
     def analysis(self):
         """Return the analysis this image belongs to."""
-        return Analysis(self._store, int(self._attr("analysis_idx")), self._context)
+        return Analysis(self._view, int(self._attr("analysis_idx")))
 
     def __repr__(self):
         """Return a debugging representation naming the image."""
@@ -334,13 +365,9 @@ def studies_of(view):
     so it is always present -- the same rule export uses.
     """
     store = view.store
-    selected = np.zeros(store.n_analyses, dtype=bool)
-    selected[view.index] = True
-    counts = np.diff(store.analysis_offsets)
-    rows = [
-        r
-        for r in range(store.n_studies)
-        if counts[r] == 0
-        or selected[store.analysis_offsets[r] : store.analysis_offsets[r + 1]].any()
-    ]
-    return [Study(store, r, view.context) for r in rows]
+    selected = view.position_of_row() >= 0
+    # bincount over the parent column rather than a reduce over the offsets
+    hits = np.bincount(store.study_idx[selected].astype(np.int64), minlength=store.n_studies) > 0
+    childless = np.diff(store.analysis_offsets) == 0
+    rows = np.flatnonzero(hits | childless)
+    return [Study(view, r) for r in rows]

--- a/nimare/studyset/studyset.py
+++ b/nimare/studyset/studyset.py
@@ -198,7 +198,7 @@ class Studyset:
         """Read-only nested accessors for the selected analyses."""
         from nimare.studyset.nested import Analysis
 
-        return [Analysis(self.store, r, self._view.context) for r in self._view.index]
+        return [Analysis(self._view, r) for r in self._view.index]
 
     def __len__(self):
         """Return the number of selected analyses."""
@@ -371,7 +371,11 @@ class Studyset:
         return Studyset._wrap(self._view.select(mask))
 
     def select_points(self, point_mask):
-        """Keep a subset of foci and every analysis."""
+        """Keep a subset of foci and every analysis.
+
+        ``point_mask`` has one entry per focus in the studyset, in the order
+        :attr:`coordinates` reports them for an unnarrowed studyset.
+        """
         return Studyset._wrap(self._view.select_points(point_mask))
 
     def with_context(self, **changes):
@@ -723,19 +727,23 @@ class Studyset:
 
     # ------------------------------------------------------------------- io
     def to_dict(self):
-        """Build the nested NIMADS document for the selected analyses."""
-        return to_nimads_dict(self.store, self._view.index)
+        """Build the nested NIMADS document for the selected analyses and foci.
+
+        An active point mask is materialised first: the document is built from a
+        store, and a mask lives on the view rather than in the columns.
+        """
+        selected = self.materialize_points()
+        return to_nimads_dict(selected.store, selected._view.index)
 
     def to_nimads(self, filename):
         """Write NIMADS JSON."""
-        write_nimads(self.store, filename, self._view.index)
+        selected = self.materialize_points()
+        write_nimads(selected.store, filename, selected._view.index)
 
     def to_parquet(self, directory):
         """Write a parquet studyset release directory."""
-        return write_parquet(
-            self.store if len(self._view) == self.store.n_analyses else _materialize(self),
-            directory,
-        )
+        whole = self._view.point_mask is None and len(self._view) == self.store.n_analyses
+        return write_parquet(self.store if whole else _materialize(self), directory)
 
     def to_dataset(self):
         """Convert to a legacy :class:`~nimare.dataset.Dataset`.
@@ -746,8 +754,9 @@ class Studyset:
         from nimare.io import convert_nimads_to_dataset
 
         # Resolved image paths: a Dataset has no base path of its own.
+        selected = self.materialize_points()
         return convert_nimads_to_dataset(
-            to_nimads_dict(self.store, self._view.index, basepath=self.basepath)
+            to_nimads_dict(selected.store, selected._view.index, basepath=selected.basepath)
         )
 
     def save(self, filename):

--- a/nimare/studyset/view.py
+++ b/nimare/studyset/view.py
@@ -151,7 +151,7 @@ class View:
         if "point_flags" not in self._cache:
             mask = self.point_mask
             if mask is not None:
-                mask = np.asarray(mask, dtype=bool)
+                mask = np.ascontiguousarray(np.asarray(mask, dtype=bool))
             self._cache["point_flags"] = (
                 None if mask is None or mask.all() else mask.view(np.uint8).tobytes()
             )

--- a/nimare/studyset/view.py
+++ b/nimare/studyset/view.py
@@ -133,6 +133,30 @@ class View:
             self._cache["position_of_row"] = got
         return got
 
+    def analysis_flags(self):
+        """Per-store-row ``1``/``0`` for the analyses kept, or ``None`` for all of them.
+
+        One byte per analysis, memoised, because the reader is a nested walk
+        asking one row at a time. A ``bytes`` index is a C-level lookup.
+        ``None`` says this view narrows nothing, so the walk can skip
+        the lookup entirely.
+        """
+        if "analysis_flags" not in self._cache:
+            kept = self.position_of_row() >= 0
+            self._cache["analysis_flags"] = None if kept.all() else kept.view(np.uint8).tobytes()
+        return self._cache["analysis_flags"]
+
+    def point_flags(self):
+        """Per-store-row ``1``/``0`` for the foci kept, or ``None`` for all of them."""
+        if "point_flags" not in self._cache:
+            mask = self.point_mask
+            if mask is not None:
+                mask = np.asarray(mask, dtype=bool)
+            self._cache["point_flags"] = (
+                None if mask is None or mask.all() else mask.view(np.uint8).tobytes()
+            )
+        return self._cache["point_flags"]
+
     def row_of_key(self):
         """``{full analysis id: position in this selection}``, memoised."""
         got = self._cache.get("row_of_key")
@@ -222,8 +246,19 @@ class View:
         return self.select(~per_analysis if exclude else per_analysis)
 
     def select_points(self, mask):
-        """Narrow to a subset of foci, keeping every analysis."""
+        """Narrow to a subset of foci, keeping every analysis.
+
+        ``mask`` is aligned to the store's foci, not to the foci this view can
+        already see, because that is what a point-level predicate is computed
+        over -- :meth:`points_in_mask` and :meth:`points_near` both return one.
+        """
         mask = np.asarray(mask, dtype=bool)
+        if len(mask) != self.store.n_points:
+            raise ValueError(
+                f"point mask has length {len(mask)}, expected one entry per focus in the "
+                f"studyset ({self.store.n_points}). A point mask is aligned to the studyset's "
+                "foci, not to the subset a previous selection kept."
+            )
         combined = mask if self.point_mask is None else (mask & self.point_mask)
         return View(self.store, self.index, combined, self.context)
 

--- a/nimare/tests/conftest.py
+++ b/nimare/tests/conftest.py
@@ -219,6 +219,30 @@ def testdata_ibma_resample(tmp_path_factory):
     return dset
 
 
+@pytest.fixture
+def split_studyset():
+    """One study, two analyses, three foci: the smallest shape a selection can split."""
+    return {
+        "id": "example",
+        "studies": [
+            {
+                "id": "S1",
+                "name": "s1",
+                "analyses": [
+                    {
+                        "id": "A1",
+                        "points": [
+                            {"space": "MNI", "coordinates": [1, 2, 3]},
+                            {"space": "MNI", "coordinates": [4, 5, 6]},
+                        ],
+                    },
+                    {"id": "A2", "points": [{"space": "MNI", "coordinates": [7, 8, 9]}]},
+                ],
+            }
+        ],
+    }
+
+
 @pytest.fixture(scope="session")
 def sample_size_nimads_studyset():
     """Download/lookup example NiMADS studyset."""

--- a/nimare/tests/test_nimads.py
+++ b/nimare/tests/test_nimads.py
@@ -526,7 +526,11 @@ def test_image_references_resolve_against_the_view(tmp_path):
     rooted = nimads.Studyset(doc, target=None, basepath=str(tmp_path))
     image = rooted.analyses[0].images[0]
 
-    assert image.filename == str(tmp_path / "imgs" / "z.nii.gz")
+    # Compared as paths, not as strings: joining a POSIX-style reference onto a
+    # Windows base path gives mixed separators, which open fine and compare equal
+    # as paths but not as text.
+    assert Path(image.filename) == tmp_path / "imgs" / "z.nii.gz"
+    assert Path(image.filename).is_file()
     assert nimads.Studyset(doc, target=None).analyses[0].images[0].filename == "imgs/z.nii.gz"
     # A URL is already a location; only relative paths are resolved.
     assert image.url == image_doc["url"]
@@ -536,5 +540,6 @@ def test_image_references_resolve_against_the_view(tmp_path):
     # Both doors into a Dataset resolve the same way.
     from nimare.io import convert_nimads_to_dataset
 
-    assert convert_nimads_to_dataset(rooted).images["z"].tolist() == [image.filename]
-    assert rooted.to_dataset().images["z"].tolist() == [image.filename]
+    direct = convert_nimads_to_dataset(rooted).images["z"].tolist()
+    assert direct == rooted.to_dataset().images["z"].tolist()
+    assert [Path(p) for p in direct] == [Path(image.filename)]

--- a/nimare/tests/test_nimads.py
+++ b/nimare/tests/test_nimads.py
@@ -420,3 +420,121 @@ def test_data_retrieval_methods(example_nimads_studyset):
     frame_counts = studyset.coordinates.groupby("contrast_id").size().to_dict()
     for contrast_id, count in frame_counts.items():
         assert accessor_counts[contrast_id] == count
+
+
+def test_selection_reaches_nested_accessors(split_studyset):
+    """Every path out of a selected Studyset reports the same analyses and foci.
+
+    The accessors used to hold only a store row, so a walk read the store's full
+    ranges and handed back the analyses and foci the selection had dropped.
+    """
+    studyset = nimads.Studyset(split_studyset, target=None)
+
+    sub = studyset.slice(["S1-A1"]).select_points([True, False, False])
+
+    kept = {"A1": [[1.0, 2.0, 3.0]]}
+    assert {a.id: [p.coordinates for p in a.points] for a in sub.analyses} == kept
+    assert {
+        a.id: [p.coordinates for p in a.points] for s in sub.studies for a in s.analyses
+    } == kept
+    # Reverse navigation is a walk too, so it hides what the walk down hid.
+    assert [a.id for a in sub.analyses[0].study.analyses] == ["A1"]
+    assert sub.coordinates[["x", "y", "z"]].to_numpy().tolist() == kept["A1"]
+    # An unselected studyset still walks the whole store.
+    assert {a.id: len(a.points) for s in studyset.studies for a in s.analyses} == {
+        "A1": 2,
+        "A2": 1,
+    }
+    # A point mask is aligned to the studyset's foci, not to what the slice kept.
+    with pytest.raises(ValueError, match="one entry per focus"):
+        sub.select_points([True, False])
+
+
+def test_selection_reaches_export(split_studyset, tmp_path):
+    """A selection survives every way out of a Studyset, not just the frames.
+
+    A point mask lives on the view rather than in the columns, so export has to
+    materialise it; analysis selection was already passed as rows.
+    """
+    sub = (
+        nimads.Studyset(split_studyset, target=None)
+        .slice(["S1-A1"])
+        .select_points([True, False, False])
+    )
+    kept = {"A1": [[1.0, 2.0, 3.0]]}
+
+    def analyses_of(document):
+        return {
+            a["id"]: [p["coordinates"] for p in a["points"]]
+            for s in document["studies"]
+            for a in s["analyses"]
+        }
+
+    assert analyses_of(sub.to_dict()) == kept
+
+    sub.to_nimads(tmp_path / "selected.json")
+    assert analyses_of(load_json(str(tmp_path / "selected.json"))) == kept
+
+    sub.to_parquet(tmp_path / "release")
+    assert analyses_of(nimads.Studyset.from_parquet(tmp_path / "release").to_dict()) == kept
+
+    dataset = sub.to_dataset()
+    assert list(dataset.ids) == ["S1-A1"]
+    assert dataset.coordinates[["x", "y", "z"]].to_numpy().tolist() == kept["A1"]
+
+
+def test_accessors_read_in_their_view_s_space(split_studyset):
+    """An accessor reports coordinates in the space its view reads them in.
+
+    The view is the accessor's only input, so a selection and a space cannot
+    come from different places.
+    """
+    raw = nimads.Studyset(split_studyset, target=None)
+    projected = nimads.Studyset(split_studyset, target="TAL")
+
+    point = projected.analyses[0].points[0]
+    assert (raw.analyses[0].points[0].space, point.space) == ("MNI", "TAL")
+    assert point.coordinates != raw.analyses[0].points[0].coordinates
+    # And the accessor agrees with the frame the same view builds.
+    assert point.coordinates == projected.coordinates[["x", "y", "z"]].to_numpy()[0].tolist()
+
+
+def test_image_references_resolve_against_the_view(tmp_path):
+    """Image paths come back openable, while export still writes what NIMADS stores.
+
+    A reference is stored relative, so the frames resolved it against the base
+    path and the accessors did not, which left the two Dataset doors disagreeing.
+    """
+    (tmp_path / "imgs").mkdir()
+    (tmp_path / "imgs" / "z.nii.gz").write_text("placeholder")
+    image_doc = {
+        "value_type": "z",
+        "filename": "imgs/z.nii.gz",
+        "url": "https://neurovault.org/images/1",
+        "space": "MNI",
+    }
+    doc = {
+        "id": "example",
+        "studies": [
+            {
+                "id": "S1",
+                "name": "s1",
+                "analyses": [{"id": "A1", "images": [image_doc], "points": []}],
+            }
+        ],
+    }
+    rooted = nimads.Studyset(doc, target=None, basepath=str(tmp_path))
+    image = rooted.analyses[0].images[0]
+
+    assert image.filename == str(tmp_path / "imgs" / "z.nii.gz")
+    assert nimads.Studyset(doc, target=None).analyses[0].images[0].filename == "imgs/z.nii.gz"
+    # A URL is already a location; only relative paths are resolved.
+    assert image.url == image_doc["url"]
+    # Export writes the document's own form, base path or not.
+    exported = rooted.to_dict()["studies"][0]["analyses"][0]["images"][0]
+    assert exported["filename"] == image_doc["filename"]
+    # Both doors into a Dataset resolve the same way.
+    from nimare.io import convert_nimads_to_dataset
+
+    assert convert_nimads_to_dataset(rooted).images["z"].tolist() == [image.filename]
+    assert rooted.to_dataset().images["z"].tolist() == [image.filename]

--- a/nimare/tests/test_sleuth_conversion.py
+++ b/nimare/tests/test_sleuth_conversion.py
@@ -412,3 +412,24 @@ def test_convert_dataset_to_studyset_preserves_execution_context():
 
     view = normalize_collection(studyset)
     assert set(view.ids) == set(dset.ids)
+
+
+def test_sleuth_export_writes_only_the_selection(split_studyset, tmp_path):
+    """Sleuth export walks the nested accessors, so it must see the selection.
+
+    Exporting a sliced studyset used to write back the analyses the slice had
+    dropped, because the walk read the store rather than the view.
+    """
+    from nimare import nimads
+
+    sub = (
+        nimads.Studyset(split_studyset, target=None)
+        .slice(["S1-A1"])
+        .select_points([True, False, False])
+    )
+
+    convert_nimads_to_sleuth(studyset=sub, output_dir=tmp_path)
+
+    written = (tmp_path / "nimads_sleuth_file.txt").read_text()
+    assert "Analysis_A1" in written and "Analysis_A2" not in written
+    assert "1.00\t2.00\t3.00" in written and "4.00" not in written


### PR DESCRIPTION
<!---
This is a suggested pull request template for NiMARE.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!

Please also label your pull request with the relevant tags.
See here for more information and a list of available options:
https://github.com/neurostuff/NiMARE/blob/main/CONTRIBUTING.md#pull-requests
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue when this
pull request is merged!
https://help.github.com/articles/closing-issues-using-keywords -->
Closes #1133 .

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers to indicate
what they should be looking for when they review the pull request. -->
Changes proposed in this pull request:

- keep the filtered view when accessing child/parent objects. (Studysets can be different views of the same store; the storage is immutable, and the studysets are immutable as well, but multiple studysets can reference the same store)

## Summary by Sourcery

Keep Studyset selections intact across nested traversal and all supported export paths.

Bug Fixes:
- Preserve analysis and focus selections when traversing nested Studyset accessors, including parent and child relationships.
- Ensure coordinates, image references, and exported representations remain consistent with the active Studyset view.

Enhancements:
- Propagate view context through nested accessors and validate point-selection masks against the full store.
- Optimize nested selection lookups and parent-study discovery for filtered views.

Documentation:
- Clarify that nested accessors remain confined to the originating Studyset view and document point-mask alignment.

Tests:
- Add coverage for filtered nested traversal, view-specific coordinate spaces, resolved image references, exports, and Sleuth conversion.