### PR TITLE
[FIX] Build Monte Carlo null bin edges from the bin centres

### DIFF
--- a/nimare/meta/cbma/base.py
+++ b/nimare/meta/cbma/base.py
@@ -38,6 +38,18 @@ from nimare.utils import (
 
 LGR = logging.getLogger(__name__)
 
+
+def _histogram_bin_edges(bin_centers):
+    """Edges halfway between the bin centres in ``bin_centers``.
+
+    ``null_distributions_["histogram_bins"]`` holds centres, so a value belongs
+    to the centre it is nearest to. Building edges from the centres themselves
+    instead floors every value into the bin below.
+    """
+    step_size = bin_centers[1] - bin_centers[0]
+    return np.append(bin_centers - (step_size / 2), bin_centers[-1] + (step_size / 2))
+
+
 #: Distinguishes "no plan applies" from "a plan has not been built yet".
 _UNSET = object()
 
@@ -743,10 +755,7 @@ class CBMAEstimator(Estimator):
 
         # Reuse shared histogram edges when available to avoid per-permutation allocation.
         if bin_edges is None:
-            bin_centers = self.null_distributions_["histogram_bins"]
-            step_size = bin_centers[1] - bin_centers[0]
-            bin_edges = bin_centers - (step_size / 2)
-            bin_edges = np.append(bin_centers, bin_centers[-1] + step_size)
+            bin_edges = _histogram_bin_edges(self.null_distributions_["histogram_bins"])
 
         counts, _ = np.histogram(iter_ss_map, bins=bin_edges, density=False)
         return counts
@@ -782,10 +791,7 @@ class CBMAEstimator(Estimator):
         if getattr(self, "_permutation_parallel_backend", None) is not None:
             parallel_kwargs["backend"] = self._permutation_parallel_backend
 
-        bin_centers = self.null_distributions_["histogram_bins"]
-        step_size = bin_centers[1] - bin_centers[0]
-        bin_edges = bin_centers - (step_size / 2)
-        bin_edges = np.append(bin_centers, bin_centers[-1] + step_size)
+        bin_edges = _histogram_bin_edges(self.null_distributions_["histogram_bins"])
 
         perm_histograms = Parallel(**parallel_kwargs)(
             delayed(self._compute_null_montecarlo_permutation)(

--- a/nimare/tests/test_meta_ale.py
+++ b/nimare/tests/test_meta_ale.py
@@ -497,6 +497,29 @@ def test_ALE_csr_approximate_null_matches_dense_reference():
     )
 
 
+def test_montecarlo_histogram_bin_edges_straddle_centres():
+    """Monte Carlo null edges sit half a step either side of each bin centre.
+
+    ``histogram_bins`` holds centres, so a summary statistic belongs to the
+    centre nearest it. Edges taken from the centres themselves floor every value
+    into the bin below -- the same half-bin bias the approximate null carried,
+    on the path meant to be free of it.
+    """
+    from nimare.meta.cbma.base import _histogram_bin_edges
+
+    bin_centers = np.arange(0, 5e-4, 1e-5)
+    step_size = bin_centers[1] - bin_centers[0]
+    bin_edges = _histogram_bin_edges(bin_centers)
+
+    assert len(bin_edges) == len(bin_centers) + 1
+    np.testing.assert_allclose(bin_edges[0], bin_centers[0] - step_size / 2)
+    np.testing.assert_allclose(bin_edges[-1], bin_centers[-1] + step_size / 2)
+
+    # A value just under a centre belongs to that centre, not the one below.
+    just_under = np.array([bin_centers[20] - step_size / 100])
+    assert np.histogram(just_under, bins=bin_edges)[0].argmax() == 20
+
+
 def test_ALE_study_ma_histogram_edge_bins():
     """Study histogram binning should match the legacy floor-based implementation at edges."""
     inv_step_size = 10.0


### PR DESCRIPTION
Found while cross-checking NiMARE against GingerALE for #998.

`_compute_null_montecarlo` and `_compute_null_montecarlo_permutation` in `nimare/meta/cbma/base.py` both did:

```python
bin_edges = bin_centers - (step_size / 2)
bin_edges = np.append(bin_centers, bin_centers[-1] + step_size)
```

The first line computes the correct edges — half a step either side of each centre — and the second throws it away, rebuilding the edges from the centres themselves. `np.histogram` then floors every summary statistic into the bin below, reproducing on the Monte Carlo path the same half-bin bias the approximate null carries (#1143). That the first line is dead is what marks this as an editing slip rather than a decision.

Both versions produce the same number of edges, so nothing downstream changes shape — only which bin a value lands in:

```
value just below the centre at index 20
  correct edges -> bin 20
  edges from centres -> bin 19
```

Both call sites carried an identical copy of the two lines, so the calculation is extracted into `_histogram_bin_edges` and called twice. That is what makes it testable, and it removes the duplication that let the same mistake live in two places.

Note this is on the path *meant* to be the unbiased alternative to the analytic null, and it is also the path [#1141](https://github.com/neurostuff/NiMARE/pull/1141) routes weighted MKDA through, so that PR's weighted Monte Carlo binning benefits from it too. The two merge cleanly.

Adds one regression test. `test_meta_ale.py` passes (49).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct Monte Carlo null histogram binning to eliminate the half-bin assignment bias.

Bug Fixes:
- Correct Monte Carlo null histogram bin edges so summary statistics are assigned to the nearest bin centre without the previous half-bin bias.

Enhancements:
- Extract shared histogram edge calculation for permutation and standard Monte Carlo paths to keep binning behavior consistent and testable.

Tests:
- Add regression coverage verifying Monte Carlo histogram edges straddle bin centres and classify near-centre values correctly.