### PR TITLE
[FIX] Correct KDA's approximate-null binning

### DIFF
--- a/nimare/meta/cbma/mkda.py
+++ b/nimare/meta/cbma/mkda.py
@@ -1585,8 +1585,9 @@ class KDA(CBMAEstimator):
         bin_centers = self.null_distributions_["histogram_bins"]
         step_size = bin_centers[1] - bin_centers[0]
         inv_step_size = 1 / step_size
-        bin_edges = bin_centers - (step_size / 2)
-        bin_edges = np.append(bin_centers, bin_centers[-1] + step_size)
+        bin_edges = np.append(
+            bin_centers - (step_size / 2), bin_centers[-1] + (step_size / 2)
+        )
 
         n_exp = ma_maps.shape[0]
         n_bins = bin_centers.shape[0]
@@ -1621,7 +1622,7 @@ class KDA(CBMAEstimator):
 
             # Compute output MA values, stat_hist indices, and probabilities
             stat_scores = np.add.outer(bin_centers[exp_idx], bin_centers[stat_idx]).ravel()
-            score_idx = np.floor(stat_scores * inv_step_size).astype(int)
+            score_idx = np.round(stat_scores * inv_step_size).astype(int)
             probabilities = np.outer(exp_hist[exp_idx], stat_hist[stat_idx]).ravel()
 
             # Reset histogram and set probabilities. Use at() because there can

--- a/nimare/tests/test_meta_mkda.py
+++ b/nimare/tests/test_meta_mkda.py
@@ -12,6 +12,23 @@ from nimare.correct import FDRCorrector, FWECorrector
 from nimare.meta import KDA, MKDAChi2, MKDADensity, MKDAKernel
 
 
+def test_KDA_approximate_null_is_scale_invariant(testdata_cbma):
+    """KDA p-values do not depend on the kernel's value scaling.
+
+    Multiplying every kernel value by a constant scales the summary statistic
+    and the null identically, so the p-values must not move. They did: the
+    approximate null floored each convolved score onto the histogram instead of
+    rounding it, and built its bin edges from the centres rather than half a
+    step either side, so a bin width other than 1.0 misplaced the whole null.
+    """
+    unit = KDA(kernel__value=1, null_method="approximate").fit(testdata_cbma)
+    scaled = KDA(kernel__value=0.7, null_method="approximate").fit(testdata_cbma)
+
+    unit_p = unit.get_map("p", return_type="array")
+    scaled_p = scaled.get_map("p", return_type="array")
+    np.testing.assert_allclose(scaled_p, unit_p, rtol=1e-6)
+
+
 def test_MKDADensity_kernel_instance_with_kwargs(testdata_cbma):
     """Smoke test for MKDADensity with a kernel transformer object.
 


### PR DESCRIPTION
Found for #998, while checking whether the two binning faults in the ALE and Monte Carlo nulls ([#1143](https://github.com/neurostuff/NiMARE/pull/1143), [#1144](https://github.com/neurostuff/NiMARE/pull/1144)) had siblings elsewhere. One did.

`KDA._compute_null_approximate` in `nimare/meta/cbma/mkda.py` carries both:

```python
bin_edges = bin_centers - (step_size / 2)          # dead
bin_edges = np.append(bin_centers, bin_centers[-1] + step_size)
...
score_idx = np.floor(stat_scores * inv_step_size).astype(int)
```

The first line is overwritten by the second, which builds edges from the centres themselves, and the convolved scores are floored rather than rounded — despite the comment two lines above stating *"The histogram bins are bin \*centers\*, not edges."*

**Latent with the default kernel, severe otherwise.** KDA's default kernel gives each focus a value of 1, so the statistic is an integer count on a grid of step 1.0, where flooring and rounding agree; p-values on the NIDM pain coordinates are identical before and after, to every printed digit.

Scaling the kernel value breaks that. Multiplying every kernel value by a constant scales the statistic and the null identically, so p must not move:

| `kernel__value` | as shipped | with this fix |
|---|---|---|
| 1 | 3.283075e-12 | 3.283075e-12 |
| 0.7 | **6.037268e-27** | 3.283075e-12 |

Fifteen orders of magnitude, because a bin width other than 1.0 misplaces the whole null. The corrected version is scale-invariant, which is what the new regression test asserts (verified to fail without the change).

`test_meta_mkda.py` passes (22), KDA included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix KDA approximate-null score binning to preserve scale-invariant p-values.

Bug Fixes:
- Correct KDA approximate-null histogram binning so scaled kernel values produce consistent p-values.

Tests:
- Add a regression test verifying that KDA approximate-null p-values are invariant to kernel-value scaling.