### PR TITLE
[FIX] Round to the nearest bin in the ALE approximate null

### DIFF
--- a/nimare/meta/cbma/null_utils.py
+++ b/nimare/meta/cbma/null_utils.py
@@ -121,7 +121,7 @@ def _study_ma_histogram(study_ma_values, n_zero_voxels, mask_voxel_recip, inv_st
     """Bin one study's nonzero ALE values onto the fixed approximate-null grid."""
     exp_hist = np.zeros(n_bins, dtype=np.float64)
     for i_val in range(study_ma_values.shape[0]):
-        idx = int(study_ma_values[i_val] * inv_step_size)
+        idx = int(round(study_ma_values[i_val] * inv_step_size))
         if idx < 0:
             idx = 0
         elif idx >= n_bins:
@@ -147,7 +147,7 @@ def _update_ale_histogram(
         exp_one_minus = 1.0 - exp_center
         for i_ale in range(ale_idx.shape[0]):
             score = 1.0 - exp_one_minus * (1.0 - bin_centers[ale_idx[i_ale]])
-            score_idx = int(score * inv_step_size)
+            score_idx = int(round(score * inv_step_size))
             if score_idx < 0:
                 score_idx = 0
             elif score_idx >= n_bins:

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -65,7 +65,8 @@ def _dense_ale_reference(ma_values):
     hist_bins = np.round(np.arange(0, max_poss_ale + (1.5 * step_size), step_size), 5)
 
     bin_centers = hist_bins
-    bin_edges = np.append(bin_centers, bin_centers[-1] + step_size)
+    # hist_bins holds centres, so the edges sit half a step either side of them.
+    bin_edges = np.append(bin_centers - (step_size / 2), bin_centers[-1] + (step_size / 2))
     n_mask_voxels = ma_values.shape[1]
 
     ale_hist = None
@@ -86,7 +87,7 @@ def _dense_ale_reference(ma_values):
         ale_idx = np.where(ale_hist > 0)[0]
         exp_idx = np.where(exp_hist > 0)[0]
         ale_scores = 1 - np.outer((1 - bin_centers[exp_idx]), (1 - bin_centers[ale_idx])).ravel()
-        score_idx = np.floor(ale_scores * inv_step_size).astype(int)
+        score_idx = np.round(ale_scores * inv_step_size).astype(int)
         probabilities = np.outer(exp_hist[exp_idx], ale_hist[ale_idx]).ravel()
         ale_hist = np.zeros(ale_hist.shape)
         np.add.at(ale_hist, score_idx, probabilities)
@@ -121,7 +122,7 @@ def _study_ma_histogram_reference(
     """Reference implementation for ALE study-histogram binning."""
     exp_hist = np.zeros(n_bins, dtype=np.float64)
     for value in study_ma_values:
-        idx = int(np.floor(value * inv_step_size))
+        idx = int(np.round(value * inv_step_size))
         idx = min(max(idx, 0), n_bins - 1)
         exp_hist[idx] += 1.0
 
@@ -229,7 +230,7 @@ def _update_ale_histogram_reference(
         exp_one_minus = 1.0 - exp_center
         for i_ale in range(ale_idx.shape[0]):
             score = 1.0 - exp_one_minus * (1.0 - bin_centers[ale_idx[i_ale]])
-            score_idx = int(np.floor(score * inv_step_size))
+            score_idx = int(np.round(score * inv_step_size))
             score_idx = min(max(score_idx, 0), n_bins - 1)
             out[score_idx] += exp_prob * ale_probs[i_ale]
     return out
@@ -498,7 +499,12 @@ def test_ALE_csr_approximate_null_matches_dense_reference():
 
 
 def test_ALE_study_ma_histogram_edge_bins():
-    """Study histogram binning should match the legacy floor-based implementation at edges."""
+    """Study histogram binning sends each value to its nearest bin centre.
+
+    The grid is bin *centres*, so a value a hair below a centre belongs in that
+    centre's bin. Flooring would push it one bin down, once per study in the
+    convolution that follows, which biases the whole null low.
+    """
     inv_step_size = 10.0
     n_bins = 11
     n_zero_voxels = 3
@@ -524,6 +530,8 @@ def test_ALE_study_ma_histogram_edge_bins():
     )
 
     np.testing.assert_allclose(actual, expected)
+    # 0.099999999 belongs with the bin centred at 0.1, not the one at 0.0.
+    assert actual[1] > 0.0
 
 
 def test_ALE_update_histogram_edge_bins():


### PR DESCRIPTION
Found while cross-checking NiMARE against GingerALE for #998.

`_study_ma_histogram` and `_update_ale_histogram` in `nimare/meta/cbma/null_utils.py` address the histogram with `int(value * inv_step_size)`, which truncates. The grid those indices address is defined by bin *centres* — `_determine_histogram_bins` says so: *"bins are -.0005-.0005, .0005-.0015, etc."* — so the correct lookup is `round`.

Truncating moves probability mass down by up to a full bin **once per study in the convolution**, so the null drifts low in proportion to the number of studies and uncorrected p-values come out too small.

**Validated against an independent computation.** The same convolution at the same resolution, with correct rounding, recomputed from the same MA maps; it is converged (going from 1e-5 to 2e-6 moves tail p by under 0.6%). GingerALE 3.0.2 matches that reference to its float32 output precision.

pain21, at the peak ALE value:

| | p |
|---|---|
| NiMARE, as shipped | 2.4635e-12 |
| NiMARE, with this fix | 2.6883e-12 |
| GingerALE 3.0.2 | 2.6812e-12 |

**The bias grows with corpus size** (ratio of shipped to corrected p, 99th percentile): 0.965 at 19 studies, 0.920 at 50, 0.843 at 100, **0.703 at 200**.

**Downstream**, pain21 at 1000 permutations with the same mask and threshold, NiMARE declared 666 voxels significant at voxel-level FWE against GingerALE's 566 — 17.7% more, in the direction the bias predicts.

Three reference implementations in `test_meta_ale.py` mirrored the flooring they were checking and are corrected alongside; `_dense_ale_reference` also built its per-study histogram edges from the bin centres rather than half a step either side, which floors by a different route.

`test_meta_ale.py` passes (48).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct approximate ALE null binning to use nearest bin centres and produce unbiased null distributions and p-values.

Bug Fixes:
- Correct approximate ALE null histogram binning so values and convolution scores are assigned to their nearest bin centre, preventing study-count-dependent downward bias in null distributions and p-values.

Enhancements:
- Align dense and reference ALE implementations with centre-based histogram binning and update edge-case coverage.

Tests:
- Update ALE histogram reference tests and add coverage confirming values just below a bin centre remain in that centre's bin.